### PR TITLE
Implement Blink version detection via Chrome/ token.

### DIFF
--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -678,7 +678,7 @@ class Browser extends AbstractClientParser
             if (\preg_match('~Chrome/.+ Safari/537.36~i', $this->userAgent)) {
                 $engine        = 'Blink';
                 $family        = self::getBrowserFamily((string) $short) ?? 'Chrome';
-                $engineVersion = self::buildEngineVersion($engine);
+                $engineVersion = $this->buildEngineVersion($engine);
             }
 
             if (null === $short) {

--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -678,7 +678,7 @@ class Browser extends AbstractClientParser
             if (\preg_match('~Chrome/.+ Safari/537.36~i', $this->userAgent)) {
                 $engine        = 'Blink';
                 $family        = self::getBrowserFamily((string) $short) ?? 'Chrome';
-                $engineVersion = '';
+                $engineVersion = self::buildEngineVersion($engine);
             }
 
             if (null === $short) {

--- a/Parser/Client/Browser/Engine/Version.php
+++ b/Parser/Client/Browser/Engine/Version.php
@@ -57,6 +57,7 @@ class Version extends AbstractClientParser
         }
 
         $engineToken = $this->engine;
+
         if ('Blink' === $this->engine) {
             $engineToken = 'Chrome';
         }

--- a/Parser/Client/Browser/Engine/Version.php
+++ b/Parser/Client/Browser/Engine/Version.php
@@ -56,8 +56,13 @@ class Version extends AbstractClientParser
             }
         }
 
+        $engineToken = $this->engine;
+        if ('Blink' === $this->engine) {
+            $engineToken = 'Chrome';
+        }
+
         \preg_match(
-            "~{$this->engine}\s*/?\s*((?(?=\d+\.\d)\d+[.\d]*|\d{1,7}(?=(?:\D|$))))~i",
+            "~{$engineToken}\s*/?\s*((?(?=\d+\.\d)\d+[.\d]*|\d{1,7}(?=(?:\D|$))))~i",
             $this->userAgent,
             $matches
         );

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -6,7 +6,7 @@
     name: Beaker Browser
     version: "0.8.2"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.181"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; GT-N7100 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30; 360 Aphone Browser (6.8.7beta)
@@ -87,7 +87,7 @@
     name: Amigo
     version: "28.0.1500.74"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.74"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; U; Android 0.5; en-us) AppleWebKit/522+ (KHTML, like Gecko) Safari/419.3
@@ -204,7 +204,7 @@
     name: Brave
     version: "0.7.9"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.73"
     family: Chrome
 -
   user_agent: 'Mozilla/4.61 [en] (X11; U; ) - BrowseX (2.0.0 Windows)'
@@ -240,7 +240,7 @@
     name: Coc Coc
     version: "45.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.74"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.11 (KHTML, like Gecko) Comodo_Dragon/17.1.0.0 Chrome/17.0.963.38 Safari/535.11
@@ -276,7 +276,7 @@
     name: Headless Chrome
     version: "63.0.3205.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3205.0"
     family:
 -
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/60.0.3112.78 Safari/537.36
@@ -285,7 +285,7 @@
     name: Headless Chrome
     version: "60.0.3112.78"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.78"
     family:
 -
   user_agent: Mozilla/5.0 ArchLinux (X11; U; Linux x86_64; en-US) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.100 Safari/534.30
@@ -303,7 +303,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36
@@ -312,7 +312,7 @@
     name: Chrome
     version: "36.0.1985.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.125"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (iPad; CPU OS 6_0_1 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/31.0.1650.18 Mobile/10A523 Safari/8536.25
@@ -339,7 +339,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.7 (KHTML, like Gecko) Chrome/16.0.912.63 Safari/535.7 CoolNovo/1.6.5.28
@@ -375,7 +375,7 @@
     name: Chromium
     version: "31.0.1650.63"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.63"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/418.9 (KHTML, like Gecko, Safari) Safari/419.3 Cheshire/1.0.ALPHA
@@ -465,7 +465,7 @@
     name: DuckDuckGo Privacy Browser
     version: "5"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/533+ (KHTML, like Gecko) Element Browser 5.0
@@ -789,7 +789,7 @@
     name: Microsoft Edge
     version: "41.1.35.1"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.0"
     family: Internet Explorer
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3738.0 Safari/537.36 Edg/75.0.107.0
@@ -798,7 +798,7 @@
     name: Microsoft Edge
     version: "75.0.107.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3738.0"
     family: Internet Explorer
 -
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; Acer; Allegro)
@@ -825,7 +825,7 @@
     name: Iron
     version: 44.0.2350.0
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2350.0"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (iPhone; CPU OS 8_0 like Mac OS X) AppleWebKit/538.34.9 (KHTML, like Gecko) Mobile/isivioo
@@ -1005,7 +1005,7 @@
     name: Avast Secure Browser
     version: "66.2.567.182"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.181"
     family: Chrome
 -
   user_agent: Maemo Browser
@@ -1257,7 +1257,7 @@
     name: Opera Mobile
     version: "15.0.1162.61541"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.63"
     family: Opera
 -
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S7230-VODAFONE/1.0; U; Bada/1.0; en-us) OperaMini/5.0.21073 Mobile WVGA SMM-MMS/1.2.0 NexPla
@@ -1311,7 +1311,7 @@
     name: Opera Next
     version: "20.0.1387.37"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.91"
     family: Opera
 -
   user_agent: 'Mozilla/1.10 [en] (Compatible; RISC OS 3.70; Oregano 1.10)'
@@ -1644,7 +1644,7 @@
     name: Vivaldi
     version: "1.0.105.7"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.114"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) TweakStyle/0.9.2 Chrome/49.0.2623.75 Electron/0.37.5 Safari/537.36 (Tab 1)
@@ -1653,7 +1653,7 @@
     name: TweakStyle
     version: "0.9.2"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (compatible; U; Webpositive/533.4; Haiku) AppleWebkit/533.4 (KHTML, like gecko) Chrome/5.0.375.55 Safari/533.4
@@ -1689,7 +1689,7 @@
     name: Yandex Browser
     version: "13.10.1500.9323"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.95"
     family:
 -
   user_agent: 'Xiino/1.0.9E [en] (v. 4.1; 153x130; g4)'
@@ -1761,7 +1761,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (iPad; CPU OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Coast/1.0.2.62956 Mobile/10B329 Safari/7534.48.3
@@ -1878,7 +1878,7 @@
     name: Firefox Rocket
     version: "1.6.2"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
     family: Firefox
 -
   user_agent: Mozilla/5.0 Linux; Android 8.0.0 AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Web Explorer/2.6.6 Chrome/75.0.3770.143 Mobile Safari/537.36
@@ -1896,7 +1896,7 @@
     name: Chrome Webview
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; Galaxy Nexus Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/5.0 Mb2345Browser/4.0 Mobile Safari/534.30
@@ -1995,7 +1995,7 @@
     name: Opera Neon
     version: "1.0.2459.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.21"
     family: Opera
 -
   user_agent: 'OPR/22.0.1481.0 OMI/4.2.12.29, KreaTV/0.0.0.0 (ARRIS, IPC1100, wired)CM[00.01]'
@@ -2049,7 +2049,7 @@
     name: Seznam Browser
     version: "3.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.102"
     family: Chrome
 -
   user_agent: UCWEB/2.0 (Linux; U; Opera Mini/7.1.32052/30.3697; en-US; QMobile Z10 Build/LMY47D) U2/1.0.0 UCMini/10.9.0.946 (SpeedMode; Android 5.1; QMobile Z10 Build/LMY47D) Mobile
@@ -2067,7 +2067,7 @@
     name: Whale Browser
     version: "0.7.33.5"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.116"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5044O Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36 Hawk/TurboBrowser/v3.0.0.4.21.06211557
@@ -2076,7 +2076,7 @@
     name: Hawk Turbo Browser
     version: "3.0.0.4.21.06211557"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5044O Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36 Hawk/TurboBrowser/2.0.51
@@ -2085,7 +2085,7 @@
     name: Hawk Turbo Browser
     version: "2.0.51"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 6.0; M5c Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.143 NoxBrowser/2.0.0 Mobile Safari/537.36
@@ -2094,7 +2094,7 @@
     name: Nox Browser
     version: "2.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
     family:
 -
   user_agent: Mozilla/5.0 (Linux; Android 6.0; U10 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.105 Mobile Safari/537.36 FreeU/1.2.148
@@ -2103,7 +2103,7 @@
     name: FreeU
     version: "1.2.148"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.105"
     family:
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:60.9) Gecko/20100101 Goanna/4.4 Firefox/60.9 Basilisk/20190912
@@ -2130,7 +2130,7 @@
     name: K.Browser
     version: "26.07"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.169"
     family:
 -
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Pacific) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/6.0.17.167158974 SamsungBrowser/4.0 Chrome/74.0.3729.182 Mobile VR Safari/537.36
@@ -2148,7 +2148,7 @@
     name: Jio Browser
     version: "1.4.2"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
     family:
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.87 Safari/537.36 Hola/1.148.217
@@ -2157,7 +2157,7 @@
     name: hola! Browser
     version: "1.148.217"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.87"
     family:
 -
   user_agent: Mozilla/5.0 (Linux; Android 9; VOG-L29 Build/HUAWEIVOG-L29) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.64 HuaweiBrowser/10.0.1.332 Mobile Safari/537.36
@@ -2166,7 +2166,7 @@
     name: Huawei Browser Mobile
     version: "10.0.1.332"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 9; vivo 1901 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36 VivoBrowser/5.10.0.1
@@ -2193,7 +2193,7 @@
     name: Yandex Browser Lite
     version: "19.1.0.130"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
     family:
 -
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HM NOTE 1W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 YaBrowser/18.11.1.822.00 (alpha) Mobile Safari/537.36
@@ -2202,7 +2202,7 @@
     name: Yandex Browser
     version: "18.11.1.822.00 alpha"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
     family:
 -
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; YOGA Tablet 2-1050L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/18.11.0.102 YaBrowser/18.11.0.350.01 (beta) Safari/537.36
@@ -2211,7 +2211,7 @@
     name: Yandex Browser
     version: "18.11.0.350.01 beta"
     engine: Blink
-    engine_version: ""
+    engine_version: "18.11.0.102"
     family:
 -
   user_agent: Mozilla/5.0 (X11; Linux i686 on x86_64; rv:52.0) Gecko/20100101 Firefox/52.0 Ordissimo/3.8.20+svn37598
@@ -2256,7 +2256,7 @@
     name: Opera GX
     version: "60.0.3255.50747"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.103"
     family: Opera
 -
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; BV6000 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.0.1163 UCTurbo/1.7.9.900 Mobile Safari/537.36
@@ -2274,7 +2274,7 @@
     name: UBrowser
     version: 5.5.5701.114
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.157"
     family: Chrome
 -
   user_agent: 'Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; SHP-SH330T/V03.03; 320*480; CTC/2.0) eZBrowser/1.0'
@@ -2355,7 +2355,7 @@
     name: CCleaner
     version: "75.1.103.145"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.142"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DUB-AL20 Build/HUAWEIDUB-AL20; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36 AlohaLite/1.4.0.1 AlohaBrowser/2.9.0.1
@@ -2364,7 +2364,7 @@
     name: Aloha Browser Lite
     version: "1.4.0.1"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/536.11 (KHTML, like Gecko) Chrome/20.0.1132.11 TaoBrowser/3.1 Safari/536.11
@@ -2463,7 +2463,7 @@
     name: Beamrise
     version: 31.0.1650.7639
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.57"
     family: Chrome
 -
   user_agent: Faux/20151018 CFNetwork/808.1.4 Darwin/16.1.0
@@ -2481,7 +2481,7 @@
     name: Iron
     version: "77.0.4000.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.4000.0"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/602.1 (KHTML, like Gecko) splash Version/10.0 Safari/602.1
@@ -2508,7 +2508,7 @@
     name: AVG Secure Browser
     version: "77.2.2156.122"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Zun X Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.97 Mobile Safari/537.36 Start/53.0.2785.97
@@ -2634,7 +2634,7 @@
     name: Avast Secure Browser
     version: "4.58.2552.909"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.81"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 6.2; WOW64; rv:52.9) Gecko/20100101 Goanna/3.4 Firefox/52.9 ArcticFox/27.9.19
@@ -2814,7 +2814,7 @@
     name: Avast Secure Browser
     version: "49.0.79.75"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (X11 TOS; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 ToGate/72.0.3626.109 Safari/537.36
@@ -2823,7 +2823,7 @@
     name: ToGate
     version: "72.0.3626.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.109"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 6055P Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36 bdbrowser/1.9.0.2
@@ -2868,7 +2868,7 @@
     name: Yaani Browser
     version: "4.3.0.153"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3317.0"
     family: Chrome
 -
   user_agent: GOGGalaxyClient/2.0.20.39 (GOG Galaxy) 83b6745cff679691b69876bc7ee33e05e5d90bda (win10 x64)
@@ -2904,7 +2904,7 @@
     name: Yandex Browser
     version: 20.93.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
     family:
 -
   user_agent: FLY_E141TV_PLUS/ WAP Browser/MAUI(HTTP PGDL;HTTPS)Profile/Q03C1-2.40 ru-RU
@@ -2931,7 +2931,7 @@
     name: Slimjet
     version: 22.0.4.0
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.101 7Star/1.45.0.415 Safari/537.36
@@ -2940,7 +2940,7 @@
     name: 7Star
     version: 1.45.0.415
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.101"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) MxNitro/1.0.1.3000 Chrome/35.0.1849.0 Safari/537.36
@@ -2949,7 +2949,7 @@
     name: MxNitro
     version: 1.0.1.3000
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1849.0"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0; Crazy Browser 3.1.0) like Gecko
@@ -3057,7 +3057,7 @@
     name: Secure Browser
     version: 57.0.441.112
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.112"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 10; JNY-LX1 Build/HUAWEIJNY-L21; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36 AgentWeb/4.1.3 UCBrowser/11.6.4.950
@@ -3066,7 +3066,7 @@
     name: CoolBrowser
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) SFive/62.115 Chrome/62.115.3202.101 Safari/537.36
@@ -3075,7 +3075,7 @@
     name: SFive
     version: "62.115.3202.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.115.3202.101"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Freebox; Linux i686) AppleWebKit/538.1 (KHTML, like Gecko) Navigateur web/1.0 Safari/538.1
@@ -3093,7 +3093,7 @@
     name: Seewo Browser
     version: 2.0.16.3558
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.139"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) UR/61.1.3163.21 Chrome/62.0.3202.94 Safari/537.36
@@ -3102,7 +3102,7 @@
     name: UR Browser
     version: 61.1.3163.21
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.94"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 7.0; N280 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Stargon/2.3.2 Chrome/59.0.3071.125 Mobile Safari/537.36
@@ -3111,7 +3111,7 @@
     name: Stargon
     version: 2.3.2
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (X11; Linux x86_64; Deepin 15.11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.75 Safari/537.36 NFSBrowser/5.0.5.2050
@@ -3120,7 +3120,7 @@
     name: NFS Browser
     version: 5.0.5.2050
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.75"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T8 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) YoloBrowser/1.0.1.74 Safari/537.36
@@ -3138,7 +3138,7 @@
     name: Smart Lenovo Browser
     version: 6.0.1.9171
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.87"
     family:
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko Core/1.63.5847.400 SLBrowser/10.0.2559.400
@@ -3165,7 +3165,7 @@
     name: Odin
     version: 74.3729.2.10
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.108"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-G935F Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SFive_Android/65.0.3325.109 Chrome/65.0.3325.109 Mobile Safari/537.36
@@ -3174,7 +3174,7 @@
     name: SFive
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) SFive_iOS/1.0.0.16 CriOS/57.0.2979.0 Mobile/14G60 Safari/602.1
@@ -3192,7 +3192,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux) AppleWebKit/534.51 (KHTML, like Gecko) Ekioh/2.2.4.7-moto-mob Safari/534.51
@@ -3408,7 +3408,7 @@
     name: Chim Lac
     version: "1.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.140"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.91 chimlac/73.0.3683.91 Safari/537.36
@@ -3417,7 +3417,7 @@
     name: Chim Lac
     version: 73.0.3683.91
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.91"
     family: Chrome
 -
   user_agent: 'Sleipnir%20Browser/4.5.5012 CFNetwork/673.6 Darwin/13.4.0 (x86_64) (MacBookPro9%2C2)'
@@ -3462,7 +3462,7 @@
     name: Chim Lac
     version: "1.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.140"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.91 chimlac/73.0.3683.91 Safari/537.36
@@ -3471,7 +3471,7 @@
     name: Chim Lac
     version: 73.0.3683.91
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.91"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.157 Torrent/44.0.1.3 Safari/537.36
@@ -3480,7 +3480,7 @@
     name: Maelstrom
     version: 44.0.1.3
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.157"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.0.7) Gecko/2009030821 Firefox/3.0.7 Orca/1.1 build 2
@@ -3498,7 +3498,7 @@
     name: Cornowser
     version: 1.0.4.7
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2655.1"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Arvin/9.0.0 Chrome/78.0.3904.108 Mobile Safari/537.36
@@ -3507,7 +3507,7 @@
     name: Arvin
     version: 9.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36 Helio/0.98.0
@@ -3516,7 +3516,7 @@
     name: Helio
     version: 0.98.0
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.90"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.105 Safari/537.36 7654Browser/1.0.2.3
@@ -3525,7 +3525,7 @@
     name: 7654 Browser
     version: 1.0.2.3
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.105"
     family:
 -
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.153 DeledaoPersonal/80.0.3987.153 Safari/537.36
@@ -3534,7 +3534,7 @@
     name: Deledao
     version: 80.0.3987.153
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.153"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.80 DeledaoFamily/73.0.3683.80 Safari/537.36
@@ -3543,7 +3543,7 @@
     name: Deledao
     version: 73.0.3683.80
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.80"
     family: Chrome
 -
   user_agent: QwantMobile/2.0 (iPad; CPU OS 10_3_4 like Mac OS X) AppleWebKit/603.3.8 (KHTML, like Gecko) QwantiOS/2.4.1b1 Mobile/14G61 Safari/603.3.8
@@ -3561,7 +3561,7 @@
     name: HasBrowser
     version: "5.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3112.101"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) DotBrowser/3.0.2-alpha Chrome/81.0.4044.122 Safari/537.36
@@ -3570,7 +3570,7 @@
     name: Dot Browser
     version: 3.0.2
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.122"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Macintosh; U; PPC Mac OS X) AppleWebKit/312.8 (KHTML, like Gecko, Safari) DeskBrowse/1.0
@@ -3588,7 +3588,7 @@
     name: GinxDroid Browser
     version: 90.9.8.3
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.36 AviraScout/47.0.2526.111
@@ -3597,7 +3597,7 @@
     name: Avira Scout
     version: 47.0.2526.111
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.111"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-T515 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.4 Mobile Safari/537.36 YandexSearch/10.91/apad YandexSearchBrowser/10.91
@@ -3606,7 +3606,7 @@
     name: Yandex Browser
     version: "10.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.4"
     family:
 -
   user_agent: Mozilla/5.0 (iPad; CPU OS 7_1_2 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) BaiduHD/2.6.2 Mobile/10A406 Safari/8536.25
@@ -3633,7 +3633,7 @@
     name: Venus Browser
     version: 2.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.122 Otter/1.0.01
@@ -3642,7 +3642,7 @@
     name: Otter Browser
     version: 1.0.01
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.122"
     family:
 -
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 13_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/605.1.15/Smooz/1.96.6.2725
@@ -3660,7 +3660,7 @@
     name: Smooz
     version: 1.47.0
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
     family:
 -
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36 BriskBard/1.8.4
@@ -3669,7 +3669,7 @@
     name: BriskBard
     version: 1.8.4
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.88"
     family:
 -
   user_agent: Mozilla/5.0 (Linux x86_64) AppleWebKit/538.19 (KHTML, like Gecko) JavaFX/8.0 Safari/538.19
@@ -3696,7 +3696,7 @@
     name: Craving Explorer
     version: 2.2.17
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; WOW64; rv:68.9) Gecko/20100101 Goanna/4.6 Firefox/68.9 Lolifox/28.12.0
@@ -3714,7 +3714,7 @@
     name: Jio Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
     family:
 -
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:36.0) Gecko/20100101 Firefox/36.0 PolyBrowser/36.0
@@ -3732,7 +3732,7 @@
     name: Coc Coc
     version: "47.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.119"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) qutebrowser/1.13.1 QtWebEngine/5.14.2 Chrome/77.0.3865.129 Safari/537.36
@@ -3741,7 +3741,7 @@
     name: Qutebrowser
     version: 1.13.1
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.129"
     family:
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) flast/83.0.0 Chrome/83.0.4103.122 Safari/537.36
@@ -3750,7 +3750,7 @@
     name: Flast
     version: 83.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.122"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.1 (KHTML, like Gecko) Chrome/21.0.1180.75 Safari/537.1 AvantBrowser/Tri-Core
@@ -3768,7 +3768,7 @@
     name: Coc Coc
     version: 33.0.1750.157
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.157"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.146 SparkSafe/2.x Safari/537.36
@@ -3795,7 +3795,7 @@
     name: Maxthon
     version: 5.2.6.200
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.79"
     family:
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.79 Safari/537.36 Maxthon/5.2.1.5000
@@ -3804,7 +3804,7 @@
     name: Maxthon
     version: 5.2.1.5000
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.79"
     family:
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3727.0 Mandarin Browser/1.0.0.0 Safari/537.36
@@ -3813,7 +3813,7 @@
     name: Mandarin
     version: 1.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3727.0"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Degdegan/75.4.128 Chrome/87.4.3497.128 Safari/537.36
@@ -3822,7 +3822,7 @@
     name: deg-degan
     version: 75.4.128
     engine: Blink
-    engine_version: ""
+    engine_version: "87.4.3497.128"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.78 Chedot/8.0.1 Safari/537.36
@@ -3831,7 +3831,7 @@
     name: Chedot
     version: 8.0.1
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.78"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 (Chromium GOST) Safari/537.36
@@ -3840,7 +3840,7 @@
     name: Chromium GOST
     version: 83.0.4103.116
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.16 Safari/537.36 bdbrowserhd_i18n/1.9.0.1
@@ -3867,7 +3867,7 @@
     name: Midori
     version: "1.2"
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
     family:
 -
   user_agent: Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/88.0.4324.93 Mobile OceanHero/6 Safari/537.36
@@ -3876,7 +3876,7 @@
     name: OceanHero
     version: "6"
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (SMART-TV; Linux; Tizen 2.4.0) AppleWebKit/538.1 (KHTML, like Gecko) Version/2.4.0 TV Safari/538.1
@@ -3903,7 +3903,7 @@
     name: OpenFin
     version: 6.49.12.65
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-G973U Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/86.0.4240.185 Mobile Safari/537.36 EdgW/1.0
@@ -3921,7 +3921,7 @@
     name: SuperBird
     version: 73.0.3683.103
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.103"
     family:
 -
   user_agent: Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 SY/1.9 Chrome/90.0.4430.210 Mobile Safari/537.36
@@ -3930,7 +3930,7 @@
     name: Stampy Browser
     version: "1.9"
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
     family: Chrome
 -
   user_agent: Nokia6120c/GoBrowser/2.0.290
@@ -3948,7 +3948,7 @@
     name: Tenta Browser
     version: 4.0.55
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) FlashBrowser/1.0.0 Chrome/83.0.4103.122 Electron/9.1.0 Safari/537.36
@@ -3957,7 +3957,7 @@
     name: Flash Browser
     version: 1.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.122"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) spectre-browser/1.1.2 Chrome/76.0.3809.146 Electron/6.1.7 Safari/537.36
@@ -3966,7 +3966,7 @@
     name: Spectre Browser
     version: 1.1.2
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.146"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) bonsai-browser/1.1.1 Chrome/91.0.4472.164 Electron/13.4.0 Safari/537.36
@@ -3975,7 +3975,7 @@
     name: Bonsai
     version: 1.1.1
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Harman_Browser/0.0.6 Chrome/85.0.4183.121 Electron/10.1.5 Safari/537.36
@@ -3984,7 +3984,7 @@
     name: Harman Browser
     version: 0.0.6
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.121"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) psi-secure-browser/1.1.4 Chrome/61.0.3163.100 Electron/2.90.12 Safari/537.36
@@ -3993,7 +3993,7 @@
     name: PSI Secure Browser
     version: 1.1.4
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.100"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_0) AppleWebKit/537.36 (KHTML, like Gecko) lagatos-browser/2.0.0-1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36
@@ -4002,7 +4002,7 @@
     name: Lagatos Browser
     version: 2.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.122"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) LTBrowser/1.5.1 Chrome/80.0.3987.163 Electron/8.5.5 Safari/537.36
@@ -4011,7 +4011,7 @@
     name: LT Browser
     version: 1.5.1
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.163"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) dBrowser/1.0.0 Chrome/84.0.4129.0 Electron/10.0.0-beta.2 Safari/537.36
@@ -4020,7 +4020,7 @@
     name: Peeps dBrowser
     version: 1.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4129.0"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) SushiBrowser/0.32.0 Chrome/85.0.4183.121 Electron/10.1.3 Safari/537.36
@@ -4029,7 +4029,7 @@
     name: Sushi Browser
     version: 0.32.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.121"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 OPX/1.3.1
@@ -4056,7 +4056,7 @@
     name: Opera GX
     version: "1.3"
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
     family: Opera
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.107 Safari/537.36 HBPC/11.0.7.301
@@ -4065,7 +4065,7 @@
     name: Huawei Browser
     version: 11.0.7.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.107"
     family: Chrome
 -
   user_agent: iBrowser/2.8 Mozilla/5.0 (Linux; Android 4.4.2; itel_it1701 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
@@ -4101,7 +4101,7 @@
     name: Lunascape
     version: 11.2.2
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
     family:
 -
   user_agent: Mozilla/5.0 (Linux; Android 9; veSt7P28s4; U; en) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Mobile AvastSecureBrowser/6.2.3 Build/3670 Safari/537.36
@@ -4110,7 +4110,7 @@
     name: Avast Secure Browser
     version: 6.2.3
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/96.0.4664.92 Mobile Safari/537.36 webexplorer/4
@@ -4128,7 +4128,7 @@
     name: T+Browser
     version: 2.3.4.1
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Safari/537.36 ChanjetCloud/77.1588.2.2
@@ -4137,7 +4137,7 @@
     name: ChanjetCloud
     version: 77.1588.2.2
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (iPad; CPU OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/10.0 Mobile/15E216 Safari/602.1 MXiOS/5.2.8.415
@@ -4155,7 +4155,7 @@
     name: Hawk Quick Browser
     version: 2.1.9.20467
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/538.1 (KHTML, like Gecko) Google Earth Pro/7.3.3.7721 Safari/538.1
@@ -4299,7 +4299,7 @@
     name: SiteKiosk
     version: "9.6"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.82"
     family:
 -
   user_agent: Opera/3 CFNetwork/1329 Darwin/21.3.0
@@ -4353,7 +4353,7 @@
     name: Opera
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
     family: Opera
 -
   user_agent: Mozilla/5.0 (Linux; U; Android 11; zh-CN; TECNO LE7 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 HiBrowser/2.3.013 UWS/ Mobile Safari/537.36
@@ -4362,7 +4362,7 @@
     name: Hi Browser
     version: 2.3.013
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.108"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; N817 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36 Navegador
@@ -4371,7 +4371,7 @@
     name: Navegador
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 11; LAVA LZG403 Build/RP1A.200720.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/93.0.4577.62 Mobile Safari/537.36uc mini browser1.0
@@ -4380,7 +4380,7 @@
     name: UC Browser Mini
     version: "1.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
     family:
 -
   user_agent: Mozilla/5.0 (Linux; Android 11; M2101K7AI Build/RKQ1.201022.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/87.0.4280.141 Mobile Safari/537.36UC Browser1.1
@@ -4389,7 +4389,7 @@
     name: UC Browser
     version: "1.1"
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
     family:
 -
   user_agent: Mozilla/5.0 (Linux; Android 10; M2006C3LG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.75 Mobile Safari/537.36 ABB/3.0.1
@@ -4398,7 +4398,7 @@
     name: AdBlock Browser
     version: 3.0.1
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.75"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 10; ONEPLUS A6003 Build/QKQ1.190716.003; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36 youcare-android-app
@@ -4407,7 +4407,7 @@
     name: YouCare
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/78.0.3904.84 Mobile/15E148 Safari/605.1 youcare-ios-app
@@ -4425,7 +4425,7 @@
     name: Decentr
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "96.4.4664.32"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_4_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.182 Safari/537.36 (Chromium GOST)
@@ -4434,7 +4434,7 @@
     name: Chromium GOST
     version: 88.0.4324.182
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36 (Chromium GOST)
@@ -4443,7 +4443,7 @@
     name: Chromium GOST
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
     family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; en_US) AppleWebKit/534.34 PocketBook/801 (screen 600x800; FW W801.4.1.886)
@@ -4461,7 +4461,7 @@
     name: Gener8
     version: "98.0.4758.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.109"
     family: Chrome
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="98.0.4758.109", "Gener8";v="98.0.4758.109"'
@@ -4479,7 +4479,7 @@
     name: Opera Crypto
     version: "99.0.4844.16"
     engine: Blink
-    engine_version: ""
+    engine_version: "99.0.4844.16"
     family: Opera
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="99.0.4844.16", "Opera Crypto";v="99.0.4844.16"'
@@ -4497,7 +4497,7 @@
     name: Whale Browser
     version: 3.13.131.36
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.104"
     family: Chrome
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="98", "Whale";v="3.13.131.36"'
@@ -4515,7 +4515,7 @@
     name: Opera GX
     version: 98.0.4758.102
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.102"
     family: Opera
   headers:
     Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="98.0.4758.102", "Opera GX";v="98.0.4758.102"'
@@ -4544,7 +4544,7 @@
     name: Via
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
     family: Chrome
   headers:
     X-Requested-With: mark.via.gp
@@ -4555,7 +4555,7 @@
     name: Pure Mini Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
     family: Chrome
   headers:
     X-Requested-With: com.pure.mini.browser
@@ -4566,7 +4566,7 @@
     name: Raise Fast Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
     family: Chrome
   headers:
     X-Requested-With: acr.browser.raisebrowserfull
@@ -4577,7 +4577,7 @@
     name: Fast Browser UC Lite
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3029.83"
     family: Chrome
   headers:
     X-Requested-With: com.Fast.BrowserUc.lite
@@ -4588,7 +4588,7 @@
     name: Lightning Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
     family: Chrome
   headers:
     X-Requested-With: acr.browser.barebones
@@ -4599,7 +4599,7 @@
     name: Dark Web Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
     family: Chrome
   headers:
     X-Requested-With: anar.app.darkweb
@@ -4610,7 +4610,7 @@
     name: Kiwi
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
     family: Chrome
   headers:
     X-Requested-With: com.kiwibrowser.browser
@@ -4621,7 +4621,7 @@
     name: Puffin Web Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
     family: Chrome
   headers:
     X-Requested-With: com.cloudmosa.puffinFree
@@ -4632,7 +4632,7 @@
     name: Aloha Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
     family: Chrome
   headers:
     X-Requested-With: com.aloha.browser
@@ -4643,7 +4643,7 @@
     name: Cake Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
     family: Chrome
   headers:
     X-Requested-With: com.cake.browser
@@ -4665,7 +4665,7 @@
     name: UC Browser
     version: ''
     engine: Blink
-    engine_version: ''
+    engine_version: "96.0.4664.45"
     family: Chrome
   headers:
     X-Requested-With: com.UCMobile.intl
@@ -4676,7 +4676,7 @@
     name: IE Browser Fast
     version: ''
     engine: Blink
-    engine_version: ''
+    engine_version: "97.0.4692.98"
     family: Chrome
   headers:
     X-Requested-With: com.iebrowser.fast
@@ -4687,7 +4687,7 @@
     name: Vegas Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
     family: Chrome
   headers:
     X-Requested-With: acr.browser.linxy
@@ -4698,7 +4698,7 @@
     name: OH Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
     family: Chrome
   headers:
     X-Requested-With: com.oh.bro
@@ -4709,7 +4709,7 @@
     name: OH Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
     family: Chrome
   headers:
     X-Requested-With: com.oh.bro
@@ -4720,7 +4720,7 @@
     name: DuckDuckGo Privacy Browser
     version: "5"
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
     family: Chrome
   headers:
     X-Requested-With: com.duckduckgo.mobile.android
@@ -4731,7 +4731,7 @@
     name: Stargon
     version: 4.6.0
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
     family: Chrome
   headers:
     X-Requested-With: net.onecook.browser
@@ -4753,7 +4753,7 @@
     name: Odin Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
     family: Chrome
   headers:
     X-Requested-With: com.hisense.odinbrowser
@@ -4764,7 +4764,7 @@
     name: Brave
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
     family: Chrome
   headers:
     X-Requested-With: com.brave.browser
@@ -4775,7 +4775,7 @@
     name: Firefox Klar
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
     family: Chrome
   headers:
     X-Requested-With: org.mozilla.klar
@@ -4786,7 +4786,7 @@
     name: Anka Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
     family: Chrome
   headers:
     X-Requested-With: phx.hot.browser
@@ -4797,7 +4797,7 @@
     name: Firefox Focus
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
     family: Chrome
   headers:
     X-Requested-With: org.mozilla.focus
@@ -4808,7 +4808,7 @@
     name: Vivaldi
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.91"
     family: Chrome
   headers:
     X-Requested-With: com.vivaldi.browser
@@ -4819,7 +4819,7 @@
     name: Dragon Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.87"
     family: Chrome
   headers:
     X-Requested-With: web.browser.dragon
@@ -4830,7 +4830,7 @@
     name: Easy Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.70"
     family: Chrome
   headers:
     X-Requested-With: org.easyweb.browser
@@ -4841,7 +4841,7 @@
     name: XBrowser Mini
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
     family: Chrome
   headers:
     X-Requested-With: com.xbrowser.play
@@ -4852,7 +4852,7 @@
     name: Sharkee Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
     family: Chrome
   headers:
     X-Requested-With: com.sharkeeapp.browser
@@ -4863,7 +4863,7 @@
     name: Lark Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
     family: Chrome
   headers:
     X-Requested-With: com.mobiu.browser
@@ -4874,7 +4874,7 @@
     name: Pluma
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
     family: Chrome
   headers:
     X-Requested-With: com.qflair.browserq
@@ -4885,7 +4885,7 @@
     name: Nox Browser
     version: 2.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
     family:
   headers:
     X-Requested-With: com.noxgroup.app.browser
@@ -4896,7 +4896,7 @@
     name: Nox Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
     family: Chrome
   headers:
     X-Requested-With: com.noxgroup.app.browser
@@ -4907,7 +4907,7 @@
     name: JioPages
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
     family: Chrome
   headers:
     X-Requested-With: com.jio.web
@@ -4918,7 +4918,7 @@
     name: Ume Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
     family: Chrome
   headers:
     X-Requested-With: com.ume.browser.cust
@@ -4929,7 +4929,7 @@
     name: KUTO Mini Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
     family: Chrome
   headers:
     X-Requested-With: com.kuto.browser
@@ -4940,7 +4940,7 @@
     name: Dolphin Zero
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
     family: Chrome
   headers:
     X-Requested-With: com.dolphin.browser.zero
@@ -4951,7 +4951,7 @@
     name: Dolphin
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.70"
     family: Chrome
   headers:
     X-Requested-With: mobi.mgeek.TunnyBrowser
@@ -4962,7 +4962,7 @@
     name: Atlas
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
     family: Chrome
   headers:
     X-Requested-With: nextapp.atlas
@@ -4973,7 +4973,7 @@
     name: Firefox Rocket
     version: 2.6.0
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
     family: Firefox
   headers:
     X-Requested-With: org.mozilla.rocket
@@ -4984,7 +4984,7 @@
     name: Firefox Rocket
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
     family: Firefox
   headers:
     X-Requested-With: org.mozilla.rocket
@@ -4995,7 +4995,7 @@
     name: OH Private Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
     family: Chrome
   headers:
     X-Requested-With: com.oh.brop
@@ -5006,7 +5006,7 @@
     name: Maxthon
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
     family:
 -
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2185 Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/97.0.4692.98 Mobile Safari/537.36 Maxthon/9000
@@ -5015,7 +5015,7 @@
     name: Maxthon
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
     family:
 -
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Redmi Pro Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36 MxBrowser/4.5.10.1300
@@ -5024,7 +5024,7 @@
     name: Maxthon
     version: 4.5.10.1300
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
     family:
 -
   user_agent: Mozilla/5.0 (Linux; Android 9; Mi A1 Build/PKQ1.180917.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/99.0.4844.48 Mobile Safari/537.36 Maxthon/9000
@@ -5033,7 +5033,7 @@
     name: Maxthon
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "99.0.4844.48"
     family:
   headers:
     X-Requested-With: com.mx.browser
@@ -5044,7 +5044,7 @@
     name: Maxthon
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
     family: Chrome
   headers:
     X-Requested-With: com.mx.browser
@@ -5055,7 +5055,7 @@
     name: Ecosia
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
     family: Chrome
   headers:
     X-Requested-With: com.ecosia.android
@@ -5066,7 +5066,7 @@
     name: Jelly
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
     family: Chrome
   headers:
     X-Requested-With: org.lineageos.jelly
@@ -5077,7 +5077,7 @@
     name: Opera GX
     version: "1.4"
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
     family: Opera
   headers:
     X-Requested-With: com.opera.gx

--- a/Tests/fixtures/camera.yml
+++ b/Tests/fixtures/camera.yml
@@ -28,7 +28,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: camera
     brand: Panasonic
@@ -64,7 +64,7 @@
     name: Opera Mobile
     version: "15.0.1162.60140"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.63"
   device:
     type: camera
     brand: Samsung
@@ -82,7 +82,7 @@
     name: Chrome Mobile
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: camera
     brand: Samsung

--- a/Tests/fixtures/car_browser.yml
+++ b/Tests/fixtures/car_browser.yml
@@ -10,7 +10,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: car browser
     brand: NewsMy
@@ -28,7 +28,7 @@
     name: Chrome
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: car browser
     brand: NewsMy
@@ -46,7 +46,7 @@
     name: Chromium
     version: "75.0.3770.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.100"
   device:
     type: car browser
     brand: Tesla
@@ -82,7 +82,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: car browser
     brand: Allwinner
@@ -118,7 +118,7 @@
     name: Chrome
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: car browser
     brand: MAC AUDIO
@@ -136,7 +136,7 @@
     name: Chrome
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: car browser
     brand: Allwinner
@@ -154,7 +154,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: car browser
     brand: Topway
@@ -172,7 +172,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: car browser
     brand: Allwinner
@@ -190,7 +190,7 @@
     name: Chrome
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: car browser
     brand: Allwinner
@@ -208,7 +208,7 @@
     name: Chrome
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: car browser
     brand: Allwinner
@@ -226,7 +226,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: car browser
     brand: Allwinner
@@ -244,7 +244,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: car browser
     brand: Pioneer
@@ -262,7 +262,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: car browser
     brand: Pioneer
@@ -280,7 +280,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: car browser
     brand: Alps
@@ -298,7 +298,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: car browser
     brand: Prology
@@ -334,7 +334,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: car browser
     brand: Prology
@@ -370,7 +370,7 @@
     name: Chrome Mobile
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: car browser
     brand: Prology
@@ -388,7 +388,7 @@
     name: Chrome
     version: 55.0.2883.77
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.77"
   device:
     type: car browser
     brand: Porsche
@@ -406,7 +406,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: car browser
     brand: Alps

--- a/Tests/fixtures/clienthints-app.yml
+++ b/Tests/fixtures/clienthints-app.yml
@@ -33,7 +33,7 @@
     name: Via
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Asus
@@ -54,7 +54,7 @@
     name: Pure Mini Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: Nomi
@@ -74,7 +74,7 @@
     name: Raise Fast Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Samsung
@@ -94,7 +94,7 @@
     name: Fast Browser UC Lite
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3029.83"
   device:
     type: smartphone
     brand: ""
@@ -114,7 +114,7 @@
     name: Lightning Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -134,7 +134,7 @@
     name: Dark Web Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: OPPO
@@ -154,7 +154,7 @@
     name: Kiwi
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Infinix
@@ -174,7 +174,7 @@
     name: Puffin Web Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -194,7 +194,7 @@
     name: Aloha Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Mobicel
@@ -214,7 +214,7 @@
     name: Cake Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: phablet
     brand: Xiaomi
@@ -254,7 +254,7 @@
     name: UC Browser
     version: ''
     engine: Blink
-    engine_version: ''
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: ZTE
@@ -274,7 +274,7 @@
     name: IE Browser Fast
     version: ''
     engine: Blink
-    engine_version: ''
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Neffos
@@ -294,7 +294,7 @@
     name: IE Browser Fast
     version: ''
     engine: Blink
-    engine_version: ''
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: Xiaomi
@@ -422,7 +422,7 @@
     name: Vegas Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Xiaomi
@@ -442,7 +442,7 @@
     name: OH Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Huawei
@@ -462,7 +462,7 @@
     name: OH Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: tablet
     brand: ""
@@ -482,7 +482,7 @@
     name: DuckDuckGo Privacy Browser
     version: "5"
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: tablet
     brand: ""
@@ -502,7 +502,7 @@
     name: Stargon
     version: 4.6.0
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Vivo
@@ -542,7 +542,7 @@
     name: Odin Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: ""
@@ -562,7 +562,7 @@
     name: Brave
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Samsung
@@ -582,7 +582,7 @@
     name: Firefox Klar
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: ""
@@ -602,7 +602,7 @@
     name: Anka Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: phablet
     brand: Xiaomi
@@ -640,7 +640,7 @@
     name: Firefox Focus
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -660,7 +660,7 @@
     name: Vivaldi
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.91"
   device:
     type: smartphone
     brand: Impression
@@ -680,7 +680,7 @@
     name: Dragon Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.87"
   device:
     type: smartphone
     brand: Xiaomi
@@ -700,7 +700,7 @@
     name: Easy Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.70"
   device:
     type: smartphone
     brand: Huawei
@@ -720,7 +720,7 @@
     name: XBrowser Mini
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -740,7 +740,7 @@
     name: Sharkee Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -760,7 +760,7 @@
     name: Lark Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: phablet
     brand: Xiaomi
@@ -780,7 +780,7 @@
     name: Pluma
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: ""
@@ -800,7 +800,7 @@
     name: Nox Browser
     version: 2.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Samsung
@@ -820,7 +820,7 @@
     name: Nox Browser
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Xiaomi
@@ -840,7 +840,7 @@
     name: JioPages
     version: ""
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: phablet
     brand: Xiaomi

--- a/Tests/fixtures/clienthints.yml
+++ b/Tests/fixtures/clienthints.yml
@@ -18,7 +18,7 @@
     name: Chrome Mobile
     version: "98.0.4758.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.87"
   device:
     type: smartphone
     brand: Asus
@@ -44,7 +44,7 @@
     name: Yandex Browser
     version: "22.1.4.706"
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.174"
   device:
     type: smartphone
     brand: Asus
@@ -70,7 +70,7 @@
     name: Opera Mobile
     version: "96.0.4664.104"
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Asus
@@ -93,7 +93,7 @@
     name: Chrome
     version: "97.0.4692.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.99"
   device:
     type: desktop
     brand:
@@ -115,7 +115,7 @@
     name: Chrome
     version: "97.0.4692.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.99"
   device:
     type: desktop
     brand:
@@ -138,7 +138,7 @@
     name: Microsoft Edge
     version: "95.0.1020.44"
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.69"
   device:
     type: desktop
     brand:
@@ -162,7 +162,7 @@
     name: Opera
     version: "98.0.4758.82"
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.82"
   device:
     type: desktop
     brand:
@@ -187,7 +187,7 @@
     name: Chrome Mobile
     version: "98.0.4758.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: OnePlus
@@ -213,7 +213,7 @@
     name: CCleaner
     version: "98.0.14335.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.102"
   device:
     type: desktop
     brand: ""
@@ -239,7 +239,7 @@
     name: AVG Secure Browser
     version: "98.0.14335.104"
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.102"
   device:
     type: desktop
     brand: ""
@@ -265,7 +265,7 @@
     name: Avast Secure Browser
     version: "98.0.14335.103"
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.102"
   device:
     type: desktop
     brand: ""
@@ -291,7 +291,7 @@
     name: Mobile Silk
     version: "98.1.148"
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: tablet
     brand: Amazon
@@ -317,7 +317,7 @@
     name: Avast Secure Browser
     version: "6.6.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: tablet
     brand: ""
@@ -370,7 +370,7 @@
     name: Microsoft Edge
     version: "98.0.1108.56"
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.102"
   device:
     type: desktop
     brand: ""
@@ -397,7 +397,7 @@
     name: Chrome
     version: "98.0.4758.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.109"
   device:
     type: desktop
     brand: Apple
@@ -424,7 +424,7 @@
     name: Opera
     version: "98.0.4758.102"
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.102"
   device:
     type: desktop
     brand: Apple
@@ -451,7 +451,7 @@
     name: Chrome
     version: 98.0.4758.102
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.102"
   device:
     type: desktop
     brand: ""
@@ -477,7 +477,7 @@
     name: Chrome Mobile
     version: "98.0.4758.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: ""
@@ -504,7 +504,7 @@
     name: Microsoft Edge
     version: "97.0.1072.66"
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.71"
   device:
     type: desktop
     brand: ""
@@ -531,7 +531,7 @@
     name: Opera Crypto
     version: "99.0.4844.16"
     engine: Blink
-    engine_version: ""
+    engine_version: "99.0.4844.16"
   device:
     type: desktop
     brand: ""
@@ -558,7 +558,7 @@
     name: Gener8
     version: "98.0.4758.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.109"
   device:
     type: desktop
     brand: ""
@@ -603,7 +603,7 @@
     name: Chrome
     version: "94.0.4606.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.126"
   device:
     type: desktop
     brand: ""
@@ -629,7 +629,7 @@
     name: Chrome
     version: "94.0.4606.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.126"
   device:
     type: desktop
     brand: ""
@@ -653,7 +653,7 @@
     name: Chrome
     version: "92.0.4515.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.98"
   device:
     type: desktop
     brand: ""
@@ -675,7 +675,7 @@
     name: Chrome
     version: 96.0.6167.5881
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.6167.5881"
   device:
     type: desktop
     brand: ""
@@ -702,7 +702,7 @@
     name: Chrome
     version: 98.0.4758.121
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.121"
   device:
     type: desktop
     brand: ""

--- a/Tests/fixtures/console.yml
+++ b/Tests/fixtures/console.yml
@@ -352,7 +352,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: console
     brand: Retroid Pocket
@@ -370,7 +370,7 @@
     name: Chrome Webview
     version: 53.0.2785.97
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.97"
   device:
     type: console
     brand: Nvidia

--- a/Tests/fixtures/desktop.yml
+++ b/Tests/fixtures/desktop.yml
@@ -206,7 +206,7 @@
     name: Chrome
     version: "31.0.1650.67"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.67"
   device:
     type: desktop
     brand: ""
@@ -1090,7 +1090,7 @@
     name: Chrome
     version: "28.0.1500.45"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.45"
   device:
     type: desktop
     brand: ""
@@ -1351,7 +1351,7 @@
     name: Chrome
     version: "31.0.1650.63"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.63"
   device:
     type: desktop
     brand: ""
@@ -1387,7 +1387,7 @@
     name: Chromium
     version: "31.0.1650.63"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.63"
   device:
     type: desktop
     brand: ""
@@ -1581,7 +1581,7 @@
     name: Amigo
     version: "28.0.1500.74"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.74"
   device:
     type: desktop
     brand: ""
@@ -1653,7 +1653,7 @@
     name: Chrome
     version: "31.0.1650.63"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.63"
   device:
     type: desktop
     brand: ""
@@ -1671,7 +1671,7 @@
     name: Chrome
     version: "69.0.3497.128"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.128"
   device:
     type: desktop
     brand: ""
@@ -2097,7 +2097,7 @@
     name: Opera
     version: "18.0.1284.49"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.57"
   device:
     type: desktop
     brand: ""
@@ -2115,7 +2115,7 @@
     name: Opera Neon
     version: "1.0.2459.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.21"
   device:
     type: desktop
     brand: ""
@@ -2133,7 +2133,7 @@
     name: Opera Next
     version: "20.0.1387.37"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.91"
   device:
     type: desktop
     brand: ""
@@ -2239,7 +2239,7 @@
     name: Whale Browser
     version: "0.7.33.5"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.116"
   device:
     type: desktop
     brand: ""
@@ -2365,7 +2365,7 @@
     name: Opera Next
     version: "15.0.1147.18"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.20"
   device:
     type: desktop
     brand: ""
@@ -2435,7 +2435,7 @@
     name: Yandex Browser
     version: "13.10.1500.9323"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.95"
   device:
     type: desktop
     brand: ""
@@ -2453,7 +2453,7 @@
     name: Chrome
     version: "32.0.1700.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.76"
   device:
     type: desktop
     brand: ""
@@ -2507,7 +2507,7 @@
     name: Opera
     version: "18.0.1284.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.63"
   device:
     type: desktop
     brand: ""
@@ -2525,7 +2525,7 @@
     name: Chrome
     version: "69.0.3497.128"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.128"
   device:
     type: desktop
     brand: ""
@@ -2543,7 +2543,7 @@
     name: Chrome
     version: "69.0.3497.128"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.128"
   device:
     type: desktop
     brand: ""
@@ -2561,7 +2561,7 @@
     name: Chrome
     version: "69.0.3497.128"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.128"
   device:
     type: desktop
     brand: ""
@@ -3108,7 +3108,7 @@
     name: Seznam Browser
     version: "3.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.102"
   device:
     type: desktop
     brand: ""
@@ -3731,7 +3731,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: desktop
     brand: Chuwi
@@ -3799,7 +3799,7 @@
     name: Chrome
     version: "40.0.2214.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: desktop
     brand: Acer
@@ -3975,7 +3975,7 @@
     name: Opera Next
     version: "20.0.1387.37"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.91"
   device:
     type: desktop
     brand: Apple
@@ -4047,7 +4047,7 @@
     name: Brave
     version: "0.7.9"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.73"
   device:
     type: desktop
     brand: Apple
@@ -4239,7 +4239,7 @@
     name: Chrome
     version: "31.0.1650.63"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.63"
   device:
     type: desktop
     brand: Apple
@@ -4311,7 +4311,7 @@
     name: Chrome
     version: "31.0.1650.63"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.63"
   device:
     type: desktop
     brand: Apple
@@ -6887,7 +6887,7 @@
     name: Aloha Browser
     version: "0.1.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.83"
   device:
     type: desktop
     brand: ""
@@ -7257,7 +7257,7 @@
     name: Chrome
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: desktop
     brand: BilimLand
@@ -7339,7 +7339,7 @@
     name: Chrome
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: desktop
     brand: HP
@@ -7537,7 +7537,7 @@
     name: Chrome
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: desktop
     brand: HP
@@ -7555,7 +7555,7 @@
     name: Chrome
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: desktop
     brand: Acer
@@ -8498,7 +8498,7 @@
     name: Chrome
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: desktop
     brand: Jedi

--- a/Tests/fixtures/peripheral.yml
+++ b/Tests/fixtures/peripheral.yml
@@ -10,7 +10,7 @@
     name: Chrome Webview
     version: 51.0.2704.91
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.91"
   device:
     type: peripheral
     brand: Shtrikh-M
@@ -28,7 +28,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: peripheral
     brand: Wiseasy
@@ -46,7 +46,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: peripheral
     brand: Hardkernel
@@ -64,7 +64,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: peripheral
     brand: Hardkernel
@@ -82,7 +82,7 @@
     name: Chrome
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: peripheral
     brand: Hardkernel
@@ -118,7 +118,7 @@
     name: Chrome
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: peripheral
     brand: Mantra
@@ -136,7 +136,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: peripheral
     brand: Mantra
@@ -154,7 +154,7 @@
     name: Chrome
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: peripheral
     brand: OASYS
@@ -172,7 +172,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: peripheral
     brand: XGIMI
@@ -190,7 +190,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: peripheral
     brand: Raspberry
@@ -208,7 +208,7 @@
     name: Chrome Webview
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: peripheral
     brand: Raspberry
@@ -226,7 +226,7 @@
     name: Chrome
     version: 56.0.2924.0
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.0"
   device:
     type: peripheral
     brand: Samsung
@@ -244,7 +244,7 @@
     name: Chrome
     version: 56.0.2924.0
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.0"
   device:
     type: peripheral
     brand: Samsung
@@ -293,7 +293,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: peripheral
     brand: Urovo
@@ -311,7 +311,7 @@
     name: Chrome
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: peripheral
     brand: Epson
@@ -329,7 +329,7 @@
     name: Chrome Webview
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: peripheral
     brand: Urovo
@@ -347,7 +347,7 @@
     name: Chrome Webview
     version: 74.0.3729.186
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.186"
   device:
     type: peripheral
     brand: MobiIoT
@@ -365,7 +365,7 @@
     name: Chrome Mobile
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: peripheral
     brand: Sunmi
@@ -383,7 +383,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: peripheral
     brand: Honeywell
@@ -401,7 +401,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: peripheral
     brand: Honeywell
@@ -419,7 +419,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: peripheral
     brand: iData
@@ -455,7 +455,7 @@
     name: Chrome Mobile
     version: 98.0.4758.87
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.87"
   device:
     type: peripheral
     brand: Point Mobile
@@ -473,7 +473,7 @@
     name: Chrome
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: peripheral
     brand: iWaylink

--- a/Tests/fixtures/phablet.yml
+++ b/Tests/fixtures/phablet.yml
@@ -10,7 +10,7 @@
     name: Chrome Mobile
     version: 53.0.2785.124
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: phablet
     brand: altron
@@ -28,7 +28,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: phablet
     brand: Alcatel
@@ -46,7 +46,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: phablet
     brand: Alcatel
@@ -64,7 +64,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: phablet
     brand: Alcatel
@@ -82,7 +82,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: phablet
     brand: Alcatel
@@ -100,7 +100,7 @@
     name: Chrome
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: phablet
     brand: Alcatel
@@ -118,7 +118,7 @@
     name: Chrome
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: phablet
     brand: Alcatel
@@ -376,7 +376,7 @@
     name: Chrome
     version: 33.0.1750.166
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: phablet
     brand: Asus
@@ -394,7 +394,7 @@
     name: Chrome
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Asus
@@ -412,7 +412,7 @@
     name: Chrome
     version: 32.0.1700.99
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: phablet
     brand: Asus
@@ -430,7 +430,7 @@
     name: Chrome
     version: 33.0.1750.166
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: phablet
     brand: Asus
@@ -448,7 +448,7 @@
     name: Chrome
     version: 39.0.2171.93
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: phablet
     brand: Asus
@@ -466,7 +466,7 @@
     name: Chrome Mobile
     version: 34.0.1847.114
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: phablet
     brand: Asus
@@ -484,7 +484,7 @@
     name: Chrome Webview
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: phablet
     brand: Aiwa
@@ -502,7 +502,7 @@
     name: Chrome Webview
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: phablet
     brand: Blackview
@@ -520,7 +520,7 @@
     name: Chrome Mobile
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: phablet
     brand: Coolpad
@@ -538,7 +538,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: phablet
     brand: DEXP
@@ -572,7 +572,7 @@
     name: Chrome Webview
     version: 37.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: phablet
     brand: Google
@@ -590,7 +590,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: phablet
     brand: Huawei
@@ -608,7 +608,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: phablet
     brand: Hisense
@@ -626,7 +626,7 @@
     name: Chrome Mobile
     version: 46.0.2490.76
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: phablet
     brand: HP
@@ -662,7 +662,7 @@
     name: Chrome Mobile
     version: 32.0.1700.99
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: phablet
     brand: HTC
@@ -698,7 +698,7 @@
     name: Chrome Mobile
     version: 54.0.2840.85
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: phablet
     brand: Huawei
@@ -716,7 +716,7 @@
     name: Chrome Mobile
     version: 39.0.2171.59
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.59"
   device:
     type: phablet
     brand: Huawei
@@ -734,7 +734,7 @@
     name: Chrome Mobile
     version: 39.0.2171.59
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.59"
   device:
     type: phablet
     brand: Huawei
@@ -752,7 +752,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: phablet
     brand: Infinix
@@ -770,7 +770,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: phablet
     brand: Infinix
@@ -788,7 +788,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: phablet
     brand: MLS
@@ -842,7 +842,7 @@
     name: Chrome Webview
     version: 40.0.2214.114
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.114"
   device:
     type: phablet
     brand: Meizu
@@ -860,7 +860,7 @@
     name: Chrome Webview
     version: 40.0.2214.114
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.114"
   device:
     type: phablet
     brand: Meizu
@@ -930,7 +930,7 @@
     name: Chrome Mobile
     version: 54.0.2840.68
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.68"
   device:
     type: phablet
     brand: Meizu
@@ -966,7 +966,7 @@
     name: Chrome Webview
     version: 45.0.2454.94
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.94"
   device:
     type: phablet
     brand: Meizu
@@ -984,7 +984,7 @@
     name: Chrome Webview
     version: 51.0.2704.110
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.110"
   device:
     type: phablet
     brand: Meizu
@@ -1054,7 +1054,7 @@
     name: Chrome Mobile
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: phablet
     brand: Mediacom
@@ -1072,7 +1072,7 @@
     name: Chrome Mobile
     version: 43.0.2357.92
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.92"
   device:
     type: phablet
     brand: Mediacom
@@ -1108,7 +1108,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: phablet
     brand: Mediacom
@@ -1144,7 +1144,7 @@
     name: Chrome Mobile
     version: 43.0.2357.78
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.78"
   device:
     type: phablet
     brand: Mediacom
@@ -1252,7 +1252,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: phablet
     brand: Mediacom
@@ -1270,7 +1270,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: phablet
     brand: Mediacom
@@ -1288,7 +1288,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: phablet
     brand: Mediacom
@@ -1306,7 +1306,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: phablet
     brand: Mediacom
@@ -1479,7 +1479,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: phablet
     brand: Samsung
@@ -1605,7 +1605,7 @@
     name: Chrome Mobile
     version: 30.0.1599.82
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.82"
   device:
     type: phablet
     brand: Samsung
@@ -1623,7 +1623,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -1641,7 +1641,7 @@
     name: Chrome Mobile
     version: 59.0.3071.125
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: phablet
     brand: Samsung
@@ -1659,7 +1659,7 @@
     name: Chrome Mobile
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: phablet
     brand: Samsung
@@ -1767,7 +1767,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: phablet
     brand: Samsung
@@ -1785,7 +1785,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: phablet
     brand: Samsung
@@ -1803,7 +1803,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: phablet
     brand: Samsung
@@ -1821,7 +1821,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: phablet
     brand: Samsung
@@ -1857,7 +1857,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: phablet
     brand: Samsung
@@ -1965,7 +1965,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: phablet
     brand: Samsung
@@ -1983,7 +1983,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: phablet
     brand: Samsung
@@ -2001,7 +2001,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: phablet
     brand: Samsung
@@ -2019,7 +2019,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: phablet
     brand: Samsung
@@ -2037,7 +2037,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: phablet
     brand: Samsung
@@ -2109,7 +2109,7 @@
     name: Chrome Mobile
     version: 43.0.2357.93
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: phablet
     brand: Samsung
@@ -2127,7 +2127,7 @@
     name: Chrome Mobile
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: phablet
     brand: Samsung
@@ -2145,7 +2145,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: phablet
     brand: Samsung
@@ -2163,7 +2163,7 @@
     name: Chrome Mobile
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: phablet
     brand: Samsung
@@ -2217,7 +2217,7 @@
     name: Chrome Mobile
     version: 35.0.1916.141
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: phablet
     brand: Samsung
@@ -2235,7 +2235,7 @@
     name: Chrome Mobile
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: phablet
     brand: Samsung
@@ -2253,7 +2253,7 @@
     name: Chrome Mobile
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: phablet
     brand: Samsung
@@ -2271,7 +2271,7 @@
     name: Chrome Mobile
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: phablet
     brand: Samsung
@@ -2289,7 +2289,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -2361,7 +2361,7 @@
     name: Chrome Mobile
     version: 33.0.1750.136
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: phablet
     brand: Samsung
@@ -2451,7 +2451,7 @@
     name: Chrome Mobile
     version: 29.0.1547.72
     engine: Blink
-    engine_version: ""
+    engine_version: "29.0.1547.72"
   device:
     type: phablet
     brand: Samsung
@@ -2541,7 +2541,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: phablet
     brand: Samsung
@@ -2559,7 +2559,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: phablet
     brand: Samsung
@@ -2577,7 +2577,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: phablet
     brand: Samsung
@@ -2667,7 +2667,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: phablet
     brand: Samsung
@@ -2685,7 +2685,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: phablet
     brand: Samsung
@@ -2703,7 +2703,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: phablet
     brand: Samsung
@@ -2721,7 +2721,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: phablet
     brand: Samsung
@@ -2739,7 +2739,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: phablet
     brand: Samsung
@@ -2757,7 +2757,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: phablet
     brand: Samsung
@@ -2775,7 +2775,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: phablet
     brand: Samsung
@@ -2793,7 +2793,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: phablet
     brand: Samsung
@@ -2811,7 +2811,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: phablet
     brand: Samsung
@@ -2901,7 +2901,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: phablet
     brand: Samsung
@@ -2919,7 +2919,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: phablet
     brand: Samsung
@@ -2955,7 +2955,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: phablet
     brand: Samsung
@@ -2991,7 +2991,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: phablet
     brand: Samsung
@@ -3009,7 +3009,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: phablet
     brand: Samsung
@@ -3027,7 +3027,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: phablet
     brand: Samsung
@@ -3045,7 +3045,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: phablet
     brand: Samsung
@@ -3063,7 +3063,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: phablet
     brand: Samsung
@@ -3099,7 +3099,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: phablet
     brand: Samsung
@@ -3117,7 +3117,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: phablet
     brand: Samsung
@@ -3205,7 +3205,7 @@
     name: Chrome Mobile
     version: 32.0.1700.58
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.58"
   device:
     type: phablet
     brand: Samsung
@@ -3223,7 +3223,7 @@
     name: Chrome Mobile
     version: 32.0.1700.99
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: phablet
     brand: Samsung
@@ -3241,7 +3241,7 @@
     name: Chrome Mobile
     version: 33.0.1750.136
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: phablet
     brand: Samsung
@@ -3259,7 +3259,7 @@
     name: Chrome Mobile
     version: 33.0.1750.136
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: phablet
     brand: Samsung
@@ -3277,7 +3277,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -3295,7 +3295,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -3313,7 +3313,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -3331,7 +3331,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -3349,7 +3349,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -3401,7 +3401,7 @@
     name: Chrome Mobile
     version: 33.0.1750.136
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: phablet
     brand: Samsung
@@ -3419,7 +3419,7 @@
     name: Chrome Mobile
     version: 33.0.1750.166
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: phablet
     brand: Samsung
@@ -3437,7 +3437,7 @@
     name: Chrome Mobile
     version: 33.0.1750.166
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: phablet
     brand: Samsung
@@ -3455,7 +3455,7 @@
     name: Chrome Mobile
     version: 34.0.1847.114
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: phablet
     brand: Samsung
@@ -3473,7 +3473,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -3491,7 +3491,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -3561,7 +3561,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: phablet
     brand: Samsung
@@ -3597,7 +3597,7 @@
     name: Chrome Mobile
     version: 34.0.1847.114
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: phablet
     brand: Samsung
@@ -3615,7 +3615,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -3633,7 +3633,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -3651,7 +3651,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -3703,7 +3703,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: phablet
     brand: Samsung
@@ -3721,7 +3721,7 @@
     name: Chrome Webview
     version: 34.0.1847.76
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.76"
   device:
     type: phablet
     brand: Samsung
@@ -3775,7 +3775,7 @@
     name: Opera Mobile
     version: 43.2.2254.140293
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: phablet
     brand: Samsung
@@ -3811,7 +3811,7 @@
     name: Chrome Mobile
     version: 46.0.2490.76
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: phablet
     brand: Samsung
@@ -3829,7 +3829,7 @@
     name: Chrome Mobile
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: phablet
     brand: Samsung
@@ -3847,7 +3847,7 @@
     name: Opera Mobile
     version: 43.2.2254.140293
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: phablet
     brand: Samsung
@@ -3901,7 +3901,7 @@
     name: Chrome Mobile
     version: 51.0.2704.81
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: phablet
     brand: Samsung
@@ -3919,7 +3919,7 @@
     name: Chrome Mobile
     version: 69.0.3497.91
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: phablet
     brand: Samsung
@@ -3937,7 +3937,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: phablet
     brand: Samsung
@@ -3973,7 +3973,7 @@
     name: Chrome Mobile
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: phablet
     brand: Samsung
@@ -3991,7 +3991,7 @@
     name: Chrome Webview
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: phablet
     brand: Samsung
@@ -4009,7 +4009,7 @@
     name: Chrome Webview
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: phablet
     brand: Samsung
@@ -4081,7 +4081,7 @@
     name: Chrome Mobile
     version: 52.0.2743.98
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: phablet
     brand: Samsung
@@ -4099,7 +4099,7 @@
     name: Chrome Mobile
     version: 52.0.2743.98
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: phablet
     brand: Samsung
@@ -4117,7 +4117,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: phablet
     brand: Samsung
@@ -4135,7 +4135,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: phablet
     brand: Samsung
@@ -4153,7 +4153,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: phablet
     brand: Samsung
@@ -4171,7 +4171,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: phablet
     brand: Samsung
@@ -4189,7 +4189,7 @@
     name: Yandex Browser
     version: 19.3.3.285.00
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: phablet
     brand: Samsung
@@ -4207,7 +4207,7 @@
     name: Chrome Mobile
     version: 59.0.3071.125
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: phablet
     brand: Samsung
@@ -4225,7 +4225,7 @@
     name: Chrome Mobile
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: phablet
     brand: Samsung
@@ -4243,7 +4243,7 @@
     name: Chrome Mobile
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: phablet
     brand: Samsung
@@ -4261,7 +4261,7 @@
     name: Chrome Mobile
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: phablet
     brand: Samsung
@@ -4297,7 +4297,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: phablet
     brand: Samsung
@@ -4315,7 +4315,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: phablet
     brand: Samsung
@@ -4333,7 +4333,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: phablet
     brand: Samsung
@@ -4351,7 +4351,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: phablet
     brand: Samsung
@@ -4387,7 +4387,7 @@
     name: Opera Mobile
     version: 43.1.2254.140112
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: phablet
     brand: Samsung
@@ -4405,7 +4405,7 @@
     name: Opera Mobile
     version: 43.1.2254.140112
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: phablet
     brand: Samsung
@@ -4585,7 +4585,7 @@
     name: Chrome Mobile
     version: 33.0.1750.136
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: phablet
     brand: Samsung
@@ -4619,7 +4619,7 @@
     name: Chrome Mobile
     version: 31.0.1650.59
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: phablet
     brand: Sony
@@ -4637,7 +4637,7 @@
     name: Chrome Mobile
     version: 36.0.1985.135
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: phablet
     brand: Sony
@@ -4671,7 +4671,7 @@
     name: Chrome Mobile
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: phablet
     brand: Sony
@@ -4689,7 +4689,7 @@
     name: Chrome Mobile
     version: 36.0.1985.131
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.131"
   device:
     type: phablet
     brand: Sony
@@ -4743,7 +4743,7 @@
     name: Chrome Mobile
     version: 34.0.1847.114
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: phablet
     brand: Sony
@@ -4761,7 +4761,7 @@
     name: Chrome Mobile
     version: 34.0.1847.114
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: phablet
     brand: Sony
@@ -4779,7 +4779,7 @@
     name: Chrome Mobile
     version: 34.0.1847.114
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: phablet
     brand: Sony
@@ -4797,7 +4797,7 @@
     name: Chrome Mobile
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: phablet
     brand: Sony
@@ -4833,7 +4833,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: phablet
     brand: Sony
@@ -4851,7 +4851,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: phablet
     brand: SWISSMOBILITY
@@ -4869,7 +4869,7 @@
     name: Chrome Mobile
     version: 39.0.2171.93
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: phablet
     brand: Trevi
@@ -4887,7 +4887,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: phablet
     brand: Trevi
@@ -5031,7 +5031,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: phablet
     brand: Xiaomi
@@ -5139,7 +5139,7 @@
     name: Chrome Mobile
     version: 54.0.2840.85
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: phablet
     brand: Xiaomi
@@ -5157,7 +5157,7 @@
     name: Chrome Mobile
     version: 35.0.1916.141
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: phablet
     brand: Xiaomi
@@ -5193,7 +5193,7 @@
     name: Chrome Mobile
     version: 40.0.2214.109
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: phablet
     brand: Xiaomi
@@ -5211,7 +5211,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: phablet
     brand: Xiaomi
@@ -5265,7 +5265,7 @@
     name: Chrome Mobile
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: phablet
     brand: Xiaomi
@@ -5283,7 +5283,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: phablet
     brand: Xiaomi
@@ -5319,7 +5319,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: phablet
     brand: Xiaomi
@@ -5337,7 +5337,7 @@
     name: Chrome Mobile
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: phablet
     brand: Xiaomi
@@ -5391,7 +5391,7 @@
     name: Yandex Browser
     version: "11.41"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: phablet
     brand: Xiaomi
@@ -5409,7 +5409,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: phablet
     brand: Xiaomi
@@ -5445,7 +5445,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: phablet
     brand: Samsung
@@ -5499,7 +5499,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: phablet
     brand: Samsung
@@ -5697,7 +5697,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -5715,7 +5715,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -5733,7 +5733,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -5751,7 +5751,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -5769,7 +5769,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -5787,7 +5787,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -5805,7 +5805,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -5823,7 +5823,7 @@
     name: Chrome Webview
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: phablet
     brand: Samsung
@@ -5875,7 +5875,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: phablet
     brand: Samsung
@@ -5893,7 +5893,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: phablet
     brand: Samsung
@@ -5911,7 +5911,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: phablet
     brand: Samsung
@@ -5947,7 +5947,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: phablet
     brand: Samsung
@@ -5965,7 +5965,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: phablet
     brand: Xiaomi
@@ -5983,7 +5983,7 @@
     name: Chrome Mobile
     version: 88.0.4324.152
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.152"
   device:
     type: phablet
     brand: Xiaomi
@@ -6001,7 +6001,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: phablet
     brand: Ulefone
@@ -6019,7 +6019,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: phablet
     brand: Xiaomi
@@ -6037,7 +6037,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: phablet
     brand: iTel
@@ -6055,7 +6055,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: phablet
     brand: Xiaomi
@@ -6073,7 +6073,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: phablet
     brand: Xiaomi
@@ -6109,7 +6109,7 @@
     name: Huawei Browser Mobile
     version: 11.1.0.300
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: phablet
     brand: Xiaomi
@@ -6127,7 +6127,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: phablet
     brand: Xiaomi
@@ -6145,7 +6145,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: phablet
     brand: Xiaomi
@@ -6163,7 +6163,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: phablet
     brand: Maxwest
@@ -6181,7 +6181,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: phablet
     brand: Xiaomi
@@ -6199,7 +6199,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: phablet
     brand: Xiaomi
@@ -6217,7 +6217,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: phablet
     brand: Xiaomi
@@ -6235,7 +6235,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: phablet
     brand: P-UP
@@ -6253,7 +6253,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: phablet
     brand: Ulefone
@@ -6303,7 +6303,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: phablet
     brand: HTC
@@ -6337,7 +6337,7 @@
     name: Chrome Webview
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: phablet
     brand: Xiaomi
@@ -6355,7 +6355,7 @@
     name: Chrome Mobile
     version: 72.0.3626.14
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.14"
   device:
     type: phablet
     brand: Meizu
@@ -6373,7 +6373,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: phablet
     brand: Samsung
@@ -6391,7 +6391,7 @@
     name: Yandex Browser
     version: "20.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: phablet
     brand: Xiaomi
@@ -6409,7 +6409,7 @@
     name: Yandex Browser
     version: "9.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: phablet
     brand: Samsung
@@ -6443,7 +6443,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: phablet
     brand: Hotwav
@@ -6477,7 +6477,7 @@
     name: Chrome
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: phablet
     brand: Asus
@@ -6511,7 +6511,7 @@
     name: Yandex Browser
     version: "11.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: phablet
     brand: Samsung
@@ -6529,7 +6529,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: phablet
     brand: Xiaomi
@@ -6547,7 +6547,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: phablet
     brand: Xiaomi
@@ -6565,7 +6565,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: phablet
     brand: Xiaomi
@@ -6583,7 +6583,7 @@
     name: Chrome Webview
     version: 79.0.3945.147
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.147"
   device:
     type: phablet
     brand: Xiaomi
@@ -6601,7 +6601,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: phablet
     brand: Tecno Mobile
@@ -6637,7 +6637,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: phablet
     brand: Tecno Mobile
@@ -6655,7 +6655,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: phablet
     brand: ZTE
@@ -6673,7 +6673,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: phablet
     brand: ZTE
@@ -6709,7 +6709,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: phablet
     brand: DEXP
@@ -6727,7 +6727,7 @@
     name: Chrome Webview
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: phablet
     brand: Xiaomi
@@ -6745,7 +6745,7 @@
     name: Yandex Browser
     version: 21.5.5.110.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: phablet
     brand: Meizu
@@ -6763,7 +6763,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: phablet
     brand: Infinix
@@ -6781,7 +6781,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: phablet
     brand: Infinix
@@ -6799,7 +6799,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: phablet
     brand: Infinix
@@ -6817,7 +6817,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: phablet
     brand: Infinix
@@ -6835,7 +6835,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: phablet
     brand: Infinix
@@ -6853,7 +6853,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: phablet
     brand: Infinix
@@ -6871,7 +6871,7 @@
     name: Chrome Webview
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: phablet
     brand: Xiaomi
@@ -6889,7 +6889,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: phablet
     brand: ""
@@ -6907,7 +6907,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: phablet
     brand: Samsung
@@ -6925,7 +6925,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: phablet
     brand: Samsung
@@ -6943,7 +6943,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: phablet
     brand: Samsung
@@ -6961,7 +6961,7 @@
     name: Yandex Browser
     version: 21.51.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: phablet
     brand: ZTE
@@ -6979,7 +6979,7 @@
     name: Yandex Browser
     version: 21.5.4.119.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: phablet
     brand: Xiaomi
@@ -6997,7 +6997,7 @@
     name: Yandex Browser
     version: 21.50.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: phablet
     brand: Xiaomi
@@ -7015,7 +7015,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: phablet
     brand: Xiaomi
@@ -7033,7 +7033,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: phablet
     brand: Xiaomi
@@ -7051,7 +7051,7 @@
     name: Yandex Browser
     version: 21.6.6.55.00
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: phablet
     brand: Samsung
@@ -7069,7 +7069,7 @@
     name: Yandex Browser
     version: 21.80.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: phablet
     brand: Xiaomi
@@ -7087,7 +7087,7 @@
     name: Opera Mobile
     version: 64.2.3282.60128
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: phablet
     brand: Xiaomi
@@ -7141,7 +7141,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: phablet
     brand: Infinix
@@ -7159,7 +7159,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: phablet
     brand: Xiaomi
@@ -7303,7 +7303,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: phablet
     brand: Samsung
@@ -7321,7 +7321,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: phablet
     brand: Samsung
@@ -7339,7 +7339,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: phablet
     brand: Samsung
@@ -7357,7 +7357,7 @@
     name: Chrome Webview
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: phablet
     brand: Xiaomi
@@ -7391,7 +7391,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: phablet
     brand: Samsung
@@ -7409,7 +7409,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: phablet
     brand: Huawei
@@ -7427,7 +7427,7 @@
     name: Opera Mobile
     version: 65.1.3381.61266
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: phablet
     brand: HTC
@@ -7445,7 +7445,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: phablet
     brand: Samsung
@@ -7513,7 +7513,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: phablet
     brand: Samsung
@@ -7531,7 +7531,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: phablet
     brand: Samsung
@@ -7549,7 +7549,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: phablet
     brand: Samsung
@@ -7567,7 +7567,7 @@
     name: Chrome
     version: 95.0.4638.32
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.32"
   device:
     type: phablet
     brand: Samsung
@@ -7585,7 +7585,7 @@
     name: Yandex Browser
     version: 21.9.0.187.00 alpha
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4636.4"
   device:
     type: phablet
     brand: Xiaomi
@@ -7603,7 +7603,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: phablet
     brand: Xiaomi
@@ -7621,7 +7621,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: phablet
     brand: Xiaomi
@@ -7693,7 +7693,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: phablet
     brand: Samsung
@@ -7711,7 +7711,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: phablet
     brand: Samsung
@@ -7729,7 +7729,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: phablet
     brand: Xiaomi
@@ -7747,7 +7747,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: phablet
     brand: iTel
@@ -7765,7 +7765,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: phablet
     brand: Samsung
@@ -7907,7 +7907,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: phablet
     brand: Xiaomi
@@ -7925,7 +7925,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: phablet
     brand: Xiaomi
@@ -7943,7 +7943,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: phablet
     brand: Xiaomi
@@ -7961,7 +7961,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: phablet
     brand: Xiaomi
@@ -7979,7 +7979,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: phablet
     brand: Xiaomi
@@ -7997,7 +7997,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: phablet
     brand: Xiaomi
@@ -8015,7 +8015,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: phablet
     brand: FiGi
@@ -8033,7 +8033,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: phablet
     brand: Xiaomi
@@ -8051,7 +8051,7 @@
     name: Yandex Browser
     version: 22.11.1
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.116"
   device:
     type: phablet
     brand: Infinix
@@ -8069,7 +8069,7 @@
     name: Yandex Browser
     version: 22.11.1
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.116"
   device:
     type: phablet
     brand: Infinix
@@ -8087,7 +8087,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: phablet
     brand: Infinix
@@ -8105,7 +8105,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: phablet
     brand: Infinix
@@ -8123,7 +8123,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: phablet
     brand: FiGi
@@ -8141,7 +8141,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: phablet
     brand: FiGi
@@ -8159,7 +8159,7 @@
     name: Chrome Mobile
     version: 75.0.3770.67
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: phablet
     brand: Huawei
@@ -8177,7 +8177,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: phablet
     brand: Infinix
@@ -8195,7 +8195,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: phablet
     brand: Samsung
@@ -8267,7 +8267,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: phablet
     brand: Xiaomi
@@ -8285,7 +8285,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: phablet
     brand: Xiaomi
@@ -8303,7 +8303,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: phablet
     brand: Tecno Mobile

--- a/Tests/fixtures/portable_media_player.yml
+++ b/Tests/fixtures/portable_media_player.yml
@@ -170,7 +170,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: portable media player
     brand: Xoro
@@ -188,7 +188,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: portable media player
     brand: Xoro
@@ -206,7 +206,7 @@
     name: Chrome
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: portable media player
     brand: Wizz
@@ -518,7 +518,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: portable media player
     brand: Lenco
@@ -586,7 +586,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: portable media player
     brand: FiiO
@@ -604,7 +604,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: portable media player
     brand: FiiO

--- a/Tests/fixtures/smart_display.yml
+++ b/Tests/fixtures/smart_display.yml
@@ -28,7 +28,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smart display
     brand: Acer
@@ -64,7 +64,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smart display
     brand: ViewSonic
@@ -82,7 +82,7 @@
     name: Chrome
     version: 75.0.3739.0
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3739.0"
   device:
     type: smart display
     brand: ViewSonic
@@ -100,7 +100,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smart display
     brand: ViewSonic
@@ -118,7 +118,7 @@
     name: Chrome
     version: 76.0.3809.85
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.85"
   device:
     type: smart display
     brand: ViewSonic
@@ -136,7 +136,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smart display
     brand: ViewSonic
@@ -154,7 +154,7 @@
     name: Chrome
     version: 75.0.3739.0
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3739.0"
   device:
     type: smart display
     brand: ViewSonic
@@ -172,7 +172,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smart display
     brand: ViewSonic
@@ -190,7 +190,7 @@
     name: Chrome
     version: 76.0.3809.85
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.85"
   device:
     type: smart display
     brand: ViewSonic
@@ -244,7 +244,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smart display
     brand: Sunmi

--- a/Tests/fixtures/smart_speaker.yml
+++ b/Tests/fixtures/smart_speaker.yml
@@ -41,7 +41,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smart speaker
     brand: Amazon
@@ -69,7 +69,7 @@
     name: Chrome Webview
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smart speaker
     brand: Amazon
@@ -87,7 +87,7 @@
     name: Chrome Webview
     version: 88.0.4324.152
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.152"
   device:
     type: smart speaker
     brand: Amazon

--- a/Tests/fixtures/smartphone-1.yml
+++ b/Tests/fixtures/smartphone-1.yml
@@ -10,7 +10,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Advan
@@ -28,7 +28,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Advan
@@ -46,7 +46,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Advan
@@ -64,7 +64,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Advan
@@ -82,7 +82,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Advan
@@ -100,7 +100,7 @@
     name: Chrome Webview
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: smartphone
     brand: Advan
@@ -118,7 +118,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Advan
@@ -136,7 +136,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Advan
@@ -154,7 +154,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Advan
@@ -172,7 +172,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Advan
@@ -190,7 +190,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Advan
@@ -208,7 +208,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Advan
@@ -226,7 +226,7 @@
     name: Chrome Webview
     version: "51.0.2704.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.91"
   device:
     type: smartphone
     brand: Advan
@@ -244,7 +244,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Advan
@@ -280,7 +280,7 @@
     name: Chrome Webview
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Advan
@@ -298,7 +298,7 @@
     name: Chrome Webview
     version: "51.0.2704.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.91"
   device:
     type: smartphone
     brand: AllCall
@@ -316,7 +316,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: AllCall
@@ -334,7 +334,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: AllCall
@@ -352,7 +352,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: AllCall
@@ -440,7 +440,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: AllCall
@@ -458,7 +458,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: AllCall
@@ -476,7 +476,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: AllCall
@@ -494,7 +494,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: AllCall
@@ -512,7 +512,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: AllCall
@@ -530,7 +530,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: AllCall
@@ -548,7 +548,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: AllCall
@@ -566,7 +566,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: AllCall
@@ -656,7 +656,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: Acer
@@ -674,7 +674,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Acer
@@ -692,7 +692,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Acer
@@ -762,7 +762,7 @@
     name: Opera Mobile
     version: "49.2.2361.134358"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Acer
@@ -852,7 +852,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Acer
@@ -906,7 +906,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Acer
@@ -942,7 +942,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Acer
@@ -960,7 +960,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Acer
@@ -978,7 +978,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Acer
@@ -996,7 +996,7 @@
     name: Chrome Webview
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Acer
@@ -1014,7 +1014,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Acer
@@ -1032,7 +1032,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Acer
@@ -1050,7 +1050,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Acer
@@ -1068,7 +1068,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Acer
@@ -1173,7 +1173,7 @@
     name: Chrome Webview
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Advance
@@ -1191,7 +1191,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Advance
@@ -1209,7 +1209,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Ace
@@ -1227,7 +1227,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Ace
@@ -1245,7 +1245,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: AMGOO
@@ -1263,7 +1263,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: AMGOO
@@ -1281,7 +1281,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: AMGOO
@@ -1299,7 +1299,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: AMGOO
@@ -1317,7 +1317,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: AMGOO
@@ -1335,7 +1335,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: AMGOO
@@ -1353,7 +1353,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: AMGOO
@@ -1371,7 +1371,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: AMGOO
@@ -1389,7 +1389,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: AMGOO
@@ -1407,7 +1407,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: AMGOO
@@ -1425,7 +1425,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: AMGOO
@@ -1443,7 +1443,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: AMGOO
@@ -1461,7 +1461,7 @@
     name: Chrome Webview
     version: "50.0.2661.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: AMGOO
@@ -1479,7 +1479,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: AMGOO
@@ -1497,7 +1497,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: AMGOO
@@ -1515,7 +1515,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: AMGOO
@@ -1533,7 +1533,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: AMGOO
@@ -1569,7 +1569,7 @@
     name: Opera Mobile
     version: "30.0.1856.93524"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.78"
   device:
     type: smartphone
     brand: Akai
@@ -1587,7 +1587,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Akai
@@ -1605,7 +1605,7 @@
     name: Chrome Mobile
     version: "41.0.2272.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.94"
   device:
     type: smartphone
     brand: Akai
@@ -1623,7 +1623,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Akai
@@ -1641,7 +1641,7 @@
     name: Chrome Mobile
     version: "39.0.2171.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.59"
   device:
     type: smartphone
     brand: Akai
@@ -1659,7 +1659,7 @@
     name: Chrome Mobile
     version: "44.0.2403.133"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.133"
   device:
     type: smartphone
     brand: Akai
@@ -1677,7 +1677,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Akai
@@ -1695,7 +1695,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Alcatel
@@ -1713,7 +1713,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Alcatel
@@ -1731,7 +1731,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Alcatel
@@ -1749,7 +1749,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Alcatel
@@ -1767,7 +1767,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Alcatel
@@ -1785,7 +1785,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Alcatel
@@ -1803,7 +1803,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Alcatel
@@ -1821,7 +1821,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Alcatel
@@ -1839,7 +1839,7 @@
     name: Chrome Mobile
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: smartphone
     brand: Alcatel
@@ -1857,7 +1857,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -1875,7 +1875,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -1893,7 +1893,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Alcatel
@@ -1947,7 +1947,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -1965,7 +1965,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -1983,7 +1983,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Alcatel
@@ -2001,7 +2001,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Alcatel
@@ -2019,7 +2019,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -2037,7 +2037,7 @@
     name: Chrome Webview
     version: "85.0.4183.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Alcatel
@@ -2073,7 +2073,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Alcatel
@@ -2091,7 +2091,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Alcatel
@@ -2109,7 +2109,7 @@
     name: Chrome Webview
     version: "81.0.4044.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Alcatel
@@ -2127,7 +2127,7 @@
     name: Opera Mobile
     version: "54.2.2672.49907"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Alcatel
@@ -2145,7 +2145,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Alcatel
@@ -2163,7 +2163,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Alcatel
@@ -2181,7 +2181,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Alcatel
@@ -2199,7 +2199,7 @@
     name: Chrome Webview
     version: "85.0.4183.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Alcatel
@@ -2217,7 +2217,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -2235,7 +2235,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -2253,7 +2253,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -2271,7 +2271,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -2289,7 +2289,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Alcatel
@@ -2307,7 +2307,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -2343,7 +2343,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Alcatel
@@ -2361,7 +2361,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -2379,7 +2379,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -2397,7 +2397,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -2415,7 +2415,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -2433,7 +2433,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Alcatel
@@ -2451,7 +2451,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -2469,7 +2469,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Alcatel
@@ -2487,7 +2487,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Alcatel
@@ -2505,7 +2505,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -2541,7 +2541,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Alcatel
@@ -2559,7 +2559,7 @@
     name: Chrome Webview
     version: "84.0.4147.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -2595,7 +2595,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Alcatel
@@ -2613,7 +2613,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -2631,7 +2631,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -2667,7 +2667,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Alcatel
@@ -2685,7 +2685,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Alcatel
@@ -2703,7 +2703,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Alcatel
@@ -2721,7 +2721,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Alcatel
@@ -2739,7 +2739,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -2757,7 +2757,7 @@
     name: Opera Mobile
     version: "44.1.2254.143214"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Alcatel
@@ -2775,7 +2775,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Alcatel
@@ -2793,7 +2793,7 @@
     name: Chrome Mobile
     version: "68.0.3440.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.85"
   device:
     type: smartphone
     brand: Alcatel
@@ -2811,7 +2811,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -2829,7 +2829,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Alcatel
@@ -2847,7 +2847,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -2865,7 +2865,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Alcatel
@@ -2883,7 +2883,7 @@
     name: Chrome Webview
     version: "81.0.4044.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Alcatel
@@ -2901,7 +2901,7 @@
     name: Chrome Webview
     version: "85.0.4183.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Alcatel
@@ -2919,7 +2919,7 @@
     name: Opera Mobile
     version: "46.0.2254.145391"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Alcatel
@@ -2937,7 +2937,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -2955,7 +2955,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -2973,7 +2973,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -2991,7 +2991,7 @@
     name: Chrome Mobile
     version: "69.0.3497.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.86"
   device:
     type: smartphone
     brand: Alcatel
@@ -3009,7 +3009,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Alcatel
@@ -3027,7 +3027,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Alcatel
@@ -3045,7 +3045,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -3063,7 +3063,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -3081,7 +3081,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -3099,7 +3099,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -3117,7 +3117,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -3135,7 +3135,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -3153,7 +3153,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -3171,7 +3171,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -3189,7 +3189,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -3207,7 +3207,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -3225,7 +3225,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -3243,7 +3243,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -3261,7 +3261,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -3279,7 +3279,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -3297,7 +3297,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -3315,7 +3315,7 @@
     name: Chrome Mobile
     version: "68.0.3440.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.85"
   device:
     type: smartphone
     brand: Alcatel
@@ -3333,7 +3333,7 @@
     name: Chrome Mobile
     version: "68.0.3440.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.85"
   device:
     type: smartphone
     brand: Alcatel
@@ -3351,7 +3351,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -3369,7 +3369,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -3387,7 +3387,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -3405,7 +3405,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Alcatel
@@ -3423,7 +3423,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -3441,7 +3441,7 @@
     name: Chrome Mobile
     version: "69.0.3497.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -3459,7 +3459,7 @@
     name: Chrome Mobile
     version: "64.0.3282.123"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: smartphone
     brand: Alcatel
@@ -3477,7 +3477,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -3495,7 +3495,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -3513,7 +3513,7 @@
     name: Chrome Mobile
     version: "64.0.3282.123"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: smartphone
     brand: Alcatel
@@ -3531,7 +3531,7 @@
     name: Chrome Mobile
     version: "64.0.3282.123"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: smartphone
     brand: Alcatel
@@ -3549,7 +3549,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -3567,7 +3567,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -3585,7 +3585,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -3603,7 +3603,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -3621,7 +3621,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -3639,7 +3639,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -3657,7 +3657,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -3675,7 +3675,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -3693,7 +3693,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -3711,7 +3711,7 @@
     name: Chrome Webview
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Alcatel
@@ -3819,7 +3819,7 @@
     name: Opera Mobile
     version: "21.0.1437.74904"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.116"
   device:
     type: smartphone
     brand: Alcatel
@@ -3837,7 +3837,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Alcatel
@@ -3855,7 +3855,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Alcatel
@@ -3891,7 +3891,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Alcatel
@@ -4161,7 +4161,7 @@
     name: Chrome Mobile
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -4179,7 +4179,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Alcatel
@@ -4197,7 +4197,7 @@
     name: Chrome Mobile
     version: "42.0.2311.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -4215,7 +4215,7 @@
     name: Chrome Mobile
     version: "44.0.2403.133"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.133"
   device:
     type: smartphone
     brand: Alcatel
@@ -4233,7 +4233,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -4251,7 +4251,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -4269,7 +4269,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Alcatel
@@ -4287,7 +4287,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Alcatel
@@ -4305,7 +4305,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Alcatel
@@ -4323,7 +4323,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Alcatel
@@ -4341,7 +4341,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -4359,7 +4359,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -4377,7 +4377,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -4395,7 +4395,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -4413,7 +4413,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -4431,7 +4431,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -4449,7 +4449,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -4467,7 +4467,7 @@
     name: Chrome Mobile
     version: "44.0.2403.133"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.133"
   device:
     type: smartphone
     brand: Alcatel
@@ -4485,7 +4485,7 @@
     name: Chrome Mobile
     version: "44.0.2403.133"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.133"
   device:
     type: smartphone
     brand: Alcatel
@@ -4503,7 +4503,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: Alcatel
@@ -4521,7 +4521,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: Alcatel
@@ -4539,7 +4539,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Alcatel
@@ -4557,7 +4557,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Alcatel
@@ -4575,7 +4575,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Alcatel
@@ -4593,7 +4593,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -4611,7 +4611,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -4645,7 +4645,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -4663,7 +4663,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -4681,7 +4681,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -4699,7 +4699,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -4717,7 +4717,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -4735,7 +4735,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -4771,7 +4771,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -4789,7 +4789,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -4807,7 +4807,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -4825,7 +4825,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -4843,7 +4843,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -4861,7 +4861,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -4879,7 +4879,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -4897,7 +4897,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -4915,7 +4915,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Alcatel
@@ -4933,7 +4933,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -4951,7 +4951,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -4969,7 +4969,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -4987,7 +4987,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Alcatel
@@ -5005,7 +5005,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -5023,7 +5023,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Alcatel
@@ -5041,7 +5041,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -5059,7 +5059,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -5077,7 +5077,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -5095,7 +5095,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Alcatel
@@ -5113,7 +5113,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -5131,7 +5131,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -5149,7 +5149,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -5167,7 +5167,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -5185,7 +5185,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -5203,7 +5203,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -5221,7 +5221,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -5239,7 +5239,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -5257,7 +5257,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -5275,7 +5275,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -5293,7 +5293,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -5311,7 +5311,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -5329,7 +5329,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Alcatel
@@ -5347,7 +5347,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Alcatel
@@ -5365,7 +5365,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -5383,7 +5383,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -5401,7 +5401,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -5419,7 +5419,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -5437,7 +5437,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Alcatel
@@ -5455,7 +5455,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Alcatel
@@ -5473,7 +5473,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -5491,7 +5491,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -5509,7 +5509,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -5527,7 +5527,7 @@
     name: Chrome Mobile
     version: "40.0.2214.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -5545,7 +5545,7 @@
     name: Chrome Mobile
     version: "40.0.2214.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -5563,7 +5563,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Alcatel
@@ -5581,7 +5581,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Alcatel
@@ -5599,7 +5599,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Alcatel
@@ -5617,7 +5617,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -5635,7 +5635,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -5653,7 +5653,7 @@
     name: Chrome Mobile
     version: "49.0.2623.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -5671,7 +5671,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -5689,7 +5689,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -5707,7 +5707,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -5725,7 +5725,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -5743,7 +5743,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -5761,7 +5761,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -5779,7 +5779,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -5797,7 +5797,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -5815,7 +5815,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -5833,7 +5833,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -5851,7 +5851,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -5869,7 +5869,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -5887,7 +5887,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -5905,7 +5905,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -5923,7 +5923,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -5941,7 +5941,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Alcatel
@@ -5959,7 +5959,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -5977,7 +5977,7 @@
     name: Chrome Webview
     version: "42.0.2311.154"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.154"
   device:
     type: smartphone
     brand: Alcatel
@@ -5995,7 +5995,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Alcatel
@@ -6013,7 +6013,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Alcatel
@@ -6031,7 +6031,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Alcatel
@@ -6049,7 +6049,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Alcatel
@@ -6067,7 +6067,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Alcatel
@@ -6085,7 +6085,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -6103,7 +6103,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -6121,7 +6121,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -6139,7 +6139,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -6157,7 +6157,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -6175,7 +6175,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -6193,7 +6193,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -6211,7 +6211,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -6229,7 +6229,7 @@
     name: Chrome Mobile
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -6247,7 +6247,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -6265,7 +6265,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -6283,7 +6283,7 @@
     name: Chrome Mobile
     version: "69.0.3497.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.86"
   device:
     type: smartphone
     brand: Alcatel
@@ -6301,7 +6301,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Alcatel
@@ -6337,7 +6337,7 @@
     name: Chrome Mobile
     version: "69.0.3497.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.86"
   device:
     type: smartphone
     brand: Alcatel
@@ -6355,7 +6355,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -6373,7 +6373,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -6391,7 +6391,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Alcatel
@@ -6409,7 +6409,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -6427,7 +6427,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -6445,7 +6445,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -6463,7 +6463,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -6481,7 +6481,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Alcatel
@@ -6499,7 +6499,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -6517,7 +6517,7 @@
     name: Chrome Webview
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Alcatel
@@ -6535,7 +6535,7 @@
     name: Chrome Webview
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Alcatel
@@ -6553,7 +6553,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -6571,7 +6571,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -6589,7 +6589,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -6607,7 +6607,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -6625,7 +6625,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -6643,7 +6643,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -6661,7 +6661,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -6679,7 +6679,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -6697,7 +6697,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -6715,7 +6715,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -6733,7 +6733,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -6751,7 +6751,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Alcatel
@@ -6769,7 +6769,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -6787,7 +6787,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -6805,7 +6805,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -6823,7 +6823,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -6841,7 +6841,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -6859,7 +6859,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -6877,7 +6877,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -6895,7 +6895,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Alcatel
@@ -6913,7 +6913,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Alcatel
@@ -6931,7 +6931,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Alcatel
@@ -6949,7 +6949,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -6967,7 +6967,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Alcatel
@@ -6985,7 +6985,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Alcatel
@@ -7003,7 +7003,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -7021,7 +7021,7 @@
     name: Chrome Webview
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -7039,7 +7039,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -7057,7 +7057,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Alcatel
@@ -7075,7 +7075,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Alcatel
@@ -7093,7 +7093,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Alcatel
@@ -7111,7 +7111,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Alcatel
@@ -7147,7 +7147,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Alcatel
@@ -7165,7 +7165,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -7183,7 +7183,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -7201,7 +7201,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Alcatel
@@ -7219,7 +7219,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -7237,7 +7237,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -7255,7 +7255,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -7273,7 +7273,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -7291,7 +7291,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -7309,7 +7309,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Alcatel
@@ -7327,7 +7327,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -7345,7 +7345,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -7363,7 +7363,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -7381,7 +7381,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Alcatel
@@ -7399,7 +7399,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -7417,7 +7417,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -7435,7 +7435,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -7453,7 +7453,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -7471,7 +7471,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -7489,7 +7489,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -7507,7 +7507,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -7525,7 +7525,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Alcatel
@@ -7543,7 +7543,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Alcatel
@@ -7561,7 +7561,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Alcatel
@@ -7579,7 +7579,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -7597,7 +7597,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Alcatel
@@ -7615,7 +7615,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Alcatel
@@ -7633,7 +7633,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Alcatel
@@ -7651,7 +7651,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Alcatel
@@ -7669,7 +7669,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Alcatel
@@ -7687,7 +7687,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Alcatel
@@ -7723,7 +7723,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Alcatel
@@ -7741,7 +7741,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -7759,7 +7759,7 @@
     name: Chrome Mobile
     version: "37.0.2062.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.117"
   device:
     type: smartphone
     brand: Alcatel
@@ -7777,7 +7777,7 @@
     name: Chrome Mobile
     version: "54.0.2840.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.68"
   device:
     type: smartphone
     brand: Alcatel
@@ -7795,7 +7795,7 @@
     name: Chrome Mobile
     version: "44.0.2403.133"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.133"
   device:
     type: smartphone
     brand: Alcatel
@@ -7813,7 +7813,7 @@
     name: Chrome Mobile
     version: "44.0.2403.133"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.133"
   device:
     type: smartphone
     brand: Alcatel
@@ -7831,7 +7831,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Alcatel
@@ -7849,7 +7849,7 @@
     name: Chrome Mobile
     version: "37.0.2062.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.117"
   device:
     type: smartphone
     brand: Alcatel
@@ -7867,7 +7867,7 @@
     name: Chrome Mobile
     version: "44.0.2403.133"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.133"
   device:
     type: smartphone
     brand: Alcatel
@@ -7885,7 +7885,7 @@
     name: Chrome Mobile
     version: "44.0.2403.133"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.133"
   device:
     type: smartphone
     brand: Alcatel
@@ -7903,7 +7903,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Alcatel
@@ -7921,7 +7921,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Alcatel
@@ -7939,7 +7939,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Alcatel
@@ -7957,7 +7957,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Alcatel
@@ -7975,7 +7975,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Alcatel
@@ -7993,7 +7993,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Alcatel
@@ -8011,7 +8011,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -8029,7 +8029,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -8047,7 +8047,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Alcatel
@@ -8065,7 +8065,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Alcatel
@@ -8083,7 +8083,7 @@
     name: Chrome Mobile
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: smartphone
     brand: Alcatel
@@ -8101,7 +8101,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Alcatel
@@ -8119,7 +8119,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -8137,7 +8137,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -8155,7 +8155,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -8173,7 +8173,7 @@
     name: Chrome Mobile
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: smartphone
     brand: Alcatel
@@ -8191,7 +8191,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -8209,7 +8209,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -8227,7 +8227,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -8245,7 +8245,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Alcatel
@@ -8263,7 +8263,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -8281,7 +8281,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Alcatel
@@ -8299,7 +8299,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Alcatel
@@ -8317,7 +8317,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Alcatel
@@ -8335,7 +8335,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Alcatel
@@ -8407,7 +8407,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -8425,7 +8425,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -8443,7 +8443,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -8461,7 +8461,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Alcatel
@@ -8479,7 +8479,7 @@
     name: Chrome Mobile
     version: "62.0.3202.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.73"
   device:
     type: smartphone
     brand: Alcatel
@@ -8497,7 +8497,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -8515,7 +8515,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -8533,7 +8533,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -8551,7 +8551,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Alcatel
@@ -8569,7 +8569,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Alcatel
@@ -8587,7 +8587,7 @@
     name: Chrome Mobile
     version: "48.0.2564.95"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.95"
   device:
     type: smartphone
     brand: Alcatel
@@ -8605,7 +8605,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -8623,7 +8623,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -8641,7 +8641,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Alcatel
@@ -8659,7 +8659,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Alcatel
@@ -8677,7 +8677,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Alcatel
@@ -8695,7 +8695,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -8713,7 +8713,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -8731,7 +8731,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -8749,7 +8749,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -8767,7 +8767,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -8785,7 +8785,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -8803,7 +8803,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -8821,7 +8821,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Alcatel
@@ -8839,7 +8839,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -8857,7 +8857,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -8875,7 +8875,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -8893,7 +8893,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -8911,7 +8911,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -8929,7 +8929,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -8947,7 +8947,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -8965,7 +8965,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Alcatel
@@ -8983,7 +8983,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -9001,7 +9001,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9019,7 +9019,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9037,7 +9037,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9055,7 +9055,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9073,7 +9073,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9091,7 +9091,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9109,7 +9109,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9127,7 +9127,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9145,7 +9145,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9163,7 +9163,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9181,7 +9181,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9199,7 +9199,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9217,7 +9217,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9235,7 +9235,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9253,7 +9253,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9271,7 +9271,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9613,7 +9613,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: EKT

--- a/Tests/fixtures/smartphone-10.yml
+++ b/Tests/fixtures/smartphone-10.yml
@@ -10,7 +10,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: MyPhone
@@ -28,7 +28,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: MyPhone
@@ -46,7 +46,7 @@
     name: Chrome Webview
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: MyPhone
@@ -64,7 +64,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: MyPhone
@@ -82,7 +82,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: MyPhone
@@ -100,7 +100,7 @@
     name: Chrome Mobile
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Nuvo
@@ -224,7 +224,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Nextbit
@@ -242,7 +242,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Nextbit
@@ -260,7 +260,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Navon
@@ -278,7 +278,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Navon
@@ -296,7 +296,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Navon
@@ -314,7 +314,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Navon
@@ -332,7 +332,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Navon
@@ -350,7 +350,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Navon
@@ -368,7 +368,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Navon
@@ -386,7 +386,7 @@
     name: Chrome Webview
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Navon
@@ -404,7 +404,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Navon
@@ -422,7 +422,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: MTN
@@ -440,7 +440,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: MTN
@@ -476,7 +476,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: NOA
@@ -494,7 +494,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: NOA
@@ -512,7 +512,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: NOA
@@ -530,7 +530,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: NOA
@@ -548,7 +548,7 @@
     name: Chrome Mobile
     version: "68.0.3440.70"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.70"
   device:
     type: smartphone
     brand: NOA
@@ -566,7 +566,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: NOA
@@ -584,7 +584,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: NOA
@@ -602,7 +602,7 @@
     name: Chrome Mobile
     version: "40.0.2214.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: smartphone
     brand: NOA
@@ -620,7 +620,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: NOA
@@ -674,7 +674,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: NOA
@@ -692,7 +692,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: NOA
@@ -710,7 +710,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: NOA
@@ -728,7 +728,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: NOA
@@ -746,7 +746,7 @@
     name: Chrome Webview
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: NOA
@@ -764,7 +764,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: NOA
@@ -782,7 +782,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: NOA
@@ -800,7 +800,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: NOA
@@ -818,7 +818,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: NOA
@@ -854,7 +854,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: NOA
@@ -872,7 +872,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: NOA
@@ -890,7 +890,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: NOA
@@ -908,7 +908,7 @@
     name: Chrome Webview
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: NOA
@@ -926,7 +926,7 @@
     name: Chrome Webview
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Nobby
@@ -944,7 +944,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Nobby
@@ -962,7 +962,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Nobby
@@ -980,7 +980,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Nobby
@@ -998,7 +998,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Newland
@@ -1016,7 +1016,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Noblex
@@ -1034,7 +1034,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Noblex
@@ -1052,7 +1052,7 @@
     name: Chrome
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Noblex
@@ -1070,7 +1070,7 @@
     name: Chrome
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Noblex
@@ -1088,7 +1088,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Neffos
@@ -1106,7 +1106,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Neffos
@@ -1124,7 +1124,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Neffos
@@ -1142,7 +1142,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Neffos
@@ -1160,7 +1160,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Neffos
@@ -1178,7 +1178,7 @@
     name: Chrome Webview
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Neffos
@@ -1196,7 +1196,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Neffos
@@ -1214,7 +1214,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Neffos
@@ -1232,7 +1232,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Neffos
@@ -1268,7 +1268,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Neffos
@@ -1286,7 +1286,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Neffos
@@ -1304,7 +1304,7 @@
     name: Yandex Browser
     version: "18.11.1.979.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: smartphone
     brand: Neffos
@@ -1322,7 +1322,7 @@
     name: Chrome Mobile
     version: "75.0.3770.67"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: smartphone
     brand: Neffos
@@ -1410,7 +1410,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: NGM
@@ -1446,7 +1446,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: NGM
@@ -1482,7 +1482,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: NGM
@@ -1518,7 +1518,7 @@
     name: Chrome Mobile
     version: "41.0.2272.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.96"
   device:
     type: smartphone
     brand: NGM
@@ -1552,7 +1552,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: NGM
@@ -1606,7 +1606,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: NGM
@@ -1624,7 +1624,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: NGM
@@ -1691,7 +1691,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Nokia
@@ -1709,7 +1709,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Nokia
@@ -1727,7 +1727,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Nokia
@@ -1745,7 +1745,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Nokia
@@ -1817,7 +1817,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Nokia
@@ -1835,7 +1835,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Nokia
@@ -1889,7 +1889,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Nokia
@@ -1907,7 +1907,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Nokia
@@ -1925,7 +1925,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Nokia
@@ -1943,7 +1943,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Nokia
@@ -1979,7 +1979,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Nokia
@@ -1997,7 +1997,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Nokia
@@ -2033,7 +2033,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Nokia
@@ -2051,7 +2051,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Nokia
@@ -2069,7 +2069,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Nokia
@@ -2087,7 +2087,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Nokia
@@ -2105,7 +2105,7 @@
     name: Chrome Mobile
     version: "73.0.3683.75"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.75"
   device:
     type: smartphone
     brand: Nokia
@@ -2123,7 +2123,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Nokia
@@ -2141,7 +2141,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Nokia
@@ -2159,7 +2159,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Nokia
@@ -2177,7 +2177,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Nokia
@@ -2267,7 +2267,7 @@
     name: Chrome Mobile
     version: "71.0.3578.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: smartphone
     brand: Nokia
@@ -2285,7 +2285,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Nokia
@@ -2375,7 +2375,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Nokia
@@ -2393,7 +2393,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Nokia
@@ -2429,7 +2429,7 @@
     name: Chrome Mobile
     version: "66.0.3359.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.106"
   device:
     type: smartphone
     brand: Nokia
@@ -2447,7 +2447,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Nokia
@@ -3581,7 +3581,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: NUU Mobile
@@ -3599,7 +3599,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: NUU Mobile
@@ -3617,7 +3617,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: NUU Mobile
@@ -3635,7 +3635,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: NUU Mobile
@@ -3653,7 +3653,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: NUU Mobile
@@ -3671,7 +3671,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: NUU Mobile
@@ -3689,7 +3689,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: NUU Mobile
@@ -3707,7 +3707,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: NUU Mobile
@@ -3725,7 +3725,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: NUU Mobile
@@ -3743,7 +3743,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Nomi
@@ -3795,7 +3795,7 @@
     name: Chrome Mobile
     version: "70.0.3538.32"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.32"
   device:
     type: smartphone
     brand: Nomi
@@ -3849,7 +3849,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Nomi
@@ -3993,7 +3993,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Nous
@@ -4011,7 +4011,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Nous
@@ -4029,7 +4029,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Nous
@@ -4065,7 +4065,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Nous
@@ -4083,7 +4083,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Nous
@@ -4101,7 +4101,7 @@
     name: Opera Mobile
     version: "55.0.2719.50560"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Nous
@@ -4137,7 +4137,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: NeuImage
@@ -4155,7 +4155,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: NeuImage
@@ -4173,7 +4173,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: NeuImage
@@ -4248,7 +4248,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4266,7 +4266,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4284,7 +4284,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4302,7 +4302,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4320,7 +4320,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4338,7 +4338,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4356,7 +4356,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4374,7 +4374,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4392,7 +4392,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4410,7 +4410,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4428,7 +4428,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4446,7 +4446,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4464,7 +4464,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4482,7 +4482,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4500,7 +4500,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4518,7 +4518,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4536,7 +4536,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4572,7 +4572,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4590,7 +4590,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -4608,7 +4608,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Odys
@@ -4644,7 +4644,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Owwo
@@ -4680,7 +4680,7 @@
     name: Chrome Webview
     version: "48.0.2564.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.116"
   device:
     type: smartphone
     brand: Owwo
@@ -4752,7 +4752,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: O+
@@ -4770,7 +4770,7 @@
     name: Chrome Mobile
     version: "68.0.3440.70"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.70"
   device:
     type: smartphone
     brand: O+
@@ -4788,7 +4788,7 @@
     name: Chrome Webview
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: O+
@@ -4806,7 +4806,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: O+
@@ -4824,7 +4824,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: O+
@@ -4842,7 +4842,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: O+
@@ -4860,7 +4860,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Orbic
@@ -4878,7 +4878,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Orbic
@@ -4950,7 +4950,7 @@
     name: Yandex Browser
     version: "16.11.0.649.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.90"
   device:
     type: smartphone
     brand: Obi
@@ -4986,7 +4986,7 @@
     name: Chrome Webview
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Obi
@@ -5076,7 +5076,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Obi
@@ -5112,7 +5112,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Obi
@@ -5130,7 +5130,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Obi
@@ -5148,7 +5148,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Obi
@@ -5184,7 +5184,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Oukitel
@@ -5202,7 +5202,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Oukitel
@@ -5238,7 +5238,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Oukitel
@@ -5256,7 +5256,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Oukitel
@@ -5274,7 +5274,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Oukitel
@@ -5292,7 +5292,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Oukitel
@@ -5328,7 +5328,7 @@
     name: Opera Mobile
     version: "54.0.2672.49578"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Oukitel
@@ -5346,7 +5346,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Oukitel
@@ -5382,7 +5382,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Oukitel
@@ -5436,7 +5436,7 @@
     name: Yandex Browser
     version: "18.9.1.2199.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.106"
   device:
     type: smartphone
     brand: Oukitel
@@ -5454,7 +5454,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Oukitel
@@ -5472,7 +5472,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Sonim
@@ -5490,7 +5490,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Sonim
@@ -5664,7 +5664,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: OnePlus
@@ -5682,7 +5682,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: OnePlus
@@ -5700,7 +5700,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: OnePlus
@@ -5718,7 +5718,7 @@
     name: Chrome Mobile
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: OnePlus
@@ -5736,7 +5736,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: OnePlus
@@ -5880,7 +5880,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: OnePlus
@@ -5898,7 +5898,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: OnePlus
@@ -5916,7 +5916,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: OnePlus
@@ -5934,7 +5934,7 @@
     name: Chrome Mobile
     version: "72.0.3626.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: OnePlus
@@ -5952,7 +5952,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: OnePlus
@@ -5970,7 +5970,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: OnePlus
@@ -5988,7 +5988,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: OnePlus
@@ -6006,7 +6006,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: OnePlus
@@ -6024,7 +6024,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: OnePlus
@@ -6042,7 +6042,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: OnePlus
@@ -6060,7 +6060,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: OnePlus
@@ -6078,7 +6078,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: OnePlus
@@ -6112,7 +6112,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: OnePlus
@@ -6130,7 +6130,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: OnePlus
@@ -6148,7 +6148,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: OnePlus
@@ -6166,7 +6166,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: OnePlus
@@ -6184,7 +6184,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: OnePlus
@@ -6202,7 +6202,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: OnePlus
@@ -6220,7 +6220,7 @@
     name: Chrome Mobile
     version: "85.0.4183.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: OnePlus
@@ -6238,7 +6238,7 @@
     name: Chrome Webview
     version: "84.0.4147.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: OnePlus
@@ -6274,7 +6274,7 @@
     name: Chrome Webview
     version: "84.0.4147.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: OnePlus
@@ -6364,7 +6364,7 @@
     name: Chrome Webview
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: OnePlus
@@ -6382,7 +6382,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: OnePlus
@@ -6400,7 +6400,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: OnePlus
@@ -6418,7 +6418,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: OnePlus
@@ -6436,7 +6436,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: OnePlus
@@ -6454,7 +6454,7 @@
     name: Chrome Mobile
     version: "71.0.3578.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: smartphone
     brand: OnePlus
@@ -6630,7 +6630,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Opsson
@@ -6666,7 +6666,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: OPPO
@@ -6684,7 +6684,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: OPPO
@@ -6702,7 +6702,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: OPPO
@@ -6720,7 +6720,7 @@
     name: Yandex Browser
     version: "20.7.2.70.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
   device:
     type: smartphone
     brand: OPPO
@@ -6738,7 +6738,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: OPPO
@@ -6756,7 +6756,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: OPPO
@@ -6774,7 +6774,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -6810,7 +6810,7 @@
     name: Yandex Browser
     version: "20.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
   device:
     type: smartphone
     brand: OPPO
@@ -6828,7 +6828,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: OPPO
@@ -6846,7 +6846,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: OPPO
@@ -6864,7 +6864,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: OPPO
@@ -6900,7 +6900,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: OPPO
@@ -6918,7 +6918,7 @@
     name: Chrome Mobile
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: OPPO
@@ -6952,7 +6952,7 @@
     name: Opera Mobile
     version: "37.0.2192.11"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.94"
   device:
     type: smartphone
     brand: OPPO
@@ -6986,7 +6986,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -7004,7 +7004,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -7022,7 +7022,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -7040,7 +7040,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -7058,7 +7058,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: OPPO
@@ -7110,7 +7110,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -7128,7 +7128,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: OPPO
@@ -7146,7 +7146,7 @@
     name: Chrome Webview
     version: "83.0.4103.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: OPPO
@@ -7200,7 +7200,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: OPPO
@@ -7218,7 +7218,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: OPPO
@@ -7236,7 +7236,7 @@
     name: Yandex Browser
     version: "19.6.4.366.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.169"
   device:
     type: smartphone
     brand: OPPO
@@ -7254,7 +7254,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: OPPO
@@ -7272,7 +7272,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: OPPO
@@ -7290,7 +7290,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: OPPO
@@ -7308,7 +7308,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: OPPO
@@ -7344,7 +7344,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: OPPO
@@ -7362,7 +7362,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -7380,7 +7380,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -7416,7 +7416,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: OPPO
@@ -7452,7 +7452,7 @@
     name: Chrome Webview
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: OPPO
@@ -7488,7 +7488,7 @@
     name: Yandex Browser
     version: "20.7.0.101.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
   device:
     type: smartphone
     brand: OPPO
@@ -7506,7 +7506,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: OPPO
@@ -7524,7 +7524,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: OPPO
@@ -7542,7 +7542,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: OPPO
@@ -7560,7 +7560,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: OPPO
@@ -7578,7 +7578,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: OPPO
@@ -7596,7 +7596,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: OPPO
@@ -7632,7 +7632,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -7650,7 +7650,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: OPPO
@@ -7668,7 +7668,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: OPPO
@@ -7686,7 +7686,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: OPPO
@@ -7704,7 +7704,7 @@
     name: Chrome Mobile
     version: "84.0.4147.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: OPPO
@@ -7740,7 +7740,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: OPPO
@@ -7758,7 +7758,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: OPPO
@@ -7776,7 +7776,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: OPPO
@@ -7794,7 +7794,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: OPPO
@@ -7812,7 +7812,7 @@
     name: Chrome Webview
     version: "74.0.3729.186"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.186"
   device:
     type: smartphone
     brand: OPPO
@@ -7830,7 +7830,7 @@
     name: Chrome Webview
     version: "74.0.3729.186"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.186"
   device:
     type: smartphone
     brand: OPPO
@@ -7866,7 +7866,7 @@
     name: Chrome Webview
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: OPPO
@@ -7884,7 +7884,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -7902,7 +7902,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: OPPO
@@ -7920,7 +7920,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -7938,7 +7938,7 @@
     name: Opera Mobile
     version: "37.0.2192.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.94"
   device:
     type: smartphone
     brand: OPPO
@@ -7956,7 +7956,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: OPPO
@@ -7974,7 +7974,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: OPPO
@@ -7992,7 +7992,7 @@
     name: Chrome Mobile
     version: "84.0.4147.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: OPPO
@@ -8010,7 +8010,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: OPPO
@@ -8028,7 +8028,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: OPPO
@@ -8064,7 +8064,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: OPPO
@@ -8082,7 +8082,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: OPPO
@@ -8100,7 +8100,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: OPPO
@@ -8118,7 +8118,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: OPPO
@@ -8136,7 +8136,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: OPPO
@@ -8154,7 +8154,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -8190,7 +8190,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -8208,7 +8208,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: OPPO
@@ -8226,7 +8226,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -8244,7 +8244,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: OPPO
@@ -8280,7 +8280,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: OPPO
@@ -8298,7 +8298,7 @@
     name: Chrome Mobile
     version: "38.0.2125.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.114"
   device:
     type: smartphone
     brand: OPPO
@@ -8316,7 +8316,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: OPPO
@@ -8334,7 +8334,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: OPPO
@@ -8384,7 +8384,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: OPPO
@@ -8490,7 +8490,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: OPPO
@@ -8596,7 +8596,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -8614,7 +8614,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -8632,7 +8632,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: OPPO
@@ -8650,7 +8650,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: OPPO
@@ -8668,7 +8668,7 @@
     name: Chrome Mobile
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: OPPO
@@ -8686,7 +8686,7 @@
     name: Chrome Webview
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: OPPO
@@ -8704,7 +8704,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: OPPO
@@ -8740,7 +8740,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: OPPO
@@ -8758,7 +8758,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: OPPO
@@ -8776,7 +8776,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: OPPO
@@ -8794,7 +8794,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -8830,7 +8830,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: OPPO
@@ -8848,7 +8848,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: OPPO
@@ -8866,7 +8866,7 @@
     name: Chrome Webview
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: OPPO
@@ -8918,7 +8918,7 @@
     name: Chrome Mobile
     version: "33.0.1750.170"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.170"
   device:
     type: smartphone
     brand: OPPO
@@ -8954,7 +8954,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: OPPO
@@ -8972,7 +8972,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: OPPO
@@ -8990,7 +8990,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Elephone
@@ -9008,7 +9008,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Elephone
@@ -9026,7 +9026,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: CUBOT
@@ -9044,7 +9044,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Leagoo
@@ -9062,7 +9062,7 @@
     name: Yandex Browser
     version: 21.9.0.359.00
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Leagoo
@@ -9080,7 +9080,7 @@
     name: Chrome Mobile
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: ZTE
@@ -9098,7 +9098,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Sony
@@ -9116,7 +9116,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Sharp
@@ -9134,7 +9134,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Unihertz
@@ -9152,7 +9152,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Sony
@@ -9170,7 +9170,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Sony
@@ -9188,7 +9188,7 @@
     name: Opera Mobile
     version: 61.0.2254.59937
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Huawei
@@ -9206,7 +9206,7 @@
     name: Yandex Browser
     version: 21.112.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Realme
@@ -9224,7 +9224,7 @@
     name: Yandex Browser
     version: 21.32.1
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.128"
   device:
     type: smartphone
     brand: OPPO
@@ -9242,7 +9242,7 @@
     name: Yandex Browser
     version: 21.112.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Oukitel
@@ -9260,7 +9260,7 @@
     name: Yandex Browser
     version: 21.110.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Inoi
@@ -9278,7 +9278,7 @@
     name: Yandex Browser
     version: 21.110.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Xiaomi
@@ -9296,7 +9296,7 @@
     name: Chrome Webview
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9314,7 +9314,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9332,7 +9332,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9350,7 +9350,7 @@
     name: Chrome Webview
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Realme
@@ -9368,7 +9368,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Realme
@@ -9386,7 +9386,7 @@
     name: Chrome Webview
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Realme
@@ -9404,7 +9404,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Realme
@@ -9422,7 +9422,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: CUBOT
@@ -9440,7 +9440,7 @@
     name: Chrome Webview
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: OPPO
@@ -9458,7 +9458,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: OPPO
@@ -9476,7 +9476,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: DEXP
@@ -9494,7 +9494,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Xiaomi
@@ -9512,7 +9512,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: Stylo

--- a/Tests/fixtures/smartphone-11.yml
+++ b/Tests/fixtures/smartphone-11.yml
@@ -46,7 +46,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: OPPO
@@ -64,7 +64,7 @@
     name: Chrome Webview
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -100,7 +100,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: OPPO
@@ -118,7 +118,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: OPPO
@@ -136,7 +136,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: OPPO
@@ -154,7 +154,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: OPPO
@@ -172,7 +172,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -190,7 +190,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: OPPO
@@ -260,7 +260,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -278,7 +278,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: OPPO
@@ -314,7 +314,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: OPPO
@@ -332,7 +332,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: OPPO
@@ -350,7 +350,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -386,7 +386,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -404,7 +404,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OPPO
@@ -422,7 +422,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: OPPO
@@ -440,7 +440,7 @@
     name: Chrome Webview
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: OPPO
@@ -458,7 +458,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: OPPO
@@ -626,7 +626,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: OPPO
@@ -660,7 +660,7 @@
     name: Chrome Mobile
     version: "38.0.2125.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.114"
   device:
     type: smartphone
     brand: OPPO
@@ -712,7 +712,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: OPPO
@@ -898,7 +898,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: OPPO
@@ -916,7 +916,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: OPPO
@@ -934,7 +934,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: OPPO
@@ -970,7 +970,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: OPPO
@@ -988,7 +988,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: OPPO
@@ -1006,7 +1006,7 @@
     name: Opera Mobile
     version: "53.1.2569.142848"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: OPPO
@@ -1024,7 +1024,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: OPPO
@@ -1042,7 +1042,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: OPPO
@@ -1076,7 +1076,7 @@
     name: Chrome Webview
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: OPPO
@@ -1094,7 +1094,7 @@
     name: Chrome Mobile
     version: "85.0.4183.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: OPPO
@@ -1112,7 +1112,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: OPPO
@@ -1130,7 +1130,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: OPPO
@@ -1148,7 +1148,7 @@
     name: Yandex Browser
     version: "20.74"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
   device:
     type: smartphone
     brand: OPPO
@@ -1166,7 +1166,7 @@
     name: Opera Mobile
     version: "54.0.2672.49578"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: OPPO
@@ -1184,7 +1184,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: OPPO
@@ -1202,7 +1202,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: OPPO
@@ -1220,7 +1220,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: OPPO
@@ -1238,7 +1238,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: OPPO
@@ -1274,7 +1274,7 @@
     name: Chrome Mobile
     version: "84.0.4147.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: OPPO
@@ -1292,7 +1292,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: OPPO
@@ -1310,7 +1310,7 @@
     name: Chrome Webview
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: OPPO
@@ -1346,7 +1346,7 @@
     name: Chrome Mobile
     version: "85.0.4183.120"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: smartphone
     brand: OPPO
@@ -1364,7 +1364,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: OPPO
@@ -1382,7 +1382,7 @@
     name: Chrome Webview
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: OPPO
@@ -1418,7 +1418,7 @@
     name: Chrome Webview
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: OPPO
@@ -1436,7 +1436,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: OPPO
@@ -1454,7 +1454,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: OPPO
@@ -1472,7 +1472,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: OPPO
@@ -1490,7 +1490,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: OPPO
@@ -1508,7 +1508,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: OPPO
@@ -1526,7 +1526,7 @@
     name: Opera Mobile
     version: "53.1.2569.142848"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: OPPO
@@ -1544,7 +1544,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: OPPO
@@ -1562,7 +1562,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: OPPO
@@ -1580,7 +1580,7 @@
     name: Chrome Webview
     version: "68.0.3440.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.106"
   device:
     type: smartphone
     brand: OPPO
@@ -1652,7 +1652,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Orange
@@ -1670,7 +1670,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Orange
@@ -1688,7 +1688,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Orange
@@ -1706,7 +1706,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Orange
@@ -1742,7 +1742,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Orange
@@ -1760,7 +1760,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Orange
@@ -1778,7 +1778,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Orange
@@ -1850,7 +1850,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Orange
@@ -1868,7 +1868,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Orange
@@ -1886,7 +1886,7 @@
     name: Chrome Webview
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: smartphone
     brand: Orange
@@ -1904,7 +1904,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Orange
@@ -1922,7 +1922,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Orange
@@ -1940,7 +1940,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Orange
@@ -1958,7 +1958,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Orange
@@ -1976,7 +1976,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Orange
@@ -1994,7 +1994,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Orange
@@ -2012,7 +2012,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Orange
@@ -2030,7 +2030,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Orange
@@ -2048,7 +2048,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Orange
@@ -2066,7 +2066,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Orange
@@ -2084,7 +2084,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Orange
@@ -2102,7 +2102,7 @@
     name: Chrome Mobile
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Orange
@@ -2120,7 +2120,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Orange
@@ -2138,7 +2138,7 @@
     name: Chrome Webview
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: smartphone
     brand: Orange
@@ -2192,7 +2192,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Orange
@@ -2210,7 +2210,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Orange
@@ -2316,7 +2316,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Overmax
@@ -2334,7 +2334,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Overmax
@@ -2352,7 +2352,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Overmax
@@ -2370,7 +2370,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: öwn
@@ -2388,7 +2388,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: öwn
@@ -2406,7 +2406,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: öwn
@@ -2424,7 +2424,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: öwn
@@ -2442,7 +2442,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: öwn
@@ -2460,7 +2460,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: öwn
@@ -2478,7 +2478,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: öwn
@@ -2496,7 +2496,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: öwn
@@ -2532,7 +2532,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: öwn
@@ -2568,7 +2568,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: öwn
@@ -2586,7 +2586,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: öwn
@@ -2604,7 +2604,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Oysters
@@ -2622,7 +2622,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Oysters
@@ -2640,7 +2640,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Oysters
@@ -2658,7 +2658,7 @@
     name: Chrome Mobile
     version: "33.0.1750.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.135"
   device:
     type: smartphone
     brand: Oysters
@@ -2676,7 +2676,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Oysters
@@ -2694,7 +2694,7 @@
     name: Opera Mobile
     version: "50.3.2426.136976"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Oysters
@@ -2748,7 +2748,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: PPTV
@@ -2766,7 +2766,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: PPTV
@@ -2784,7 +2784,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Plum
@@ -2820,7 +2820,7 @@
     name: Chrome Webview
     version: "64.0.3282.123"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: smartphone
     brand: Polytron
@@ -2964,7 +2964,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Polytron
@@ -3144,7 +3144,7 @@
     name: Chrome Webview
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Polytron
@@ -3216,7 +3216,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Polytron
@@ -3252,7 +3252,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Polytron
@@ -3270,7 +3270,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Polytron
@@ -3288,7 +3288,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Polytron
@@ -3342,7 +3342,7 @@
     name: Chrome Webview
     version: "50.0.2661.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Polytron
@@ -3378,7 +3378,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Protruly
@@ -3396,7 +3396,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Protruly
@@ -3414,7 +3414,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Protruly
@@ -3432,7 +3432,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Panasonic
@@ -3450,7 +3450,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Panasonic
@@ -3468,7 +3468,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Panasonic
@@ -3486,7 +3486,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Panasonic
@@ -3504,7 +3504,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Panasonic
@@ -3522,7 +3522,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Panasonic
@@ -3540,7 +3540,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Panasonic
@@ -3558,7 +3558,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Panasonic
@@ -3576,7 +3576,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Panasonic
@@ -3594,7 +3594,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: PCBOX
@@ -3612,7 +3612,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: PCBOX
@@ -3630,7 +3630,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: PCBOX
@@ -3648,7 +3648,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: PCD
@@ -3666,7 +3666,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: PCD Argentina
@@ -3684,7 +3684,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: PCD Argentina
@@ -3702,7 +3702,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: PCD Argentina
@@ -3774,7 +3774,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Philips
@@ -3954,7 +3954,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Polaroid
@@ -3990,7 +3990,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Polaroid
@@ -4008,7 +4008,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Polaroid
@@ -4026,7 +4026,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Polaroid
@@ -4044,7 +4044,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Polaroid
@@ -4062,7 +4062,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Polaroid
@@ -4080,7 +4080,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Polaroid
@@ -4098,7 +4098,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Polaroid
@@ -4116,7 +4116,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Polaroid
@@ -4134,7 +4134,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Polaroid
@@ -4152,7 +4152,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Polaroid
@@ -4170,7 +4170,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Polaroid
@@ -4188,7 +4188,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Polaroid
@@ -4224,7 +4224,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Polaroid
@@ -4296,7 +4296,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Polaroid
@@ -4350,7 +4350,7 @@
     name: Chrome Webview
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Polaroid
@@ -4368,7 +4368,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Polaroid
@@ -4386,7 +4386,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Polaroid
@@ -4404,7 +4404,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Polaroid
@@ -4422,7 +4422,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Polaroid
@@ -4633,7 +4633,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Prestigio
@@ -4793,7 +4793,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Prestigio
@@ -4811,7 +4811,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Prestigio
@@ -4847,7 +4847,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Prestigio
@@ -4865,7 +4865,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Prestigio
@@ -4883,7 +4883,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Prestigio
@@ -4919,7 +4919,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Positivo
@@ -5099,7 +5099,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: Pantech
@@ -5153,7 +5153,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Pantech
@@ -5297,7 +5297,7 @@
     name: Chrome Mobile
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Pixus
@@ -5315,7 +5315,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Pixus
@@ -5333,7 +5333,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Pixus
@@ -5351,7 +5351,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Quantum
@@ -5387,7 +5387,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Quantum
@@ -5441,7 +5441,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Quantum
@@ -5477,7 +5477,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Quantum
@@ -5495,7 +5495,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Q.Bell
@@ -5513,7 +5513,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Q.Bell
@@ -5531,7 +5531,7 @@
     name: Chrome Webview
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Q.Bell
@@ -5549,7 +5549,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Q-Touch
@@ -5585,7 +5585,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Qilive
@@ -5603,7 +5603,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Qilive
@@ -5639,7 +5639,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Qilive
@@ -5657,7 +5657,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Qilive
@@ -5675,7 +5675,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Qilive
@@ -5693,7 +5693,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Qilive
@@ -5711,7 +5711,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Qilive
@@ -5729,7 +5729,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Qilive
@@ -5747,7 +5747,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Qilive
@@ -5765,7 +5765,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Qilive
@@ -5783,7 +5783,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Qilive
@@ -5801,7 +5801,7 @@
     name: Chrome Webview
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Qilive
@@ -5819,7 +5819,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Qilive
@@ -5837,7 +5837,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Qilive
@@ -5927,7 +5927,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: QMobile
@@ -5945,7 +5945,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: QMobile
@@ -5963,7 +5963,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: QMobile
@@ -5999,7 +5999,7 @@
     name: Opera Mobile
     version: "27.0.1698.88647"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: smartphone
     brand: QMobile
@@ -6071,7 +6071,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Qumo
@@ -6089,7 +6089,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Qumo
@@ -6107,7 +6107,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Qumo
@@ -6125,7 +6125,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Qumo
@@ -6143,7 +6143,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Qumo
@@ -6161,7 +6161,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Qumo
@@ -6215,7 +6215,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Quechua
@@ -6233,7 +6233,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Rokit
@@ -6251,7 +6251,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Casper
@@ -6269,7 +6269,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Casper
@@ -6287,7 +6287,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Casper
@@ -6305,7 +6305,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Casper
@@ -6323,7 +6323,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Casper
@@ -6341,7 +6341,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Casper
@@ -6359,7 +6359,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Casper
@@ -6377,7 +6377,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Casper
@@ -6395,7 +6395,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Casper
@@ -6413,7 +6413,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Casper
@@ -6431,7 +6431,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Casper
@@ -6449,7 +6449,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Casper
@@ -6467,7 +6467,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Casper
@@ -6485,7 +6485,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Casper
@@ -6503,7 +6503,7 @@
     name: Aloha Browser
     version: "2.8.0.3"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Casper
@@ -6521,7 +6521,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Casper
@@ -6539,7 +6539,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Casper
@@ -6557,7 +6557,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Casper
@@ -6575,7 +6575,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Casper
@@ -6593,7 +6593,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Casper
@@ -6611,7 +6611,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Casper
@@ -6629,7 +6629,7 @@
     name: Chrome Mobile
     version: "80.0.3987.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: smartphone
     brand: Casper
@@ -6647,7 +6647,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Casper
@@ -6665,7 +6665,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Casper
@@ -6683,7 +6683,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Casper
@@ -6701,7 +6701,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Casper
@@ -6719,7 +6719,7 @@
     name: Chrome Mobile
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: smartphone
     brand: Casper
@@ -6737,7 +6737,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Casper
@@ -6755,7 +6755,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Casper
@@ -6773,7 +6773,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: RoverPad
@@ -6791,7 +6791,7 @@
     name: Chrome Webview
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Ritzviva
@@ -6809,7 +6809,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: RED
@@ -6827,7 +6827,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Ravoz
@@ -6845,7 +6845,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Ravoz
@@ -6863,7 +6863,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Ravoz
@@ -6881,7 +6881,7 @@
     name: Chrome Mobile
     version: "84.0.4114.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4114.0"
   device:
     type: smartphone
     brand: Ravoz
@@ -6899,7 +6899,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Ravoz
@@ -6917,7 +6917,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Ravoz
@@ -6935,7 +6935,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: RCA Tablets
@@ -6953,7 +6953,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Realme
@@ -6971,7 +6971,7 @@
     name: Chrome Mobile
     version: "71.0.3578.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.98"
   device:
     type: smartphone
     brand: Realme
@@ -7007,7 +7007,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Realme
@@ -7025,7 +7025,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Realme
@@ -7043,7 +7043,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Realme
@@ -7061,7 +7061,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Realme
@@ -7079,7 +7079,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Realme
@@ -7097,7 +7097,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Realme
@@ -7115,7 +7115,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Realme
@@ -7151,7 +7151,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Realme
@@ -7169,7 +7169,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Realme
@@ -7187,7 +7187,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Realme
@@ -7205,7 +7205,7 @@
     name: Chrome Mobile
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Realme
@@ -7241,7 +7241,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Realme
@@ -7259,7 +7259,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Realme
@@ -7277,7 +7277,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Realme
@@ -7295,7 +7295,7 @@
     name: Chrome Webview
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Realme
@@ -7313,7 +7313,7 @@
     name: Chrome Webview
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Realme
@@ -7349,7 +7349,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Realme
@@ -7367,7 +7367,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Realme
@@ -7385,7 +7385,7 @@
     name: Chrome Webview
     version: "85.0.4183.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Realme
@@ -7403,7 +7403,7 @@
     name: Chrome Webview
     version: "85.0.4183.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Realme
@@ -7421,7 +7421,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Realme
@@ -7439,7 +7439,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Realme
@@ -7457,7 +7457,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Realme
@@ -7475,7 +7475,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Realme
@@ -7511,7 +7511,7 @@
     name: Chrome Webview
     version: "81.0.4044.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Realme
@@ -7529,7 +7529,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Realme
@@ -7547,7 +7547,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Realme
@@ -7599,7 +7599,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Realme
@@ -7635,7 +7635,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Realme
@@ -7653,7 +7653,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Realme
@@ -7671,7 +7671,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Realme
@@ -7689,7 +7689,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Realme
@@ -7707,7 +7707,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Realme
@@ -7743,7 +7743,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Realme
@@ -7779,7 +7779,7 @@
     name: Chrome Webview
     version: "74.0.3729.186"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.186"
   device:
     type: smartphone
     brand: Realme
@@ -7815,7 +7815,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Realme
@@ -7833,7 +7833,7 @@
     name: Chrome Webview
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Realme
@@ -7851,7 +7851,7 @@
     name: Opera Mobile
     version: "54.3.2672.50220"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Realme
@@ -7905,7 +7905,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: RugGear
@@ -7923,7 +7923,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: RugGear
@@ -7941,7 +7941,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: RugGear
@@ -7959,7 +7959,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: RugGear
@@ -7977,7 +7977,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: RugGear
@@ -7995,7 +7995,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: RugGear
@@ -8013,7 +8013,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: RIM
@@ -8209,7 +8209,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: RIM
@@ -8227,7 +8227,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: RIM
@@ -8245,7 +8245,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: RIM
@@ -8281,7 +8281,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: RIM
@@ -8299,7 +8299,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: RIM
@@ -8317,7 +8317,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: RIM
@@ -8335,7 +8335,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: RIM
@@ -8353,7 +8353,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: RIM
@@ -8389,7 +8389,7 @@
     name: Chrome Mobile
     version: "69.0.3497"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497"
   device:
     type: smartphone
     brand: RIM
@@ -8407,7 +8407,7 @@
     name: Chrome Mobile
     version: "69.0.3497"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497"
   device:
     type: smartphone
     brand: RIM
@@ -8425,7 +8425,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: RIM
@@ -8443,7 +8443,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: RIM
@@ -8461,7 +8461,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: RIM
@@ -8479,7 +8479,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: RIM
@@ -8497,7 +8497,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: RIM
@@ -8515,7 +8515,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: RIM
@@ -8533,7 +8533,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: RIM
@@ -8551,7 +8551,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: RIM
@@ -8569,7 +8569,7 @@
     name: Chrome Mobile
     version: "69.0.3497"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497"
   device:
     type: smartphone
     brand: RIM
@@ -8587,7 +8587,7 @@
     name: Chrome Mobile
     version: "69.0.3497"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497"
   device:
     type: smartphone
     brand: RIM
@@ -8605,7 +8605,7 @@
     name: Chrome Mobile
     version: "69.0.3497"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497"
   device:
     type: smartphone
     brand: RIM
@@ -8623,7 +8623,7 @@
     name: Chrome Mobile
     version: "69.0.3497"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497"
   device:
     type: smartphone
     brand: RIM
@@ -8641,7 +8641,7 @@
     name: Chrome Mobile
     version: "69.0.3497"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497"
   device:
     type: smartphone
     brand: RIM
@@ -8659,7 +8659,7 @@
     name: Chrome Mobile
     version: "69.0.3497"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497"
   device:
     type: smartphone
     brand: RIM
@@ -8677,7 +8677,7 @@
     name: Chrome Mobile
     version: "69.0.3497"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497"
   device:
     type: smartphone
     brand: RIM
@@ -8695,7 +8695,7 @@
     name: Chrome Mobile
     version: "69.0.3497"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497"
   device:
     type: smartphone
     brand: RIM
@@ -8713,7 +8713,7 @@
     name: Chrome Mobile
     version: "69.0.3497"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497"
   device:
     type: smartphone
     brand: RIM
@@ -8731,7 +8731,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: RIM
@@ -8749,7 +8749,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: RIM
@@ -8767,7 +8767,7 @@
     name: Chrome Mobile
     version: "67.0.3396.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.68"
   device:
     type: smartphone
     brand: RIM
@@ -8785,7 +8785,7 @@
     name: Chrome Mobile
     version: "67.0.3396.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.68"
   device:
     type: smartphone
     brand: RIM
@@ -8803,7 +8803,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: RIM
@@ -8821,7 +8821,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: RIM
@@ -8839,7 +8839,7 @@
     name: Chrome Mobile
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: RIM
@@ -8857,7 +8857,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: RIM
@@ -8875,7 +8875,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: RIM
@@ -8893,7 +8893,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: RIM
@@ -8929,7 +8929,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: RT Project

--- a/Tests/fixtures/smartphone-12.yml
+++ b/Tests/fixtures/smartphone-12.yml
@@ -10,7 +10,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Runbo
@@ -28,7 +28,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Runbo
@@ -46,7 +46,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Runbo
@@ -64,7 +64,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Runbo
@@ -118,7 +118,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Runbo
@@ -154,7 +154,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Runbo
@@ -190,7 +190,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Riviera
@@ -208,7 +208,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Ritmix
@@ -226,7 +226,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Ritmix
@@ -244,7 +244,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Ritmix
@@ -298,7 +298,7 @@
     name: Aloha Browser
     version: "2.7.0.3"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Ryte
@@ -316,7 +316,7 @@
     name: Chrome Mobile
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Razer
@@ -334,7 +334,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Sanei
@@ -442,7 +442,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Sencor
@@ -460,7 +460,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Stonex
@@ -496,7 +496,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Stonex
@@ -514,7 +514,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Stonex
@@ -532,7 +532,7 @@
     name: Chrome Mobile
     version: "43.0.2357.78"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.78"
   device:
     type: smartphone
     brand: Stonex
@@ -618,7 +618,7 @@
     name: Chrome Mobile
     version: "43.0.2357.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.92"
   device:
     type: smartphone
     brand: Star
@@ -636,7 +636,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Star
@@ -672,7 +672,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Star
@@ -726,7 +726,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Star
@@ -744,7 +744,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Senseit
@@ -762,7 +762,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Senseit
@@ -780,7 +780,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Senseit
@@ -798,7 +798,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Senseit
@@ -816,7 +816,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Senseit
@@ -834,7 +834,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Smartisan
@@ -976,7 +976,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Smartisan
@@ -1044,7 +1044,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: STK
@@ -1062,7 +1062,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: STK
@@ -1080,7 +1080,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: STK
@@ -1134,7 +1134,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Samsung
@@ -1170,7 +1170,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Samsung
@@ -1188,7 +1188,7 @@
     name: Yandex Browser
     version: "8.60"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Samsung
@@ -1206,7 +1206,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Samsung
@@ -1224,7 +1224,7 @@
     name: Chrome Mobile
     version: "80.0.3987.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Samsung
@@ -1242,7 +1242,7 @@
     name: Chrome Webview
     version: "83.0.4103.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Samsung
@@ -1278,7 +1278,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Samsung
@@ -1296,7 +1296,7 @@
     name: Yandex Browser
     version: "19.9.1.126.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Samsung
@@ -1332,7 +1332,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Samsung
@@ -1368,7 +1368,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Samsung
@@ -1386,7 +1386,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -1404,7 +1404,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -1422,7 +1422,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -1440,7 +1440,7 @@
     name: Chrome Mobile
     version: "83.0.4103.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Samsung
@@ -1494,7 +1494,7 @@
     name: Chrome Mobile
     version: "83.0.4103.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Samsung
@@ -1566,7 +1566,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Samsung
@@ -1584,7 +1584,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Samsung
@@ -1602,7 +1602,7 @@
     name: Chrome Mobile
     version: "68.0.3440.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.85"
   device:
     type: smartphone
     brand: Samsung
@@ -1620,7 +1620,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Samsung
@@ -1674,7 +1674,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Samsung
@@ -1800,7 +1800,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Samsung
@@ -1818,7 +1818,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -1836,7 +1836,7 @@
     name: Chrome Mobile
     version: "83.0.4103.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Samsung
@@ -1854,7 +1854,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Samsung
@@ -1890,7 +1890,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -1926,7 +1926,7 @@
     name: Chrome Webview
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Samsung
@@ -1944,7 +1944,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -1962,7 +1962,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Samsung
@@ -1980,7 +1980,7 @@
     name: Chrome Mobile
     version: "84.0.4147.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Samsung
@@ -1998,7 +1998,7 @@
     name: Chrome Webview
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Samsung
@@ -2016,7 +2016,7 @@
     name: Chrome Mobile
     version: "36.0.1985.534"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.534"
   device:
     type: smartphone
     brand: Samsung
@@ -2034,7 +2034,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Samsung
@@ -2052,7 +2052,7 @@
     name: Chrome Mobile
     version: "81.0.4044.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: Samsung
@@ -2070,7 +2070,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Samsung
@@ -2088,7 +2088,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Samsung
@@ -2106,7 +2106,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Samsung
@@ -2142,7 +2142,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Samsung
@@ -2160,7 +2160,7 @@
     name: Chrome Mobile
     version: "64.0.3282.123"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: smartphone
     brand: Samsung
@@ -2178,7 +2178,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Samsung
@@ -2232,7 +2232,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Samsung
@@ -2286,7 +2286,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Samsung
@@ -2304,7 +2304,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Samsung
@@ -2322,7 +2322,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Samsung
@@ -2394,7 +2394,7 @@
     name: Chrome Webview
     version: "34.0.1847.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.76"
   device:
     type: smartphone
     brand: Samsung
@@ -2412,7 +2412,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Samsung
@@ -2430,7 +2430,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Samsung
@@ -2448,7 +2448,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Samsung
@@ -2484,7 +2484,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Samsung
@@ -2502,7 +2502,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -2520,7 +2520,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Samsung
@@ -2538,7 +2538,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -2592,7 +2592,7 @@
     name: Chrome Mobile
     version: "83.0.4103.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Samsung
@@ -2646,7 +2646,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Samsung
@@ -2664,7 +2664,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Samsung
@@ -2682,7 +2682,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Samsung
@@ -2700,7 +2700,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Samsung
@@ -2718,7 +2718,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Samsung
@@ -2736,7 +2736,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Samsung
@@ -2754,7 +2754,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Samsung
@@ -2772,7 +2772,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Samsung
@@ -2790,7 +2790,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Samsung
@@ -2844,7 +2844,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Samsung
@@ -2898,7 +2898,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Samsung
@@ -2916,7 +2916,7 @@
     name: Chrome Webview
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Samsung
@@ -2988,7 +2988,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Samsung
@@ -3060,7 +3060,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Samsung
@@ -3078,7 +3078,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Samsung
@@ -3132,7 +3132,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Samsung
@@ -3150,7 +3150,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -3186,7 +3186,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Samsung
@@ -3240,7 +3240,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Samsung
@@ -3276,7 +3276,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Samsung
@@ -3294,7 +3294,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Samsung
@@ -3312,7 +3312,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Samsung
@@ -3366,7 +3366,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Samsung
@@ -3384,7 +3384,7 @@
     name: Chrome Mobile
     version: "84.0.4147.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.84"
   device:
     type: smartphone
     brand: Samsung
@@ -3402,7 +3402,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Samsung
@@ -3420,7 +3420,7 @@
     name: Chrome Webview
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Samsung
@@ -3456,7 +3456,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -3492,7 +3492,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -3510,7 +3510,7 @@
     name: Chrome Mobile
     version: "83.0.4103.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Samsung
@@ -3528,7 +3528,7 @@
     name: Chrome Mobile
     version: "84.0.4147.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Samsung
@@ -3582,7 +3582,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Samsung
@@ -3600,7 +3600,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Samsung
@@ -3618,7 +3618,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Samsung
@@ -3654,7 +3654,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Samsung
@@ -3688,7 +3688,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Samsung
@@ -3706,7 +3706,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Samsung
@@ -3742,7 +3742,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Samsung
@@ -3796,7 +3796,7 @@
     name: Yandex Browser
     version: "8.30"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.103"
   device:
     type: smartphone
     brand: Samsung
@@ -3814,7 +3814,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Samsung
@@ -3868,7 +3868,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Samsung
@@ -3958,7 +3958,7 @@
     name: Chrome Mobile
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Samsung
@@ -3976,7 +3976,7 @@
     name: Chrome Mobile
     version: "83.0.4103.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Samsung
@@ -4084,7 +4084,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Samsung
@@ -4120,7 +4120,7 @@
     name: Chrome Webview
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Samsung
@@ -4174,7 +4174,7 @@
     name: Chrome Mobile
     version: "83.0.4103.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Samsung
@@ -4444,7 +4444,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Samsung
@@ -4516,7 +4516,7 @@
     name: Chrome Mobile
     version: "33.0.1750.517"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.517"
   device:
     type: smartphone
     brand: Samsung
@@ -4534,7 +4534,7 @@
     name: Chrome Mobile
     version: "33.0.1750.517"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.517"
   device:
     type: smartphone
     brand: Samsung
@@ -4552,7 +4552,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Samsung
@@ -4570,7 +4570,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Samsung
@@ -4606,7 +4606,7 @@
     name: Chrome Mobile
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: smartphone
     brand: Samsung
@@ -4624,7 +4624,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Samsung
@@ -4642,7 +4642,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Samsung
@@ -4660,7 +4660,7 @@
     name: Opera Mobile
     version: "36.2.2254.130496"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Samsung
@@ -4678,7 +4678,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Samsung
@@ -4750,7 +4750,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Samsung
@@ -4804,7 +4804,7 @@
     name: Chrome Mobile
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: smartphone
     brand: Samsung
@@ -4822,7 +4822,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Samsung
@@ -4840,7 +4840,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Samsung
@@ -4894,7 +4894,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Samsung
@@ -4930,7 +4930,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Samsung
@@ -4948,7 +4948,7 @@
     name: Chrome
     version: "79.0.3945.88"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.88"
   device:
     type: smartphone
     brand: Samsung
@@ -4966,7 +4966,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Samsung
@@ -5002,7 +5002,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Samsung
@@ -5074,7 +5074,7 @@
     name: Yandex Browser
     version: "18.11.1.1011.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: smartphone
     brand: Samsung
@@ -5164,7 +5164,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Samsung
@@ -5254,7 +5254,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Samsung
@@ -5290,7 +5290,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: Samsung
@@ -5398,7 +5398,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Samsung
@@ -5488,7 +5488,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Samsung
@@ -5542,7 +5542,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Samsung
@@ -5560,7 +5560,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Samsung
@@ -5596,7 +5596,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Samsung
@@ -5614,7 +5614,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -5632,7 +5632,7 @@
     name: Chrome Mobile
     version: "67.0.3396.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.81"
   device:
     type: smartphone
     brand: Samsung
@@ -5668,7 +5668,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Samsung
@@ -5686,7 +5686,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -5704,7 +5704,7 @@
     name: Chrome Webview
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: Samsung
@@ -5722,7 +5722,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -5740,7 +5740,7 @@
     name: Chrome Mobile
     version: "68.0.3440.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.85"
   device:
     type: smartphone
     brand: Samsung
@@ -5758,7 +5758,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Samsung
@@ -5884,7 +5884,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Samsung
@@ -5956,7 +5956,7 @@
     name: Opera Mobile
     version: "42.0.2254.139276"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Samsung
@@ -6010,7 +6010,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Samsung
@@ -6028,7 +6028,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Samsung
@@ -6082,7 +6082,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Samsung
@@ -6118,7 +6118,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -6154,7 +6154,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Samsung
@@ -6172,7 +6172,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Samsung
@@ -6190,7 +6190,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Samsung
@@ -6208,7 +6208,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Samsung
@@ -6262,7 +6262,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Samsung
@@ -6316,7 +6316,7 @@
     name: Chrome Mobile
     version: "68.0.3440.70"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.70"
   device:
     type: smartphone
     brand: Samsung
@@ -6334,7 +6334,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Samsung
@@ -6352,7 +6352,7 @@
     name: Yandex Browser
     version: "8.45"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.103"
   device:
     type: smartphone
     brand: Samsung
@@ -6370,7 +6370,7 @@
     name: Opera Mobile
     version: "20.1.2254.110627"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Samsung
@@ -6388,7 +6388,7 @@
     name: Opera Mobile
     version: "43.2.2254.140293"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Samsung
@@ -6406,7 +6406,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Samsung
@@ -6424,7 +6424,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Samsung
@@ -6514,7 +6514,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Samsung
@@ -6532,7 +6532,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Samsung
@@ -6604,7 +6604,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Samsung
@@ -6622,7 +6622,7 @@
     name: Chrome Mobile
     version: "68.0.3440.70"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.70"
   device:
     type: smartphone
     brand: Samsung
@@ -6640,7 +6640,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Samsung
@@ -6658,7 +6658,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Samsung
@@ -6730,7 +6730,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Samsung
@@ -6748,7 +6748,7 @@
     name: Chrome Mobile
     version: "67.0.3396.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.68"
   device:
     type: smartphone
     brand: Samsung
@@ -6838,7 +6838,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Samsung
@@ -6856,7 +6856,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Samsung
@@ -6874,7 +6874,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Samsung
@@ -6892,7 +6892,7 @@
     name: Chrome Mobile
     version: "68.0.3440.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.85"
   device:
     type: smartphone
     brand: Samsung
@@ -6946,7 +6946,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -6964,7 +6964,7 @@
     name: Chrome Mobile
     version: "84.0.4147.44"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.44"
   device:
     type: smartphone
     brand: Samsung
@@ -7036,7 +7036,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Samsung
@@ -7054,7 +7054,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Samsung
@@ -7072,7 +7072,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Samsung
@@ -7090,7 +7090,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Samsung
@@ -7144,7 +7144,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Samsung
@@ -7162,7 +7162,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -7252,7 +7252,7 @@
     name: Chrome Mobile
     version: "83.0.4103.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Samsung
@@ -7270,7 +7270,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Samsung
@@ -7306,7 +7306,7 @@
     name: Chrome Webview
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Samsung
@@ -7432,7 +7432,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Samsung
@@ -7450,7 +7450,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Samsung
@@ -7468,7 +7468,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Samsung
@@ -7486,7 +7486,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Samsung
@@ -7504,7 +7504,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Samsung
@@ -7540,7 +7540,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Samsung
@@ -7612,7 +7612,7 @@
     name: Chrome Mobile
     version: "83.0.4103.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Samsung
@@ -7648,7 +7648,7 @@
     name: Yandex Browser
     version: "10.70"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -7666,7 +7666,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Samsung
@@ -7756,7 +7756,7 @@
     name: Chrome Mobile
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: smartphone
     brand: Samsung
@@ -7774,7 +7774,7 @@
     name: Chrome Mobile
     version: "60.0.3112.97"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.97"
   device:
     type: smartphone
     brand: Samsung
@@ -7792,7 +7792,7 @@
     name: Opera Mobile
     version: "43.2.2254.140293"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Samsung
@@ -7810,7 +7810,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Samsung
@@ -7828,7 +7828,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Samsung
@@ -7954,7 +7954,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Samsung
@@ -7972,7 +7972,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Samsung
@@ -7990,7 +7990,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Samsung
@@ -8008,7 +8008,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Samsung
@@ -8044,7 +8044,7 @@
     name: Chrome Mobile
     version: "68.0.3440.70"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.70"
   device:
     type: smartphone
     brand: Samsung
@@ -8062,7 +8062,7 @@
     name: Chrome Mobile
     version: "68.0.3440.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.85"
   device:
     type: smartphone
     brand: Samsung
@@ -8080,7 +8080,7 @@
     name: Chrome Webview
     version: "68.0.3440.70"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.70"
   device:
     type: smartphone
     brand: Samsung
@@ -8098,7 +8098,7 @@
     name: Chrome Mobile
     version: "81.0.4044.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Samsung
@@ -8116,7 +8116,7 @@
     name: Chrome Mobile
     version: "83.0.4103.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Samsung
@@ -8134,7 +8134,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Samsung
@@ -8170,7 +8170,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Samsung
@@ -8188,7 +8188,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Samsung
@@ -8206,7 +8206,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Samsung
@@ -8242,7 +8242,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Samsung
@@ -8260,7 +8260,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Samsung
@@ -8278,7 +8278,7 @@
     name: Opera Mobile
     version: "54.2.2672.49907"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Samsung
@@ -8332,7 +8332,7 @@
     name: Opera Mobile
     version: "44.1.2254.143214"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Samsung
@@ -8350,7 +8350,7 @@
     name: Opera Mobile
     version: "52.0.2517.139457"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Samsung
@@ -8404,7 +8404,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Samsung
@@ -8440,7 +8440,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Samsung
@@ -8458,7 +8458,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Samsung
@@ -8476,7 +8476,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Samsung
@@ -8494,7 +8494,7 @@
     name: Chrome Mobile
     version: "81.0.4044.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Samsung
@@ -8512,7 +8512,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -8530,7 +8530,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Samsung
@@ -8548,7 +8548,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -8602,7 +8602,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Samsung
@@ -8638,7 +8638,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Samsung
@@ -8674,7 +8674,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Samsung
@@ -8692,7 +8692,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Samsung
@@ -8728,7 +8728,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Samsung
@@ -8746,7 +8746,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Samsung
@@ -8764,7 +8764,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Samsung
@@ -8782,7 +8782,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Samsung
@@ -8818,7 +8818,7 @@
     name: Chrome Webview
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Samsung
@@ -8854,7 +8854,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Samsung
@@ -8872,7 +8872,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Samsung
@@ -8926,7 +8926,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Samsung
@@ -8944,7 +8944,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Samsung
@@ -8962,7 +8962,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Samsung
@@ -8980,7 +8980,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Samsung

--- a/Tests/fixtures/smartphone-13.yml
+++ b/Tests/fixtures/smartphone-13.yml
@@ -28,7 +28,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Samsung
@@ -46,7 +46,7 @@
     name: Chrome Mobile
     version: "33.0.1750.514"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.514"
   device:
     type: smartphone
     brand: Samsung
@@ -64,7 +64,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Samsung
@@ -82,7 +82,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Samsung
@@ -118,7 +118,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -154,7 +154,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Samsung
@@ -190,7 +190,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Samsung
@@ -262,7 +262,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -280,7 +280,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Samsung
@@ -298,7 +298,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Samsung
@@ -352,7 +352,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Samsung
@@ -370,7 +370,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Samsung
@@ -460,7 +460,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Samsung
@@ -478,7 +478,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Samsung
@@ -496,7 +496,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Samsung
@@ -514,7 +514,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Samsung
@@ -532,7 +532,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Samsung
@@ -550,7 +550,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Samsung
@@ -568,7 +568,7 @@
     name: Opera Mobile
     version: "53.1.2569.142848"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Samsung
@@ -586,7 +586,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Samsung
@@ -622,7 +622,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Samsung
@@ -640,7 +640,7 @@
     name: Chrome Mobile
     version: "60.0.3112.107"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.107"
   device:
     type: smartphone
     brand: Samsung
@@ -676,7 +676,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Samsung
@@ -694,7 +694,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Samsung
@@ -730,7 +730,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Samsung
@@ -802,7 +802,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Samsung
@@ -820,7 +820,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Samsung
@@ -838,7 +838,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Samsung
@@ -946,7 +946,7 @@
     name: Chrome Mobile
     version: "67.0.3396.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.68"
   device:
     type: smartphone
     brand: Samsung
@@ -1216,7 +1216,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Samsung
@@ -1414,7 +1414,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Samsung
@@ -1486,7 +1486,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Samsung
@@ -1576,7 +1576,7 @@
     name: Opera Mobile
     version: "19.0.1340.69721"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.72"
   device:
     type: smartphone
     brand: Samsung
@@ -1630,7 +1630,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Samsung
@@ -1738,7 +1738,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Samsung
@@ -1774,7 +1774,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Samsung
@@ -1864,7 +1864,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -1882,7 +1882,7 @@
     name: Chrome Mobile
     version: "83.0.4103.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Samsung
@@ -1900,7 +1900,7 @@
     name: Chrome Mobile
     version: "83.0.4103.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Samsung
@@ -1936,7 +1936,7 @@
     name: Chrome Mobile
     version: "85.0.4181.5"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4181.5"
   device:
     type: smartphone
     brand: Samsung
@@ -2008,7 +2008,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Samsung
@@ -2134,7 +2134,7 @@
     name: Chrome Mobile
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Samsung
@@ -2152,7 +2152,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Samsung
@@ -2188,7 +2188,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Samsung
@@ -2206,7 +2206,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Samsung
@@ -2242,7 +2242,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Samsung
@@ -2260,7 +2260,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -2278,7 +2278,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Samsung
@@ -2296,7 +2296,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Samsung
@@ -2314,7 +2314,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Samsung
@@ -2476,7 +2476,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Samsung
@@ -2494,7 +2494,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Samsung
@@ -2512,7 +2512,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Samsung
@@ -2530,7 +2530,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Samsung
@@ -2548,7 +2548,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Samsung
@@ -2566,7 +2566,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Samsung
@@ -2584,7 +2584,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Samsung
@@ -2638,7 +2638,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Samsung
@@ -2656,7 +2656,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Samsung
@@ -2674,7 +2674,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Samsung
@@ -2692,7 +2692,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Samsung
@@ -2710,7 +2710,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Samsung
@@ -2762,7 +2762,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Samsung
@@ -2780,7 +2780,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Samsung
@@ -2798,7 +2798,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Samsung
@@ -2816,7 +2816,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Samsung
@@ -2870,7 +2870,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Samsung
@@ -2888,7 +2888,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Samsung
@@ -2924,7 +2924,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Samsung
@@ -2942,7 +2942,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Samsung
@@ -2960,7 +2960,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Samsung
@@ -2978,7 +2978,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Samsung
@@ -3050,7 +3050,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Samsung
@@ -3068,7 +3068,7 @@
     name: Chrome Webview
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Samsung
@@ -3104,7 +3104,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Samsung
@@ -3122,7 +3122,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Samsung
@@ -3158,7 +3158,7 @@
     name: Iron Mobile
     version: "1.6.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Samsung
@@ -3176,7 +3176,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Samsung
@@ -3212,7 +3212,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Samsung
@@ -3248,7 +3248,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Samsung
@@ -3266,7 +3266,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Samsung
@@ -3302,7 +3302,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Samsung
@@ -3320,7 +3320,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Samsung
@@ -3338,7 +3338,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Samsung
@@ -3410,7 +3410,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Samsung
@@ -3428,7 +3428,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Samsung
@@ -3446,7 +3446,7 @@
     name: Chrome Mobile
     version: "67.0.3396.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.68"
   device:
     type: smartphone
     brand: Samsung
@@ -3464,7 +3464,7 @@
     name: Chrome Mobile
     version: "83.0.4103.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Samsung
@@ -3482,7 +3482,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Samsung
@@ -3500,7 +3500,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Samsung
@@ -3536,7 +3536,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Samsung
@@ -3554,7 +3554,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Samsung
@@ -3572,7 +3572,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Samsung
@@ -3626,7 +3626,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Samsung
@@ -3644,7 +3644,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Samsung
@@ -3662,7 +3662,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Samsung
@@ -3698,7 +3698,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Samsung
@@ -3716,7 +3716,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Samsung
@@ -3734,7 +3734,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Samsung
@@ -3752,7 +3752,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Samsung
@@ -3770,7 +3770,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Samsung
@@ -3824,7 +3824,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Samsung
@@ -3860,7 +3860,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Samsung
@@ -3878,7 +3878,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Samsung
@@ -3968,7 +3968,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Samsung
@@ -3986,7 +3986,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Samsung
@@ -4022,7 +4022,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Samsung
@@ -4040,7 +4040,7 @@
     name: Chrome Mobile
     version: "66.0.3359.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.106"
   device:
     type: smartphone
     brand: Samsung
@@ -4058,7 +4058,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Samsung
@@ -4076,7 +4076,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Samsung
@@ -4094,7 +4094,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Samsung
@@ -4130,7 +4130,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Samsung
@@ -4148,7 +4148,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Samsung
@@ -4166,7 +4166,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Samsung
@@ -4184,7 +4184,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Samsung
@@ -4238,7 +4238,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Samsung
@@ -4256,7 +4256,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Samsung
@@ -4274,7 +4274,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Samsung
@@ -4292,7 +4292,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Samsung
@@ -4382,7 +4382,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Samsung
@@ -4400,7 +4400,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Samsung
@@ -4418,7 +4418,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Samsung
@@ -4436,7 +4436,7 @@
     name: Chrome Mobile
     version: "64.0.3282.123"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: smartphone
     brand: Samsung
@@ -4454,7 +4454,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Samsung
@@ -4542,7 +4542,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Samsung
@@ -4596,7 +4596,7 @@
     name: Chrome Mobile
     version: "75.0.3770.67"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: smartphone
     brand: Samsung
@@ -4614,7 +4614,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Samsung
@@ -4632,7 +4632,7 @@
     name: Chrome Mobile
     version: "68.0.3440.70"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.70"
   device:
     type: smartphone
     brand: Samsung
@@ -4704,7 +4704,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Samsung
@@ -4722,7 +4722,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Samsung
@@ -4740,7 +4740,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Samsung
@@ -4758,7 +4758,7 @@
     name: Chrome Mobile
     version: "81.0.4044.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Samsung
@@ -4776,7 +4776,7 @@
     name: Chrome Webview
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -4794,7 +4794,7 @@
     name: Chrome Mobile
     version: "66.0.3359.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.106"
   device:
     type: smartphone
     brand: Samsung
@@ -4812,7 +4812,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Samsung
@@ -4830,7 +4830,7 @@
     name: Chrome Mobile
     version: "69.0.3497.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: smartphone
     brand: Samsung
@@ -4866,7 +4866,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -4884,7 +4884,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Samsung
@@ -4992,7 +4992,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Samsung
@@ -5010,7 +5010,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Samsung
@@ -5208,7 +5208,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: Samsung
@@ -5226,7 +5226,7 @@
     name: Opera Mobile
     version: "21.0.1437.74904"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.116"
   device:
     type: smartphone
     brand: Samsung
@@ -5262,7 +5262,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Samsung
@@ -5352,7 +5352,7 @@
     name: Yandex Browser
     version: "20.2.0.215.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.117"
   device:
     type: smartphone
     brand: Samsung
@@ -5370,7 +5370,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Samsung
@@ -5406,7 +5406,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Samsung
@@ -5424,7 +5424,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Samsung
@@ -5532,7 +5532,7 @@
     name: Chrome Mobile
     version: "73.0.3683.75"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.75"
   device:
     type: smartphone
     brand: Samsung
@@ -5586,7 +5586,7 @@
     name: Chrome Webview
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Samsung
@@ -5604,7 +5604,7 @@
     name: Chrome Mobile
     version: "83.0.4103.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Samsung
@@ -5622,7 +5622,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Samsung
@@ -5766,7 +5766,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: Samsung
@@ -5784,7 +5784,7 @@
     name: Chrome Mobile
     version: "33.0.1750.517"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.517"
   device:
     type: smartphone
     brand: Samsung
@@ -5802,7 +5802,7 @@
     name: Chrome Mobile
     version: "33.0.1750.517"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.517"
   device:
     type: smartphone
     brand: Samsung
@@ -5820,7 +5820,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Samsung
@@ -5838,7 +5838,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Samsung
@@ -5892,7 +5892,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Samsung
@@ -5910,7 +5910,7 @@
     name: Opera Mobile
     version: "21.0.1437.74904"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.116"
   device:
     type: smartphone
     brand: Samsung
@@ -5928,7 +5928,7 @@
     name: Chrome Mobile
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Samsung
@@ -6036,7 +6036,7 @@
     name: Chrome Mobile
     version: "47.0.2526.69"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.69"
   device:
     type: smartphone
     brand: Samsung
@@ -6072,7 +6072,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Samsung
@@ -6951,7 +6951,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: Samsung
@@ -6969,7 +6969,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Samsung
@@ -6987,7 +6987,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Samsung
@@ -7021,7 +7021,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Samsung
@@ -7129,7 +7129,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: Samsung
@@ -7777,7 +7777,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Samsung
@@ -7885,7 +7885,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Samsung
@@ -7903,7 +7903,7 @@
     name: Chrome Mobile
     version: "34.0.1847.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.62"
   device:
     type: smartphone
     brand: Samsung
@@ -7975,7 +7975,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Samsung
@@ -7993,7 +7993,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Samsung
@@ -8011,7 +8011,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Samsung
@@ -8029,7 +8029,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Samsung
@@ -8451,7 +8451,7 @@
     name: Chrome Mobile
     version: "64.0.3282.123"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: smartphone
     brand: STF Mobile
@@ -8469,7 +8469,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: STF Mobile
@@ -8541,7 +8541,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Smartfren
@@ -8845,7 +8845,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Sony Ericsson
@@ -9079,7 +9079,7 @@
     name: Chrome Mobile
     version: 52.0.2743.98
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: ZTE
@@ -9187,7 +9187,7 @@
     name: Chrome Mobile
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: smartphone
     brand: Huawei
@@ -9205,7 +9205,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Huawei
@@ -9223,7 +9223,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: BB Mobile
@@ -9259,7 +9259,7 @@
     name: Chrome
     version: 36.0.1985.128
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.128"
   device:
     type: tablet
     brand: Trevi
@@ -9277,7 +9277,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Uhappy
@@ -9295,7 +9295,7 @@
     name: Chrome Mobile
     version: 64.0.3282.123
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: smartphone
     brand: Samsung
@@ -9313,7 +9313,7 @@
     name: Chrome Mobile
     version: 82.0.4085.12
     engine: Blink
-    engine_version: ""
+    engine_version: "82.0.4085.12"
   device:
     type: smartphone
     brand: Samsung
@@ -9331,7 +9331,7 @@
     name: Chrome Mobile
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Samsung
@@ -9349,7 +9349,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Samsung
@@ -9367,7 +9367,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9403,7 +9403,7 @@
     name: Chrome Mobile
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: OPPO

--- a/Tests/fixtures/smartphone-14.yml
+++ b/Tests/fixtures/smartphone-14.yml
@@ -995,7 +995,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Sharp
@@ -1013,7 +1013,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Sharp
@@ -1031,7 +1031,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Sharp
@@ -1049,7 +1049,7 @@
     name: Chrome Mobile
     version: "74.0.3729.112"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: smartphone
     brand: Sharp
@@ -1067,7 +1067,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Sharp
@@ -1085,7 +1085,7 @@
     name: Chrome Webview
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Sharp
@@ -1103,7 +1103,7 @@
     name: Chrome Mobile
     version: "81.0.4044.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Sharp
@@ -1121,7 +1121,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Sharp
@@ -1173,7 +1173,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sharp
@@ -1191,7 +1191,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Sharp
@@ -1209,7 +1209,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Sharp
@@ -1227,7 +1227,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sharp
@@ -1245,7 +1245,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sharp
@@ -1263,7 +1263,7 @@
     name: Chrome Mobile
     version: "84.0.4147.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Sharp
@@ -1281,7 +1281,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Sharp
@@ -1299,7 +1299,7 @@
     name: Chrome Webview
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Sharp
@@ -1317,7 +1317,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Sharp
@@ -1335,7 +1335,7 @@
     name: Chrome Mobile
     version: "83.0.4103.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Sharp
@@ -1371,7 +1371,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sharp
@@ -1389,7 +1389,7 @@
     name: Chrome Mobile
     version: "84.0.4147.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Sharp
@@ -1407,7 +1407,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Sharp
@@ -1425,7 +1425,7 @@
     name: Chrome Mobile
     version: "81.0.4044.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Sharp
@@ -1443,7 +1443,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sharp
@@ -1461,7 +1461,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sharp
@@ -1479,7 +1479,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Sharp
@@ -1497,7 +1497,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Sharp
@@ -1515,7 +1515,7 @@
     name: Chrome Webview
     version: "84.0.4147.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Sharp
@@ -1533,7 +1533,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Sharp
@@ -1551,7 +1551,7 @@
     name: Chrome Mobile
     version: "84.0.4147.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Sharp
@@ -1569,7 +1569,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sharp
@@ -1587,7 +1587,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Sharp
@@ -1605,7 +1605,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Sharp
@@ -1623,7 +1623,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Sharp
@@ -1641,7 +1641,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sharp
@@ -1659,7 +1659,7 @@
     name: Chrome Mobile
     version: "83.0.4103.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Sharp
@@ -1677,7 +1677,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Sharp
@@ -1695,7 +1695,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Sharp
@@ -1713,7 +1713,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Sharp
@@ -1731,7 +1731,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sharp
@@ -1767,7 +1767,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Sharp
@@ -1785,7 +1785,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sharp
@@ -1803,7 +1803,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Sharp
@@ -1821,7 +1821,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Sharp
@@ -1839,7 +1839,7 @@
     name: Chrome Webview
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Sharp
@@ -1857,7 +1857,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Sharp
@@ -1875,7 +1875,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Sharp
@@ -1893,7 +1893,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Sharp
@@ -1911,7 +1911,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Sharp
@@ -1929,7 +1929,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Sharp
@@ -1947,7 +1947,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sharp
@@ -1965,7 +1965,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Sharp
@@ -1983,7 +1983,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Sharp
@@ -2001,7 +2001,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sharp
@@ -2019,7 +2019,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Sharp
@@ -2037,7 +2037,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sharp
@@ -2163,7 +2163,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Sharp
@@ -2181,7 +2181,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sharp
@@ -2217,7 +2217,7 @@
     name: Chrome Mobile
     version: "46.0.2490.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.92"
   device:
     type: smartphone
     brand: Silent Circle
@@ -2235,7 +2235,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Selfix
@@ -2253,7 +2253,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Selfix
@@ -2271,7 +2271,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Symphony
@@ -2289,7 +2289,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Symphony
@@ -2397,7 +2397,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Sony
@@ -2415,7 +2415,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Sony
@@ -2433,7 +2433,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Sony
@@ -2451,7 +2451,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Sony
@@ -2469,7 +2469,7 @@
     name: Chrome Mobile
     version: "83.0.4103.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Sony
@@ -2487,7 +2487,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Sony
@@ -2505,7 +2505,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sony
@@ -2523,7 +2523,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Sony
@@ -2541,7 +2541,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Sony
@@ -2559,7 +2559,7 @@
     name: Chrome Webview
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Sony
@@ -2577,7 +2577,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Sony
@@ -2595,7 +2595,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sony
@@ -2613,7 +2613,7 @@
     name: Microsoft Edge
     version: "45.07.4.5057"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Sony
@@ -2631,7 +2631,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Sony
@@ -2649,7 +2649,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Sony
@@ -2667,7 +2667,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Sony
@@ -2685,7 +2685,7 @@
     name: Chrome Mobile
     version: "83.0.4103.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Sony
@@ -2703,7 +2703,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Sony
@@ -2721,7 +2721,7 @@
     name: Chrome Mobile
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Sony
@@ -2739,7 +2739,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sony
@@ -2757,7 +2757,7 @@
     name: Chrome Webview
     version: "85.0.4183.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Sony
@@ -2775,7 +2775,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Sony
@@ -2793,7 +2793,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sony
@@ -2811,7 +2811,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sony
@@ -2865,7 +2865,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Sony
@@ -2991,7 +2991,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Sony
@@ -3009,7 +3009,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Sony
@@ -3027,7 +3027,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Sony
@@ -3061,7 +3061,7 @@
     name: Chrome Mobile
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: smartphone
     brand: Sony
@@ -3079,7 +3079,7 @@
     name: Chrome Mobile
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: smartphone
     brand: Sony
@@ -3097,7 +3097,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Sony
@@ -3115,7 +3115,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Sony
@@ -3133,7 +3133,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Sony
@@ -3151,7 +3151,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Sony
@@ -3169,7 +3169,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Sony
@@ -3187,7 +3187,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Sony
@@ -3205,7 +3205,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Sony
@@ -3223,7 +3223,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Sony
@@ -3241,7 +3241,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Sony
@@ -3259,7 +3259,7 @@
     name: Chrome Webview
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Sony
@@ -3545,7 +3545,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Sony
@@ -3563,7 +3563,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Sony
@@ -3581,7 +3581,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Sony
@@ -3599,7 +3599,7 @@
     name: Chrome Mobile
     version: "36.0.1985.128"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.128"
   device:
     type: smartphone
     brand: Sony
@@ -3617,7 +3617,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Sony
@@ -3635,7 +3635,7 @@
     name: Chrome Mobile
     version: "35.0.1916.122"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.122"
   device:
     type: smartphone
     brand: Sony
@@ -3653,7 +3653,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Sony
@@ -3725,7 +3725,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Sony
@@ -3743,7 +3743,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Sony
@@ -3761,7 +3761,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Sony
@@ -3797,7 +3797,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Sony
@@ -3815,7 +3815,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Sony
@@ -3833,7 +3833,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Sony
@@ -3851,7 +3851,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Sony
@@ -3869,7 +3869,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Sony
@@ -3887,7 +3887,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Sony
@@ -4229,7 +4229,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Sony
@@ -4247,7 +4247,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Sony
@@ -4265,7 +4265,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Sony
@@ -4283,7 +4283,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Sony
@@ -4301,7 +4301,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Sony
@@ -4319,7 +4319,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Sony
@@ -4337,7 +4337,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Sony
@@ -4355,7 +4355,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Sony
@@ -4373,7 +4373,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Sony
@@ -4391,7 +4391,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Sony
@@ -4409,7 +4409,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Sony
@@ -4427,7 +4427,7 @@
     name: Chrome Webview
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Sony
@@ -4445,7 +4445,7 @@
     name: Chrome Mobile
     version: "85.0.4183.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Sony
@@ -4517,7 +4517,7 @@
     name: Chrome Mobile
     version: "33.0.1750.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.135"
   device:
     type: smartphone
     brand: Sony
@@ -4535,7 +4535,7 @@
     name: Chrome Mobile
     version: "33.0.1750.170"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.170"
   device:
     type: smartphone
     brand: Sony
@@ -4553,7 +4553,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Sony
@@ -4571,7 +4571,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Sony
@@ -4589,7 +4589,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Sony
@@ -4607,7 +4607,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Sony
@@ -4625,7 +4625,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Sony
@@ -4659,7 +4659,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Sony
@@ -4677,7 +4677,7 @@
     name: Chrome Mobile
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: smartphone
     brand: Sony
@@ -4695,7 +4695,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Sony
@@ -4713,7 +4713,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Sony
@@ -4747,7 +4747,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Sony
@@ -4765,7 +4765,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Sony
@@ -4783,7 +4783,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Sony
@@ -4801,7 +4801,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Sony
@@ -5017,7 +5017,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Sony
@@ -5053,7 +5053,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Sony
@@ -5071,7 +5071,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Sony
@@ -5197,7 +5197,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Sony
@@ -5215,7 +5215,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Sony
@@ -5341,7 +5341,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Sony
@@ -5359,7 +5359,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Sony
@@ -5377,7 +5377,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Sony
@@ -5519,7 +5519,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Sony
@@ -5537,7 +5537,7 @@
     name: Chrome Mobile
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: smartphone
     brand: Sony
@@ -5555,7 +5555,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Sony
@@ -5627,7 +5627,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Sony
@@ -5699,7 +5699,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Sony
@@ -5717,7 +5717,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Sony
@@ -5931,7 +5931,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Sony
@@ -5949,7 +5949,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Sony
@@ -5967,7 +5967,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Sony
@@ -5985,7 +5985,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Sony
@@ -6003,7 +6003,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Sony
@@ -6021,7 +6021,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Sony
@@ -6039,7 +6039,7 @@
     name: Chrome Mobile
     version: "49.0.2623.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: smartphone
     brand: Sony
@@ -6057,7 +6057,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Sony
@@ -6093,7 +6093,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Sony
@@ -6111,7 +6111,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Sony
@@ -6129,7 +6129,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Sony
@@ -6147,7 +6147,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Sony
@@ -6165,7 +6165,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Sony
@@ -6183,7 +6183,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Sony
@@ -6201,7 +6201,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Sony
@@ -6219,7 +6219,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Sony
@@ -6237,7 +6237,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Sony
@@ -6255,7 +6255,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Sony
@@ -6273,7 +6273,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Sony
@@ -6291,7 +6291,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Sony
@@ -6309,7 +6309,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Sony
@@ -6327,7 +6327,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Sony
@@ -6345,7 +6345,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Sony
@@ -6363,7 +6363,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Sony
@@ -6381,7 +6381,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Sony
@@ -6399,7 +6399,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Sony
@@ -6417,7 +6417,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Sony
@@ -6435,7 +6435,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Sony
@@ -6453,7 +6453,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Sony
@@ -6471,7 +6471,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Sony
@@ -6489,7 +6489,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Sony
@@ -6507,7 +6507,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Sony
@@ -6525,7 +6525,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Sony
@@ -6543,7 +6543,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Sony
@@ -6561,7 +6561,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Sony
@@ -6579,7 +6579,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Sony
@@ -6597,7 +6597,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Sony
@@ -6615,7 +6615,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Sony
@@ -6633,7 +6633,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Sony
@@ -6651,7 +6651,7 @@
     name: Chrome Webview
     version: "54.0.2840.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.68"
   device:
     type: smartphone
     brand: Sony
@@ -6669,7 +6669,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Sony
@@ -6687,7 +6687,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Sony
@@ -6705,7 +6705,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Sony
@@ -6723,7 +6723,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Sony
@@ -6741,7 +6741,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Sony
@@ -6759,7 +6759,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Sony
@@ -6777,7 +6777,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Sony
@@ -6795,7 +6795,7 @@
     name: Chrome Webview
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Sony
@@ -6813,7 +6813,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Sony
@@ -6831,7 +6831,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Sony
@@ -6849,7 +6849,7 @@
     name: Opera Mobile
     version: "43.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Sony
@@ -6867,7 +6867,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Sony
@@ -6885,7 +6885,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Sony
@@ -6903,7 +6903,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Sony
@@ -6921,7 +6921,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Sony
@@ -6939,7 +6939,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Sony
@@ -6957,7 +6957,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sony
@@ -6975,7 +6975,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sony
@@ -6993,7 +6993,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Sony
@@ -7011,7 +7011,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sony
@@ -7029,7 +7029,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Sony
@@ -7047,7 +7047,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Sony
@@ -7065,7 +7065,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sony
@@ -7083,7 +7083,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Sony
@@ -7101,7 +7101,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Sony
@@ -7119,7 +7119,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Sony
@@ -7137,7 +7137,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Sony
@@ -7155,7 +7155,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sony
@@ -7173,7 +7173,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sony
@@ -7191,7 +7191,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Sony
@@ -7209,7 +7209,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Sony
@@ -7227,7 +7227,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Sony
@@ -7245,7 +7245,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Sony
@@ -7263,7 +7263,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Sony
@@ -7299,7 +7299,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Sony
@@ -7369,7 +7369,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: Sony
@@ -7387,7 +7387,7 @@
     name: Chrome Mobile
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: smartphone
     brand: Sony
@@ -7405,7 +7405,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Sony
@@ -7423,7 +7423,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Sony
@@ -7459,7 +7459,7 @@
     name: Chrome Mobile
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: smartphone
     brand: Sony
@@ -7477,7 +7477,7 @@
     name: Chrome Mobile
     version: "40.0.2214.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: smartphone
     brand: Sony
@@ -7583,7 +7583,7 @@
     name: Chrome Mobile
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: smartphone
     brand: Sony
@@ -7601,7 +7601,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Sony
@@ -7619,7 +7619,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Sony
@@ -7637,7 +7637,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Sony
@@ -7655,7 +7655,7 @@
     name: Chrome Mobile
     version: "37.0.2062.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.117"
   device:
     type: smartphone
     brand: Sony
@@ -7673,7 +7673,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Sony
@@ -7691,7 +7691,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Sony
@@ -7709,7 +7709,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Sony
@@ -7727,7 +7727,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Sony
@@ -7745,7 +7745,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Sony
@@ -7781,7 +7781,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Sony
@@ -7799,7 +7799,7 @@
     name: Chrome Mobile
     version: "39.0.2171.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.59"
   device:
     type: smartphone
     brand: Sony
@@ -7817,7 +7817,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Sony
@@ -7835,7 +7835,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Sony
@@ -7853,7 +7853,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Sony
@@ -7871,7 +7871,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Sony
@@ -7889,7 +7889,7 @@
     name: Chrome Webview
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Sony
@@ -7907,7 +7907,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Sony
@@ -7925,7 +7925,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Sony
@@ -7943,7 +7943,7 @@
     name: Chrome Mobile
     version: "38.0.2125.102"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: smartphone
     brand: Sony
@@ -7961,7 +7961,7 @@
     name: Chrome Mobile
     version: "40.0.2214.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: smartphone
     brand: Sony
@@ -7979,7 +7979,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Sony
@@ -8015,7 +8015,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Sony
@@ -8033,7 +8033,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Sony
@@ -8051,7 +8051,7 @@
     name: Chrome Mobile
     version: "60.0.3112.78"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.78"
   device:
     type: smartphone
     brand: Sony
@@ -8069,7 +8069,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Sony
@@ -8087,7 +8087,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Sony
@@ -8105,7 +8105,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Sony
@@ -8123,7 +8123,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Sony
@@ -8141,7 +8141,7 @@
     name: Chrome Mobile
     version: "47.0.2526.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.76"
   device:
     type: smartphone
     brand: Sony
@@ -8159,7 +8159,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Sony
@@ -8177,7 +8177,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Sony
@@ -8195,7 +8195,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Sony
@@ -8213,7 +8213,7 @@
     name: Maxthon
     version: "4.5.10.1300"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Sony
@@ -8231,7 +8231,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Sony
@@ -8249,7 +8249,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Sony
@@ -8285,7 +8285,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Sony
@@ -8303,7 +8303,7 @@
     name: Chrome Webview
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Sony
@@ -8321,7 +8321,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Sony
@@ -8355,7 +8355,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Sony
@@ -8391,7 +8391,7 @@
     name: Chrome Mobile
     version: "30.0.1599.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.92"
   device:
     type: smartphone
     brand: Sony
@@ -8409,7 +8409,7 @@
     name: Chrome Mobile
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: smartphone
     brand: Sony
@@ -8427,7 +8427,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Sony
@@ -8445,7 +8445,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Sony
@@ -8463,7 +8463,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Sony
@@ -8481,7 +8481,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Sony
@@ -8576,7 +8576,7 @@
     name: Chrome Mobile
     version: "37.0.2062.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.117"
   device:
     type: smartphone
     brand: Spice
@@ -8612,7 +8612,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Santin
@@ -8630,7 +8630,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Santin
@@ -8648,7 +8648,7 @@
     name: Chrome Mobile
     version: "69.0.3497.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.76"
   device:
     type: smartphone
     brand: Santin
@@ -8666,7 +8666,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Santin
@@ -8684,7 +8684,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Santin
@@ -8702,7 +8702,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Santin
@@ -8720,7 +8720,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Santin
@@ -8738,7 +8738,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Santin
@@ -8756,7 +8756,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Santin
@@ -8774,7 +8774,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Santin
@@ -8792,7 +8792,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Santin
@@ -8810,7 +8810,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Santin
@@ -8828,7 +8828,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Santin
@@ -8846,7 +8846,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Santin
@@ -8864,7 +8864,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Santin
@@ -8882,7 +8882,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Santin
@@ -8900,7 +8900,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Santin
@@ -8918,7 +8918,7 @@
     name: Opera Touch
     version: "2.1"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Santin
@@ -8936,7 +8936,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Santin
@@ -8954,7 +8954,7 @@
     name: Chrome Webview
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: SWISSMOBILITY
@@ -8972,7 +8972,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: "360"
@@ -9008,7 +9008,7 @@
     name: Chrome Mobile
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: SFR
@@ -9026,7 +9026,7 @@
     name: Chrome Mobile
     version: 40.0.2214.109
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: SFR
@@ -9044,7 +9044,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: SFR
@@ -9062,7 +9062,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: SFR
@@ -9080,7 +9080,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: SFR
@@ -9098,7 +9098,7 @@
     name: Chrome Mobile
     version: 40.0.2214.109
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: SFR
@@ -9116,7 +9116,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: SFR
@@ -9134,7 +9134,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Nubia
@@ -9152,7 +9152,7 @@
     name: Chrome Webview
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Nubia
@@ -9170,7 +9170,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Nubia
@@ -9188,7 +9188,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Nubia
@@ -9206,7 +9206,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Nubia
@@ -9224,7 +9224,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Nubia
@@ -9242,7 +9242,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Nubia
@@ -9260,7 +9260,7 @@
     name: Chrome Mobile
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: smartphone
     brand: Nubia
@@ -9278,7 +9278,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Nubia
@@ -9360,7 +9360,7 @@
     name: Opera Mobile
     version: 55.1.2719.50626
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Nubia
@@ -9378,7 +9378,7 @@
     name: Opera Mobile
     version: 58.1.2878.53366
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Nubia
@@ -9414,7 +9414,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Nubia
@@ -9450,7 +9450,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: ZTE
@@ -9468,7 +9468,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: ZTE

--- a/Tests/fixtures/smartphone-15.yml
+++ b/Tests/fixtures/smartphone-15.yml
@@ -28,7 +28,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Sky
@@ -46,7 +46,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Sky
@@ -64,7 +64,7 @@
     name: Chrome
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Sky
@@ -116,7 +116,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Sky
@@ -134,7 +134,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Sky
@@ -152,7 +152,7 @@
     name: Chrome Mobile
     version: "64.0.3282.123"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: smartphone
     brand: Sky
@@ -170,7 +170,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Sky
@@ -188,7 +188,7 @@
     name: Chrome Webview
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Sky
@@ -206,7 +206,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Sky
@@ -224,7 +224,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Sky
@@ -242,7 +242,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Sky
@@ -314,7 +314,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: SFR
@@ -600,7 +600,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Trevi
@@ -654,7 +654,7 @@
     name: Chrome Mobile
     version: "79.0.3945.56"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.56"
   device:
     type: smartphone
     brand: ThL
@@ -690,7 +690,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: ThL
@@ -708,7 +708,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: ThL
@@ -780,7 +780,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Touchmate
@@ -798,7 +798,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Touchmate
@@ -816,7 +816,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Touchmate
@@ -834,7 +834,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Top House
@@ -852,7 +852,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Top House
@@ -870,7 +870,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -888,7 +888,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -906,7 +906,7 @@
     name: Chrome Webview
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -978,7 +978,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -1212,7 +1212,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -1230,7 +1230,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -1248,7 +1248,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -1403,7 +1403,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: TCL
@@ -1439,7 +1439,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: TCL
@@ -1457,7 +1457,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: TCL
@@ -1493,7 +1493,7 @@
     name: Chrome Mobile
     version: "68.0.3440.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.85"
   device:
     type: smartphone
     brand: TCL
@@ -1559,7 +1559,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: TCL
@@ -1577,7 +1577,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: TCL
@@ -1595,7 +1595,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: TCL
@@ -1613,7 +1613,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: TCL
@@ -1717,7 +1717,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: TCL
@@ -1771,7 +1771,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: TCL
@@ -1825,7 +1825,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: TCL
@@ -1861,7 +1861,7 @@
     name: Chrome Webview
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Telego
@@ -1879,7 +1879,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Telego
@@ -1897,7 +1897,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Telego
@@ -1928,7 +1928,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Telefunken
@@ -1946,7 +1946,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Telefunken
@@ -2144,7 +2144,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: T-Mobile
@@ -2162,7 +2162,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: T-Mobile
@@ -2180,7 +2180,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: T-Mobile
@@ -2234,7 +2234,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Thomson
@@ -2342,7 +2342,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Thomson
@@ -2360,7 +2360,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Thomson
@@ -2378,7 +2378,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Thomson
@@ -2396,7 +2396,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: TechPad
@@ -2414,7 +2414,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: TechPad
@@ -2432,7 +2432,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Timovi
@@ -2450,7 +2450,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Timovi
@@ -2468,7 +2468,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Timovi
@@ -2486,7 +2486,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Timovi
@@ -2504,7 +2504,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Timovi
@@ -2522,7 +2522,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Turbo-X
@@ -2540,7 +2540,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Turbo-X
@@ -2576,7 +2576,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Turbo-X
@@ -2738,7 +2738,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Tunisie Telecom
@@ -3044,7 +3044,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Tooky
@@ -3080,7 +3080,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: teXet
@@ -3098,7 +3098,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: teXet
@@ -3152,7 +3152,7 @@
     name: Opera Mobile
     version: "29.0.1809.93516"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.107"
   device:
     type: smartphone
     brand: teXet
@@ -3170,7 +3170,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: teXet
@@ -3206,7 +3206,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: teXet
@@ -3242,7 +3242,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: teXet
@@ -3260,7 +3260,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: teXet
@@ -3314,7 +3314,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: teXet
@@ -3368,7 +3368,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: teXet
@@ -3386,7 +3386,7 @@
     name: Opera Mobile
     version: "43.2.2254.140293"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: teXet
@@ -3404,7 +3404,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: teXet
@@ -3422,7 +3422,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: teXet
@@ -3458,7 +3458,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: teXet
@@ -3512,7 +3512,7 @@
     name: Chrome Mobile
     version: "60.0.3112.107"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.107"
   device:
     type: smartphone
     brand: teXet
@@ -3548,7 +3548,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: teXet
@@ -3566,7 +3566,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: teXet
@@ -3584,7 +3584,7 @@
     name: Chrome Mobile
     version: "49.0.2623.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: smartphone
     brand: teXet
@@ -3602,7 +3602,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: teXet
@@ -3638,7 +3638,7 @@
     name: Chrome Webview
     version: "69.0.3497.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: smartphone
     brand: teXet
@@ -3656,7 +3656,7 @@
     name: Chrome Webview
     version: "69.0.3497.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: smartphone
     brand: teXet
@@ -3674,7 +3674,7 @@
     name: Opera Mobile
     version: "36.2.2254.1304"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: teXet
@@ -3710,7 +3710,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: teXet
@@ -3764,7 +3764,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: teXet
@@ -3782,7 +3782,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: teXet
@@ -3800,7 +3800,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: teXet
@@ -3836,7 +3836,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: teXet
@@ -3872,7 +3872,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: teXet
@@ -3890,7 +3890,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: teXet
@@ -3908,7 +3908,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Uhans
@@ -3926,7 +3926,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Umax
@@ -3944,7 +3944,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Umax
@@ -3962,7 +3962,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Umax
@@ -3980,7 +3980,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: U.S. Cellular
@@ -3998,7 +3998,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Uhappy
@@ -4016,7 +4016,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Uhappy
@@ -4034,7 +4034,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Uhappy
@@ -4070,7 +4070,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Uhappy
@@ -4124,7 +4124,7 @@
     name: Chrome Mobile
     version: "60.0.3112.107"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.107"
   device:
     type: smartphone
     brand: Ulefone
@@ -4176,7 +4176,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Ulefone
@@ -4194,7 +4194,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Ulefone
@@ -4212,7 +4212,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Ulefone
@@ -4230,7 +4230,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Ulefone
@@ -4248,7 +4248,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Ulefone
@@ -4266,7 +4266,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Ulefone
@@ -4284,7 +4284,7 @@
     name: Chrome Mobile
     version: "84.0.4147.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Ulefone
@@ -4302,7 +4302,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Ulefone
@@ -4320,7 +4320,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Ulefone
@@ -4338,7 +4338,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Ulefone
@@ -4374,7 +4374,7 @@
     name: Chrome Mobile
     version: "48.0.2564.95"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.95"
   device:
     type: smartphone
     brand: Ulefone
@@ -4392,7 +4392,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Ulefone
@@ -4410,7 +4410,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Ulefone
@@ -4428,7 +4428,7 @@
     name: Chrome Mobile
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: smartphone
     brand: Ulefone
@@ -4446,7 +4446,7 @@
     name: Chrome
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Ulefone
@@ -4464,7 +4464,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Ulefone
@@ -4482,7 +4482,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Ulefone
@@ -4500,7 +4500,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Ulefone
@@ -4518,7 +4518,7 @@
     name: Chrome Mobile
     version: "80.0.3987.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Ulefone
@@ -4536,7 +4536,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Ulefone
@@ -4554,7 +4554,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Ulefone
@@ -4572,7 +4572,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Ulefone
@@ -4590,7 +4590,7 @@
     name: Chrome Mobile
     version: "76.0.3809.45"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.45"
   device:
     type: smartphone
     brand: Ulefone
@@ -4608,7 +4608,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Ulefone
@@ -4626,7 +4626,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Ulefone
@@ -4644,7 +4644,7 @@
     name: Chrome Webview
     version: "50.0.2661.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Ulefone
@@ -4662,7 +4662,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Ulefone
@@ -4680,7 +4680,7 @@
     name: Chrome Mobile
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -4698,7 +4698,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -4716,7 +4716,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -4734,7 +4734,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -4752,7 +4752,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -4770,7 +4770,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -4788,7 +4788,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -4806,7 +4806,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -4824,7 +4824,7 @@
     name: Chrome Mobile
     version: "60.0.3112.50"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.50"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -4842,7 +4842,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -4860,7 +4860,7 @@
     name: Chrome Mobile
     version: "81.0.4044.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -4878,7 +4878,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -4896,7 +4896,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Unnecto
@@ -4914,7 +4914,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Unnecto
@@ -4932,7 +4932,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Unnecto
@@ -4986,7 +4986,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Unnecto
@@ -5040,7 +5040,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Unnecto
@@ -5074,7 +5074,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Unnecto
@@ -5182,7 +5182,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Unonu
@@ -5200,7 +5200,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Unimax
@@ -5218,7 +5218,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Unimax
@@ -5236,7 +5236,7 @@
     name: Chrome Mobile
     version: "43.0.2357.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.92"
   device:
     type: smartphone
     brand: Unimax
@@ -5254,7 +5254,7 @@
     name: Chrome Webview
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Unimax
@@ -5290,7 +5290,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Unimax
@@ -5308,7 +5308,7 @@
     name: Chrome Webview
     version: "84.0.4147.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Unimax
@@ -5326,7 +5326,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Unihertz
@@ -5362,7 +5362,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: VKworld
@@ -5380,7 +5380,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: VKworld
@@ -5502,7 +5502,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Voto
@@ -5520,7 +5520,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Voto
@@ -5556,7 +5556,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Vonino
@@ -5574,7 +5574,7 @@
     name: Chrome Mobile
     version: "44.0.2403.133"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.133"
   device:
     type: smartphone
     brand: Vonino
@@ -5592,7 +5592,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Vonino
@@ -5610,7 +5610,7 @@
     name: Chrome Webview
     version: "53.0.2785.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: smartphone
     brand: Vonino
@@ -5628,7 +5628,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Vonino
@@ -5646,7 +5646,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Vonino
@@ -5664,7 +5664,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Vonino
@@ -5682,7 +5682,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Vonino
@@ -5700,7 +5700,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vonino
@@ -5718,7 +5718,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Vonino
@@ -5754,7 +5754,7 @@
     name: Chrome
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Vonino
@@ -5772,7 +5772,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Vinsoc
@@ -5790,7 +5790,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Vivax
@@ -5808,7 +5808,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Vivax
@@ -5826,7 +5826,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Vivax
@@ -5844,7 +5844,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Vivax
@@ -5862,7 +5862,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Vivax
@@ -5880,7 +5880,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: VGO TEL
@@ -5934,7 +5934,7 @@
     name: Opera Mobile
     version: "43.2.2254.140270"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: VGO TEL
@@ -5952,7 +5952,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Vsun
@@ -5970,7 +5970,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Vsun
@@ -5988,7 +5988,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Vsun
@@ -6096,7 +6096,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Vertu
@@ -6222,7 +6222,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Vodafone
@@ -6240,7 +6240,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Vodafone
@@ -6258,7 +6258,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Vodafone
@@ -6276,7 +6276,7 @@
     name: Chrome Mobile
     version: "43.0.2357.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.92"
   device:
     type: smartphone
     brand: Vodafone
@@ -6294,7 +6294,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Vodafone
@@ -6330,7 +6330,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Vodafone
@@ -6348,7 +6348,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Vodafone
@@ -6366,7 +6366,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Vodafone
@@ -6384,7 +6384,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Vodafone
@@ -6402,7 +6402,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Vodafone
@@ -6438,7 +6438,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Vodafone
@@ -6456,7 +6456,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Vodafone
@@ -6474,7 +6474,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Vodafone
@@ -6492,7 +6492,7 @@
     name: Chrome Mobile
     version: "48.0.2564.95"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.95"
   device:
     type: smartphone
     brand: Vodafone
@@ -6510,7 +6510,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Vodafone
@@ -6528,7 +6528,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Vodafone
@@ -6546,7 +6546,7 @@
     name: Chrome Mobile
     version: "48.0.2564.95"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.95"
   device:
     type: smartphone
     brand: Vodafone
@@ -6564,7 +6564,7 @@
     name: Chrome Mobile
     version: "40.0.2214.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: smartphone
     brand: Vodafone
@@ -6582,7 +6582,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Vodafone
@@ -6600,7 +6600,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Vodafone
@@ -6618,7 +6618,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Vodafone
@@ -6636,7 +6636,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Vodafone
@@ -6654,7 +6654,7 @@
     name: Chrome Mobile
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: smartphone
     brand: Vodafone
@@ -6672,7 +6672,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Vodafone
@@ -6690,7 +6690,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Vodafone
@@ -6708,7 +6708,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Vorago
@@ -6780,7 +6780,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: VKworld
@@ -6798,7 +6798,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: VKworld
@@ -6816,7 +6816,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: VKworld
@@ -6834,7 +6834,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: VKworld
@@ -6852,7 +6852,7 @@
     name: Chrome Mobile
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: smartphone
     brand: VKworld
@@ -6870,7 +6870,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: VKworld
@@ -6888,7 +6888,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Verykool
@@ -6922,7 +6922,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Verykool
@@ -6940,7 +6940,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Verykool
@@ -6958,7 +6958,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Verykool
@@ -6976,7 +6976,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Venso
@@ -6994,7 +6994,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Venso
@@ -7012,7 +7012,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Venso
@@ -7030,7 +7030,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Venso
@@ -7048,7 +7048,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Vernee
@@ -7066,7 +7066,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vernee
@@ -7084,7 +7084,7 @@
     name: Chrome Mobile
     version: "65.0.3325.53"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.53"
   device:
     type: smartphone
     brand: Vernee
@@ -7118,7 +7118,7 @@
     name: Yandex Browser
     version: "18.1.0.527.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.132"
   device:
     type: smartphone
     brand: Vernee
@@ -7136,7 +7136,7 @@
     name: Chrome Webview
     version: "66.0.3359.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.106"
   device:
     type: smartphone
     brand: Vernee
@@ -7208,7 +7208,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Vestel
@@ -7226,7 +7226,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Vestel
@@ -7244,7 +7244,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Vestel
@@ -7262,7 +7262,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Vestel
@@ -7280,7 +7280,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Vestel
@@ -7298,7 +7298,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Vestel
@@ -7316,7 +7316,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Vestel
@@ -7334,7 +7334,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Vestel
@@ -7352,7 +7352,7 @@
     name: Chrome Webview
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Vestel
@@ -7370,7 +7370,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Vestel
@@ -7388,7 +7388,7 @@
     name: Chrome Webview
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Vestel
@@ -7406,7 +7406,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Vulcan
@@ -7440,7 +7440,7 @@
     name: Chrome Mobile
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Vivo
@@ -7494,7 +7494,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -7512,7 +7512,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -7566,7 +7566,7 @@
     name: Chrome Webview
     version: "74.0.3729.186"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.186"
   device:
     type: smartphone
     brand: Vivo
@@ -7584,7 +7584,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -7602,7 +7602,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -7638,7 +7638,7 @@
     name: Chrome Webview
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Vivo
@@ -7656,7 +7656,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -7674,7 +7674,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -7728,7 +7728,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -7764,7 +7764,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -7800,7 +7800,7 @@
     name: Opera Mobile
     version: "43.0.2246.121183"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Vivo
@@ -7818,7 +7818,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -7836,7 +7836,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -7854,7 +7854,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Vivo
@@ -7872,7 +7872,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -7908,7 +7908,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Vivo
@@ -7926,7 +7926,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -7944,7 +7944,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -7962,7 +7962,7 @@
     name: Chrome Webview
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Vivo
@@ -7998,7 +7998,7 @@
     name: Chrome Mobile
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Vivo
@@ -8088,7 +8088,7 @@
     name: Chrome Mobile
     version: "63.0.3239.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.84"
   device:
     type: smartphone
     brand: Vivo
@@ -8124,7 +8124,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Vivo
@@ -8142,7 +8142,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Vivo
@@ -8160,7 +8160,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Vivo
@@ -8178,7 +8178,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -8196,7 +8196,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Vivo
@@ -8214,7 +8214,7 @@
     name: Chrome Mobile
     version: "38.0.2125.102"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: smartphone
     brand: Vivo
@@ -8232,7 +8232,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Vivo
@@ -8268,7 +8268,7 @@
     name: Chrome
     version: "74.0.3729.131"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.131"
   device:
     type: smartphone
     brand: Vivo
@@ -8340,7 +8340,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -8358,7 +8358,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Vivo
@@ -8376,7 +8376,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -8394,7 +8394,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Vivo
@@ -8412,7 +8412,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -8430,7 +8430,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -8448,7 +8448,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -8466,7 +8466,7 @@
     name: Chrome Mobile
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: smartphone
     brand: Vivo
@@ -8502,7 +8502,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -8520,7 +8520,7 @@
     name: Chrome Mobile
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: smartphone
     brand: Vivo
@@ -8538,7 +8538,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Vivo
@@ -8574,7 +8574,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -8610,7 +8610,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Vivo
@@ -8628,7 +8628,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -8682,7 +8682,7 @@
     name: Chrome Webview
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Vivo
@@ -8754,7 +8754,7 @@
     name: Chrome Mobile
     version: "69.0.3497.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: smartphone
     brand: Vivo
@@ -8824,7 +8824,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Vivo
@@ -8894,7 +8894,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -8912,7 +8912,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -8930,7 +8930,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -8966,7 +8966,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -8984,7 +8984,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9002,7 +9002,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9020,7 +9020,7 @@
     name: Chrome Mobile
     version: 89.0.4389.86
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.86"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9038,7 +9038,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9056,7 +9056,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9074,7 +9074,7 @@
     name: Chrome Mobile
     version: 89.0.4389.90
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.90"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9092,7 +9092,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9110,7 +9110,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9128,7 +9128,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9146,7 +9146,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9164,7 +9164,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9182,7 +9182,7 @@
     name: Chrome Webview
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9200,7 +9200,7 @@
     name: Chrome Webview
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9218,7 +9218,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9236,7 +9236,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9254,7 +9254,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Kodak
@@ -9272,7 +9272,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Mobicel

--- a/Tests/fixtures/smartphone-16.yml
+++ b/Tests/fixtures/smartphone-16.yml
@@ -10,7 +10,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Vivo
@@ -28,7 +28,7 @@
     name: Opera Mobile
     version: "54.0.2672.49578"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Vivo
@@ -118,7 +118,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Vivo
@@ -154,7 +154,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -172,7 +172,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -226,7 +226,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Vivo
@@ -244,7 +244,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Vivo
@@ -280,7 +280,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Vivo
@@ -334,7 +334,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -370,7 +370,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Vivo
@@ -424,7 +424,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Vivo
@@ -442,7 +442,7 @@
     name: Yandex Browser
     version: "9.36"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Vivo
@@ -460,7 +460,7 @@
     name: Yandex Browser
     version: "9.35"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Vivo
@@ -478,7 +478,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -496,7 +496,7 @@
     name: Yandex Browser
     version: "19.7.5.90.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Vivo
@@ -514,7 +514,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -550,7 +550,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Vivo
@@ -568,7 +568,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -604,7 +604,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Vivo
@@ -640,7 +640,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -658,7 +658,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -694,7 +694,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -730,7 +730,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -748,7 +748,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -766,7 +766,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Vivo
@@ -820,7 +820,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Vertex
@@ -838,7 +838,7 @@
     name: Chrome Webview
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Vertex
@@ -856,7 +856,7 @@
     name: Chrome Webview
     version: "42.0.2311.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.137"
   device:
     type: smartphone
     brand: Vertex
@@ -874,7 +874,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Vertex
@@ -892,7 +892,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Vertex
@@ -910,7 +910,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Vertex
@@ -928,7 +928,7 @@
     name: Chrome Mobile
     version: "69.0.3497.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: smartphone
     brand: Vertex
@@ -946,7 +946,7 @@
     name: Chrome Webview
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Vertex
@@ -964,7 +964,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Vertex
@@ -982,7 +982,7 @@
     name: Chrome Webview
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Vertex
@@ -1000,7 +1000,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vertex
@@ -1018,7 +1018,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Vertex
@@ -1036,7 +1036,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Vertex
@@ -1054,7 +1054,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Vertex
@@ -1072,7 +1072,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Vertex
@@ -1090,7 +1090,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Woo
@@ -1108,7 +1108,7 @@
     name: Yandex Browser
     version: "19.12.1.121.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.97"
   device:
     type: smartphone
     brand: Wigor
@@ -1252,7 +1252,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Walton
@@ -1270,7 +1270,7 @@
     name: Chrome Mobile
     version: "30.0.1599.82"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.82"
   device:
     type: smartphone
     brand: Walton
@@ -1306,7 +1306,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Walton
@@ -1324,7 +1324,7 @@
     name: Chrome Mobile
     version: "71.0.3578.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.98"
   device:
     type: smartphone
     brand: Walton
@@ -1342,7 +1342,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Walton
@@ -1378,7 +1378,7 @@
     name: Chrome Webview
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Walton
@@ -1396,7 +1396,7 @@
     name: Chrome Mobile
     version: "83.0.4103.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Walton
@@ -1414,7 +1414,7 @@
     name: Opera Mobile
     version: "29.0.1809.91837"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.107"
   device:
     type: smartphone
     brand: Walton
@@ -1432,7 +1432,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Walton
@@ -1450,7 +1450,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Walton
@@ -1468,7 +1468,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Walton
@@ -1486,7 +1486,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Walton
@@ -1504,7 +1504,7 @@
     name: Yandex Browser
     version: "18.11.1.979.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: smartphone
     brand: Wileyfox
@@ -1522,7 +1522,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Wileyfox
@@ -1540,7 +1540,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Wileyfox
@@ -1558,7 +1558,7 @@
     name: Yandex Browser
     version: "18.11.2.730.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: smartphone
     brand: Wileyfox
@@ -1576,7 +1576,7 @@
     name: Chrome Mobile
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Wileyfox
@@ -1594,7 +1594,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Wileyfox
@@ -1612,7 +1612,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Wileyfox
@@ -1630,7 +1630,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Wileyfox
@@ -1648,7 +1648,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Wileyfox
@@ -1666,7 +1666,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Wileyfox
@@ -1684,7 +1684,7 @@
     name: Chrome Mobile
     version: "77.0.3828.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3828.0"
   device:
     type: smartphone
     brand: Wileyfox
@@ -1702,7 +1702,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Wileyfox
@@ -1720,7 +1720,7 @@
     name: Chrome Mobile
     version: "33.0.1750.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.135"
   device:
     type: smartphone
     brand: Wolfgang
@@ -1756,7 +1756,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Wiko
@@ -1774,7 +1774,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Wiko
@@ -1792,7 +1792,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Wiko
@@ -1810,7 +1810,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Wiko
@@ -1882,7 +1882,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Wiko
@@ -1990,7 +1990,7 @@
     name: Chrome Mobile
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: smartphone
     brand: Wiko
@@ -2044,7 +2044,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Wiko
@@ -2078,7 +2078,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Wiko
@@ -2112,7 +2112,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Wiko
@@ -2130,7 +2130,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Wiko
@@ -2166,7 +2166,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Wiko
@@ -2184,7 +2184,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Wiko
@@ -2202,7 +2202,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Wiko
@@ -2220,7 +2220,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Wiko
@@ -2238,7 +2238,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Wiko
@@ -2256,7 +2256,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Wiko
@@ -2274,7 +2274,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Wiko
@@ -2292,7 +2292,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Wiko
@@ -2326,7 +2326,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Wiko
@@ -2344,7 +2344,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Wiko
@@ -2362,7 +2362,7 @@
     name: Chrome Mobile
     version: "71.0.3578.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: smartphone
     brand: Wiko
@@ -2396,7 +2396,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Wiko
@@ -2414,7 +2414,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Wiko
@@ -2432,7 +2432,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Wiko
@@ -2450,7 +2450,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Wiko
@@ -2468,7 +2468,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Wiko
@@ -2486,7 +2486,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Wiko
@@ -2538,7 +2538,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Wiko
@@ -2556,7 +2556,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Wiko
@@ -2574,7 +2574,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Wiko
@@ -2592,7 +2592,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Wiko
@@ -2610,7 +2610,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Wiko
@@ -2646,7 +2646,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Wiko
@@ -2664,7 +2664,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Wiko
@@ -2682,7 +2682,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Wiko
@@ -2700,7 +2700,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Wiko
@@ -2718,7 +2718,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Wiko
@@ -2736,7 +2736,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Wiko
@@ -2754,7 +2754,7 @@
     name: Chrome Mobile
     version: "43.0.2357.78"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.78"
   device:
     type: smartphone
     brand: Wiko
@@ -2772,7 +2772,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Wiko
@@ -2790,7 +2790,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Wiko
@@ -2824,7 +2824,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Wiko
@@ -2896,7 +2896,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Wiko
@@ -2914,7 +2914,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Wiko
@@ -2932,7 +2932,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Wiko
@@ -2950,7 +2950,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Wiko
@@ -2968,7 +2968,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Wiko
@@ -2986,7 +2986,7 @@
     name: Chrome Mobile
     version: "37.0.2062.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.117"
   device:
     type: smartphone
     brand: Wiko
@@ -3022,7 +3022,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Wiko
@@ -3040,7 +3040,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Wiko
@@ -3058,7 +3058,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Wiko
@@ -3076,7 +3076,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Wiko
@@ -3094,7 +3094,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Wiko
@@ -3112,7 +3112,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Wiko
@@ -3194,7 +3194,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Wiko
@@ -3212,7 +3212,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Wiko
@@ -3230,7 +3230,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Wiko
@@ -3248,7 +3248,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Wiko
@@ -3266,7 +3266,7 @@
     name: Chrome Mobile
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Wiko
@@ -3284,7 +3284,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Wiko
@@ -3302,7 +3302,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Wiko
@@ -3320,7 +3320,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Wiko
@@ -3338,7 +3338,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Wiko
@@ -3388,7 +3388,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Wiko
@@ -3406,7 +3406,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Wiko
@@ -3440,7 +3440,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Wiko
@@ -3458,7 +3458,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Wiko
@@ -3476,7 +3476,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Wiko
@@ -3494,7 +3494,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Wiko
@@ -3512,7 +3512,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Wiko
@@ -3530,7 +3530,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Wiko
@@ -3548,7 +3548,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Wiko
@@ -3566,7 +3566,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Wiko
@@ -3584,7 +3584,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: Wolder
@@ -3602,7 +3602,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Wolder
@@ -3620,7 +3620,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Wolder
@@ -3638,7 +3638,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Weimei
@@ -3656,7 +3656,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Wink
@@ -3674,7 +3674,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Wink
@@ -3692,7 +3692,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Wieppo
@@ -3710,7 +3710,7 @@
     name: Chrome Webview
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Wieppo
@@ -3728,7 +3728,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Wieppo
@@ -3746,7 +3746,7 @@
     name: Chrome Webview
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Winds
@@ -3764,7 +3764,7 @@
     name: Yandex Browser
     version: "15.4.2272.3842.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.118"
   device:
     type: smartphone
     brand: Wexler
@@ -3782,7 +3782,7 @@
     name: Yandex Browser
     version: "15.2.2214.3725.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.115"
   device:
     type: smartphone
     brand: Wexler
@@ -3818,7 +3818,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Safaricom
@@ -3836,7 +3836,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: X-BO
@@ -3854,7 +3854,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: X-BO
@@ -3872,7 +3872,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: X-BO
@@ -3890,7 +3890,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: X-BO
@@ -3908,7 +3908,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: X-BO
@@ -3926,7 +3926,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: X-BO
@@ -3944,7 +3944,7 @@
     name: Chrome Webview
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Xgody
@@ -3962,7 +3962,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Xiaomi
@@ -3980,7 +3980,7 @@
     name: Chrome Webview
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Xiaomi
@@ -3998,7 +3998,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4016,7 +4016,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4034,7 +4034,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4052,7 +4052,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4088,7 +4088,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4106,7 +4106,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4214,7 +4214,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4232,7 +4232,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4590,7 +4590,7 @@
     name: Chrome Mobile
     version: "32.0.1700.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.94"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4626,7 +4626,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4678,7 +4678,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4696,7 +4696,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4714,7 +4714,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4732,7 +4732,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4750,7 +4750,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4768,7 +4768,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4786,7 +4786,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4804,7 +4804,7 @@
     name: Chrome Mobile
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4822,7 +4822,7 @@
     name: Chrome Webview
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4840,7 +4840,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4858,7 +4858,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4876,7 +4876,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4912,7 +4912,7 @@
     name: Chrome Webview
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4964,7 +4964,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5000,7 +5000,7 @@
     name: Chrome Mobile
     version: "83.0.4103.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5126,7 +5126,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5144,7 +5144,7 @@
     name: Chrome Webview
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5234,7 +5234,7 @@
     name: Chrome Mobile
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5288,7 +5288,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5342,7 +5342,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5396,7 +5396,7 @@
     name: Chrome Mobile
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5466,7 +5466,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5484,7 +5484,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5502,7 +5502,7 @@
     name: Chrome Webview
     version: "84.0.4147.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5520,7 +5520,7 @@
     name: Chrome Webview
     version: "75.0.3770.156"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.156"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5538,7 +5538,7 @@
     name: Chrome Webview
     version: "85.0.4183.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5556,7 +5556,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5574,7 +5574,7 @@
     name: Chrome Webview
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Xiaolajiao
@@ -5592,7 +5592,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Xiaolajiao
@@ -5610,7 +5610,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Xiaolajiao
@@ -5628,7 +5628,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Xiaolajiao
@@ -5646,7 +5646,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Xiaolajiao
@@ -5664,7 +5664,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Xiaolajiao
@@ -5682,7 +5682,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Xiaolajiao
@@ -5718,7 +5718,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Xion
@@ -5736,7 +5736,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Xion
@@ -5754,7 +5754,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Xion
@@ -5772,7 +5772,7 @@
     name: Chrome Webview
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Xolo
@@ -5824,7 +5824,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Xolo
@@ -5878,7 +5878,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Xolo
@@ -5930,7 +5930,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Xolo
@@ -6018,7 +6018,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Xolo
@@ -6036,7 +6036,7 @@
     name: Chrome Webview
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Xoro
@@ -6054,7 +6054,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Xshitou
@@ -6072,7 +6072,7 @@
     name: Chrome Webview
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: X-TIGI
@@ -6090,7 +6090,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: X-TIGI
@@ -6108,7 +6108,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: X-TIGI
@@ -6142,7 +6142,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: X-TIGI
@@ -6160,7 +6160,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: X-View
@@ -6178,7 +6178,7 @@
     name: Chrome Webview
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Yu
@@ -6214,7 +6214,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Yu
@@ -6250,7 +6250,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Yu
@@ -6268,7 +6268,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Yu
@@ -6304,7 +6304,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Yu
@@ -6322,7 +6322,7 @@
     name: Chrome Mobile
     version: "54.0.2840.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.68"
   device:
     type: smartphone
     brand: 'Yes'
@@ -6340,7 +6340,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: 'Yes'
@@ -6394,7 +6394,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Yandex
@@ -6412,7 +6412,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Yandex
@@ -6430,7 +6430,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Yezz
@@ -6448,7 +6448,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Yezz
@@ -6466,7 +6466,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Yezz
@@ -6484,7 +6484,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Yezz
@@ -6502,7 +6502,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Yezz
@@ -6520,7 +6520,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Yezz
@@ -6538,7 +6538,7 @@
     name: Chrome Webview
     version: "50.0.2661.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Yezz
@@ -6556,7 +6556,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Yezz
@@ -6574,7 +6574,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Yezz
@@ -6592,7 +6592,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Yezz
@@ -6610,7 +6610,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Yezz
@@ -6628,7 +6628,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Yezz
@@ -6646,7 +6646,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Yezz
@@ -6664,7 +6664,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Yezz
@@ -6682,7 +6682,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Yezz
@@ -6700,7 +6700,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Yezz
@@ -6718,7 +6718,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Yezz
@@ -6736,7 +6736,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Yezz
@@ -6772,7 +6772,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Yezz
@@ -6790,7 +6790,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Yezz
@@ -6808,7 +6808,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Yota
@@ -6826,7 +6826,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Yota
@@ -6844,7 +6844,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Yota
@@ -6934,7 +6934,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Ytone
@@ -7004,7 +7004,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Yxtel
@@ -7040,7 +7040,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Yxtel
@@ -7058,7 +7058,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Avenzo
@@ -7076,7 +7076,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Avenzo
@@ -7198,7 +7198,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Zenek
@@ -7216,7 +7216,7 @@
     name: Chrome Mobile
     version: "64.0.3282.123"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: smartphone
     brand: Zenek
@@ -7234,7 +7234,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Zenek
@@ -7252,7 +7252,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Zenek
@@ -7270,7 +7270,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Zenek
@@ -7288,7 +7288,7 @@
     name: Chrome Webview
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Zen
@@ -7306,7 +7306,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Zen
@@ -7324,7 +7324,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Zen
@@ -7342,7 +7342,7 @@
     name: Chrome Webview
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Zen
@@ -7414,7 +7414,7 @@
     name: Chrome Mobile
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Zen
@@ -7432,7 +7432,7 @@
     name: Chrome Mobile
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Zen
@@ -7450,7 +7450,7 @@
     name: Chrome Webview
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Zonda
@@ -7486,7 +7486,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Zopo
@@ -7504,7 +7504,7 @@
     name: Chrome Webview
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Zopo
@@ -7522,7 +7522,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Zopo
@@ -7540,7 +7540,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Zopo
@@ -7558,7 +7558,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Zopo
@@ -7576,7 +7576,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Zopo
@@ -7594,7 +7594,7 @@
     name: Chrome Mobile
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: smartphone
     brand: Zopo
@@ -7666,7 +7666,7 @@
     name: Chrome Mobile
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Zopo
@@ -7684,7 +7684,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Zopo
@@ -7702,7 +7702,7 @@
     name: Chrome Webview
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Zopo
@@ -7792,7 +7792,7 @@
     name: Opera Mobile
     version: "27.0.1698.89115"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: smartphone
     brand: Zopo
@@ -7846,7 +7846,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Zopo
@@ -7864,7 +7864,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Zopo
@@ -7882,7 +7882,7 @@
     name: Chrome Mobile
     version: "45.0.2454.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.84"
   device:
     type: smartphone
     brand: Zopo
@@ -7918,7 +7918,7 @@
     name: Chrome Mobile
     version: "28.0.1500.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.64"
   device:
     type: smartphone
     brand: Zopo
@@ -7936,7 +7936,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Zopo
@@ -8008,7 +8008,7 @@
     name: Chrome Mobile
     version: "49.0.2623.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: smartphone
     brand: Zopo
@@ -8026,7 +8026,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Zopo
@@ -8044,7 +8044,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Zopo
@@ -8080,7 +8080,7 @@
     name: Chrome Mobile
     version: "38.0.2125.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.114"
   device:
     type: smartphone
     brand: Zopo
@@ -8098,7 +8098,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Zopo
@@ -8116,7 +8116,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Zopo
@@ -8134,7 +8134,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Zopo
@@ -8152,7 +8152,7 @@
     name: Chrome Mobile
     version: "48.0.2564.95"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.95"
   device:
     type: smartphone
     brand: Zopo
@@ -8188,7 +8188,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Zopo
@@ -8206,7 +8206,7 @@
     name: Chrome Mobile
     version: "45.0.2454.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.94"
   device:
     type: smartphone
     brand: ZYQ
@@ -8224,7 +8224,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: ZYQ
@@ -8242,7 +8242,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: ZYQ
@@ -8296,7 +8296,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: ZYQ
@@ -8368,7 +8368,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: ZYQ
@@ -8386,7 +8386,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: ZYQ
@@ -8404,7 +8404,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: ZYQ
@@ -8440,7 +8440,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: ZYQ
@@ -8458,7 +8458,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: ZYQ
@@ -8476,7 +8476,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: ZYQ
@@ -8494,7 +8494,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: ZYQ
@@ -8512,7 +8512,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: ZYQ
@@ -8530,7 +8530,7 @@
     name: Chrome Webview
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: ZYQ
@@ -8566,7 +8566,7 @@
     name: Chrome Webview
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: ZYQ
@@ -8638,7 +8638,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: ZYQ
@@ -8674,7 +8674,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: ZYQ
@@ -8692,7 +8692,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: ZYQ
@@ -8728,7 +8728,7 @@
     name: Chrome Webview
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: ZYQ
@@ -8764,7 +8764,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: ZTE
@@ -8782,7 +8782,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: ZTE
@@ -8800,7 +8800,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: ZTE
@@ -8818,7 +8818,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: ZTE
@@ -8836,7 +8836,7 @@
     name: Chrome Mobile
     version: "49.0.2623.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: smartphone
     brand: ZTE
@@ -8854,7 +8854,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: ZTE
@@ -8872,7 +8872,7 @@
     name: Chrome Webview
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: ZTE
@@ -8890,7 +8890,7 @@
     name: Chrome Mobile
     version: "84.0.4147.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: ZTE
@@ -8908,7 +8908,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: ZTE
@@ -8942,7 +8942,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: ZTE
@@ -9014,7 +9014,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: ZTE
@@ -9032,7 +9032,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Huawei
@@ -9099,7 +9099,7 @@
     name: Chrome Mobile
     version: 53.0.2785.124
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: ZTE
@@ -9117,7 +9117,7 @@
     name: Chrome Mobile
     version: 63.0.3239.107
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.107"
   device:
     type: smartphone
     brand: ZTE
@@ -9135,7 +9135,7 @@
     name: Chrome Mobile
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: ZTE
@@ -9153,7 +9153,7 @@
     name: Chrome Mobile
     version: 66.0.3359.126
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: ZTE
@@ -9171,7 +9171,7 @@
     name: Chrome Webview
     version: 33.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: ZTE
@@ -9189,7 +9189,7 @@
     name: Chrome Mobile
     version: 36.0.1985.135
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: ZTE
@@ -9207,7 +9207,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: ZTE
@@ -9225,7 +9225,7 @@
     name: Chrome Webview
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: ZTE
@@ -9243,7 +9243,7 @@
     name: Chrome Mobile
     version: 46.0.2490.76
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: ZTE
@@ -9261,7 +9261,7 @@
     name: Chrome Mobile
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: ZTE
@@ -9279,7 +9279,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: BB Mobile
@@ -9315,7 +9315,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Zuum
@@ -9387,7 +9387,7 @@
     name: Chrome Webview
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Zuum
@@ -9405,7 +9405,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Zuum
@@ -9423,7 +9423,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Zuum
@@ -9441,7 +9441,7 @@
     name: Chrome
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: Positivo BGH
@@ -9459,7 +9459,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Zuum
@@ -9477,7 +9477,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Zuum
@@ -9495,7 +9495,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Zuum
@@ -9513,7 +9513,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Zuum
@@ -9531,7 +9531,7 @@
     name: Chrome Mobile
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: ZTE
@@ -9597,7 +9597,7 @@
     name: Chrome Mobile
     version: 42.0.2311.108
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.108"
   device:
     type: smartphone
     brand: Goophone

--- a/Tests/fixtures/smartphone-17.yml
+++ b/Tests/fixtures/smartphone-17.yml
@@ -10,7 +10,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: ZTE
@@ -28,7 +28,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: ZTE
@@ -46,7 +46,7 @@
     name: Chrome Webview
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: ZTE
@@ -64,7 +64,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: ZTE
@@ -82,7 +82,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: ZTE
@@ -100,7 +100,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: ZTE
@@ -172,7 +172,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: ZTE
@@ -190,7 +190,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: ZTE
@@ -208,7 +208,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: ZTE
@@ -226,7 +226,7 @@
     name: Chrome Webview
     version: "48.0.2564.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.106"
   device:
     type: smartphone
     brand: ZTE
@@ -244,7 +244,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: ZTE
@@ -262,7 +262,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: ZTE
@@ -280,7 +280,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: ZTE
@@ -298,7 +298,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: ZTE
@@ -316,7 +316,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: ZTE
@@ -334,7 +334,7 @@
     name: Chrome Mobile
     version: "75.0.3770.67"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: smartphone
     brand: ZTE
@@ -352,7 +352,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: ZTE
@@ -370,7 +370,7 @@
     name: Chrome Mobile
     version: "63.0.3239.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.84"
   device:
     type: smartphone
     brand: ZTE
@@ -388,7 +388,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: ZTE
@@ -406,7 +406,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: ZTE
@@ -424,7 +424,7 @@
     name: Chrome Webview
     version: "50.0.2661.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: ZTE
@@ -530,7 +530,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: ZTE
@@ -548,7 +548,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: ZTE
@@ -566,7 +566,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: ZTE
@@ -584,7 +584,7 @@
     name: Chrome Webview
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: ZTE
@@ -602,7 +602,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: ZTE
@@ -620,7 +620,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: ZTE
@@ -638,7 +638,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: ZTE
@@ -656,7 +656,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: ZTE
@@ -692,7 +692,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: ZTE
@@ -710,7 +710,7 @@
     name: Chrome Mobile
     version: "49.0.2623.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: smartphone
     brand: ZTE
@@ -728,7 +728,7 @@
     name: Opera Mobile
     version: "30.0.2254.121224"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: ZTE
@@ -746,7 +746,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: ZTE
@@ -764,7 +764,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: ZTE
@@ -782,7 +782,7 @@
     name: Opera Mobile
     version: "43.0.2246.121183"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: ZTE
@@ -800,7 +800,7 @@
     name: Chrome Webview
     version: "55.0.2883.77"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.77"
   device:
     type: smartphone
     brand: ZTE
@@ -818,7 +818,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: ZTE
@@ -836,7 +836,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: ZTE
@@ -854,7 +854,7 @@
     name: Chrome Mobile
     version: "49.0.2623.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: smartphone
     brand: ZTE
@@ -872,7 +872,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: ZTE
@@ -890,7 +890,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: ZTE
@@ -908,7 +908,7 @@
     name: Chrome Webview
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: ZTE
@@ -926,7 +926,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: ZTE
@@ -994,7 +994,7 @@
     name: Chrome Webview
     version: "45.0.2454.95"
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.95"
   device:
     type: smartphone
     brand: ZTE
@@ -1012,7 +1012,7 @@
     name: Chrome Mobile
     version: "33.0.1750.170"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.170"
   device:
     type: smartphone
     brand: ZTE
@@ -1120,7 +1120,7 @@
     name: Chrome Mobile
     version: "41.0.2272.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.96"
   device:
     type: smartphone
     brand: ZTE
@@ -1138,7 +1138,7 @@
     name: Chrome Mobile
     version: "35.0.1916.122"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.122"
   device:
     type: smartphone
     brand: ZTE
@@ -1174,7 +1174,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: ZTE
@@ -1192,7 +1192,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: ZTE
@@ -1228,7 +1228,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: ZTE
@@ -1246,7 +1246,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: ZTE
@@ -1300,7 +1300,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: ZTE
@@ -1336,7 +1336,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: ZTE
@@ -1354,7 +1354,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: ZTE
@@ -1390,7 +1390,7 @@
     name: Chrome Mobile
     version: "80.0.3987.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Nubia
@@ -1408,7 +1408,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Nubia
@@ -1426,7 +1426,7 @@
     name: Chrome Webview
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Nubia
@@ -1444,7 +1444,7 @@
     name: Yandex Browser
     version: "19.9.4.104.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Nubia
@@ -1462,7 +1462,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Nubia
@@ -1480,7 +1480,7 @@
     name: Chrome Webview
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Nubia
@@ -1498,7 +1498,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Nubia
@@ -1516,7 +1516,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Nubia
@@ -1534,7 +1534,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Nubia
@@ -1588,7 +1588,7 @@
     name: Chrome Mobile
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: Nubia
@@ -1606,7 +1606,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Nubia
@@ -1642,7 +1642,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Nubia
@@ -1660,7 +1660,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Nubia
@@ -1678,7 +1678,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Nubia
@@ -1714,7 +1714,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Nubia
@@ -1732,7 +1732,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Nubia
@@ -1750,7 +1750,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Nubia
@@ -1768,7 +1768,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: ZTE
@@ -1786,7 +1786,7 @@
     name: Chrome Mobile
     version: "81.0.4044.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: ZTE
@@ -1804,7 +1804,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: ZTE
@@ -1822,7 +1822,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: ZTE
@@ -1840,7 +1840,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: ZTE
@@ -1876,7 +1876,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: ZTE
@@ -1930,7 +1930,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: ZTE
@@ -1966,7 +1966,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: ZTE
@@ -2036,7 +2036,7 @@
     name: Chrome Webview
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: ZTE
@@ -2054,7 +2054,7 @@
     name: Chrome Webview
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Ziox
@@ -2072,7 +2072,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Ziox
@@ -2090,7 +2090,7 @@
     name: Yandex Browser
     version: "19.10.1.100.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Ziox
@@ -2108,7 +2108,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: 'True'
@@ -2126,7 +2126,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: 'True'
@@ -2144,7 +2144,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: 'True'
@@ -2180,7 +2180,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: 'True'
@@ -2198,7 +2198,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: 'True'
@@ -2216,7 +2216,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Ovvi
@@ -2234,7 +2234,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: "360"
@@ -2252,7 +2252,7 @@
     name: Chrome Webview
     version: "62.0.3202.97"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.97"
   device:
     type: smartphone
     brand: "360"
@@ -2288,7 +2288,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: "360"
@@ -2306,7 +2306,7 @@
     name: Chrome Webview
     version: "55.0.2883.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.96"
   device:
     type: smartphone
     brand: "360"
@@ -2342,7 +2342,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: "360"
@@ -2378,7 +2378,7 @@
     name: Chrome Webview
     version: "81.0.4044.145"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.145"
   device:
     type: smartphone
     brand: "360"
@@ -2432,7 +2432,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: "8848"
@@ -2450,7 +2450,7 @@
     name: Chrome Webview
     version: "74.0.3729.186"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.186"
   device:
     type: smartphone
     brand: "8848"
@@ -2532,7 +2532,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Orange
@@ -2566,7 +2566,7 @@
     name: Yandex Browser
     version: "19.7.3.91.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Vivax
@@ -2584,7 +2584,7 @@
     name: Yandex Browser
     version: "19.10.1.100.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Land Rover
@@ -2602,7 +2602,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Sharp
@@ -2620,7 +2620,7 @@
     name: Chrome Mobile
     version: "85.0.4183.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: LG
@@ -2638,7 +2638,7 @@
     name: Chrome
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Lenovo
@@ -2656,7 +2656,7 @@
     name: Chrome
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: tablet
     brand: Lenovo
@@ -2674,7 +2674,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: POCO
@@ -2692,7 +2692,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: ZTE
@@ -2710,7 +2710,7 @@
     name: Chrome
     version: "85.0.4183.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Samsung
@@ -2728,7 +2728,7 @@
     name: Opera Mobile
     version: "59.1.2926.54067"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sharp
@@ -2764,7 +2764,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Sharp
@@ -2782,7 +2782,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Sharp
@@ -2800,7 +2800,7 @@
     name: Chrome Mobile
     version: "86.0.4240.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: LG
@@ -2818,7 +2818,7 @@
     name: Chrome Mobile
     version: "85.0.4183.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Sharp
@@ -2836,7 +2836,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Sharp
@@ -2854,7 +2854,7 @@
     name: Chrome Mobile
     version: "85.0.4183.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Sharp
@@ -2872,7 +2872,7 @@
     name: Chrome Mobile
     version: "85.0.4183.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: HTC
@@ -2890,7 +2890,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: ZTE
@@ -2908,7 +2908,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Sharp
@@ -2926,7 +2926,7 @@
     name: Chrome Mobile
     version: "84.0.4147.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Kyocera
@@ -2944,7 +2944,7 @@
     name: Chrome Mobile
     version: "85.0.4183.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: LG
@@ -2962,7 +2962,7 @@
     name: Chrome Mobile
     version: "85.0.4183.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: ZTE
@@ -2980,7 +2980,7 @@
     name: Chrome Mobile
     version: "86.0.4240.75"
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: smartphone
     brand: Sharp
@@ -2998,7 +2998,7 @@
     name: Chrome Mobile
     version: "86.0.4240.75"
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: smartphone
     brand: Sharp
@@ -3016,7 +3016,7 @@
     name: Chrome Mobile
     version: "86.0.4240.75"
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: smartphone
     brand: Sharp
@@ -3034,7 +3034,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: ZTE
@@ -3052,7 +3052,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Sharp
@@ -3070,7 +3070,7 @@
     name: Chrome Mobile
     version: "85.0.4183.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Sony
@@ -3088,7 +3088,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Sharp
@@ -3106,7 +3106,7 @@
     name: Chrome Mobile
     version: "84.0.4147.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Sharp
@@ -3124,7 +3124,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Ulefone
@@ -3142,7 +3142,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Sharp
@@ -3160,7 +3160,7 @@
     name: Chrome Mobile
     version: "86.0.4240.75"
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: smartphone
     brand: Sharp
@@ -3178,7 +3178,7 @@
     name: Chrome Mobile
     version: "84.0.4147.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Sharp
@@ -3196,7 +3196,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Panasonic
@@ -3214,7 +3214,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Kyocera
@@ -3232,7 +3232,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Kyocera
@@ -3250,7 +3250,7 @@
     name: Yandex Browser
     version: "9.20"
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Samsung
@@ -3300,7 +3300,7 @@
     name: Chrome Mobile
     version: "86.0.4240.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Huawei
@@ -3318,7 +3318,7 @@
     name: Yandex Browser
     version: "20.7.4.108.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
   device:
     type: smartphone
     brand: Philips
@@ -3336,7 +3336,7 @@
     name: Yandex Browser
     version: "20.7.5.84.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
   device:
     type: smartphone
     brand: Philips
@@ -3354,7 +3354,7 @@
     name: Yandex Browser
     version: "20.6.0.211.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Huawei
@@ -3372,7 +3372,7 @@
     name: Yandex Browser
     version: "20.7.5.84.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
   device:
     type: smartphone
     brand: Huawei
@@ -3390,7 +3390,7 @@
     name: Yandex Browser
     version: "20.7.2.70.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
   device:
     type: smartphone
     brand: Huawei
@@ -3408,7 +3408,7 @@
     name: Yandex Browser
     version: "20.7.5.84.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
   device:
     type: smartphone
     brand: Xiaomi
@@ -3426,7 +3426,7 @@
     name: Yandex Browser
     version: "20.7.5.84.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
   device:
     type: smartphone
     brand: Haier
@@ -3444,7 +3444,7 @@
     name: Chrome Mobile
     version: "86.0.4240.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Blackview
@@ -3462,7 +3462,7 @@
     name: Opera Mobile
     version: "43.3.2254.141404"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -3480,7 +3480,7 @@
     name: Yandex Browser
     version: "20.8.5.97.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: smartphone
     brand: Oukitel
@@ -3498,7 +3498,7 @@
     name: Yandex Browser
     version: "20.8.2.90.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: tablet
     brand: Teclast
@@ -3516,7 +3516,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Artel
@@ -3570,7 +3570,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Artel
@@ -3606,7 +3606,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Artel
@@ -3624,7 +3624,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Artel
@@ -3642,7 +3642,7 @@
     name: Aloha Browser
     version: 2.17.3
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Artel
@@ -3660,7 +3660,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Artel
@@ -3678,7 +3678,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Artel
@@ -3696,7 +3696,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Artel
@@ -3714,7 +3714,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Artel
@@ -3732,7 +3732,7 @@
     name: Chrome Mobile
     version: 39.0.2171.59
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.59"
   device:
     type: smartphone
     brand: Artel
@@ -3750,7 +3750,7 @@
     name: Chrome
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: tablet
     brand: Artel
@@ -3768,7 +3768,7 @@
     name: Chrome
     version: 36.0.1985.135
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: tablet
     brand: Artel
@@ -3786,7 +3786,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Artel
@@ -3804,7 +3804,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Artel
@@ -3822,7 +3822,7 @@
     name: Yandex Browser
     version: 20.7.5.84.00
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
   device:
     type: smartphone
     brand: Alcatel
@@ -3840,7 +3840,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Alcatel
@@ -3858,7 +3858,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Aligator
@@ -3876,7 +3876,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -3894,7 +3894,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Alcatel
@@ -3912,7 +3912,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -3930,7 +3930,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: A1
@@ -3948,7 +3948,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: OPPO
@@ -3966,7 +3966,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: A1
@@ -3984,7 +3984,7 @@
     name: Chrome Webview
     version: 80.0.3987.117
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: smartphone
     brand: CUBOT
@@ -4002,7 +4002,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Kiano
@@ -4020,7 +4020,7 @@
     name: Yandex Browser
     version: 20.7.5.84.00
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
   device:
     type: smartphone
     brand: Alcatel
@@ -4038,7 +4038,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Wiko
@@ -4056,7 +4056,7 @@
     name: Chrome Mobile
     version: 85.0.4183.120
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: smartphone
     brand: Wiko
@@ -4074,7 +4074,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Vivo
@@ -4092,7 +4092,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Vivo
@@ -4110,7 +4110,7 @@
     name: Chrome Mobile
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: smartphone
     brand: Google
@@ -4128,7 +4128,7 @@
     name: Yandex Browser
     version: 20.8.4.75.00
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: smartphone
     brand: Alcatel
@@ -4146,7 +4146,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Huawei
@@ -4182,7 +4182,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Tone
@@ -4200,7 +4200,7 @@
     name: Chrome Mobile
     version: 50.0.2661.89
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Logicom
@@ -4218,7 +4218,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Swisstone
@@ -4236,7 +4236,7 @@
     name: Opera Mobile
     version: 37.1.2254.132401
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Swisstone
@@ -4254,7 +4254,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Blu
@@ -4272,7 +4272,7 @@
     name: Microsoft Edge
     version: 45.02.2.4931
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: ZTE
@@ -4290,7 +4290,7 @@
     name: Chrome
     version: 69.0.3497.86
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.86"
   device:
     type: tablet
     brand: RCA Tablets
@@ -4308,7 +4308,7 @@
     name: Yandex Browser
     version: "7.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: tablet
     brand: Digma
@@ -4326,7 +4326,7 @@
     name: Chrome Mobile
     version: 74.0.3729.112
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: smartphone
     brand: Huawei
@@ -4344,7 +4344,7 @@
     name: Chrome Mobile
     version: 86.0.4240.42
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.42"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4362,7 +4362,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: FireFly Mobile
@@ -4380,7 +4380,7 @@
     name: Chrome Webview
     version: 44.0.2403.119
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: FireFly Mobile
@@ -4398,7 +4398,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: FireFly Mobile
@@ -4434,7 +4434,7 @@
     name: Yandex Browser
     version: "20.85.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4452,7 +4452,7 @@
     name: Chrome Mobile
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: phablet
     brand: Xiaomi
@@ -4470,7 +4470,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -4488,7 +4488,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4506,7 +4506,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4524,7 +4524,7 @@
     name: Chrome
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tv
     brand: Transpeed
@@ -4542,7 +4542,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Realme
@@ -4560,7 +4560,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Realme
@@ -4578,7 +4578,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Realme
@@ -4596,7 +4596,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Sharp
@@ -4614,7 +4614,7 @@
     name: Yandex Browser
     version: 20.8.3.71.00
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: smartphone
     brand: Huawei
@@ -4632,7 +4632,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Casper
@@ -4650,7 +4650,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Blu
@@ -4668,7 +4668,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Sony
@@ -4686,7 +4686,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Asus
@@ -4704,7 +4704,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: phablet
     brand: Samsung
@@ -4722,7 +4722,7 @@
     name: Chrome Webview
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Fujitsu
@@ -4740,7 +4740,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Sharp
@@ -4758,7 +4758,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Sony
@@ -4776,7 +4776,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Sony
@@ -4794,7 +4794,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Sharp
@@ -4812,7 +4812,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sharp
@@ -4830,7 +4830,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Sony
@@ -4848,7 +4848,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: OPPO
@@ -4866,7 +4866,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: LG
@@ -4884,7 +4884,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Sharp
@@ -4902,7 +4902,7 @@
     name: Chrome
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: tablet
     brand: LG
@@ -4920,7 +4920,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sharp
@@ -4938,7 +4938,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: phablet
     brand: P-UP
@@ -4956,7 +4956,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: LG
@@ -4974,7 +4974,7 @@
     name: Chrome Webview
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Kyocera
@@ -4992,7 +4992,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Sharp
@@ -5010,7 +5010,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Unihertz
@@ -5028,7 +5028,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Runbo
@@ -5046,7 +5046,7 @@
     name: Chrome Mobile
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Fero
@@ -5064,7 +5064,7 @@
     name: Chrome Mobile
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Fero
@@ -5082,7 +5082,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Fero
@@ -5100,7 +5100,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -5118,7 +5118,7 @@
     name: Chrome Mobile
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -5136,7 +5136,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -5172,7 +5172,7 @@
     name: Chrome Webview
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Samsung
@@ -5190,7 +5190,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Sharp
@@ -5208,7 +5208,7 @@
     name: Yandex Browser
     version: "20.91.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Huawei
@@ -5226,7 +5226,7 @@
     name: Yandex Browser
     version: 20.9.2.95.00
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Philips
@@ -5244,7 +5244,7 @@
     name: Chrome Mobile
     version: 86.0.4240.114
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.114"
   device:
     type: smartphone
     brand: Motorola
@@ -5262,7 +5262,7 @@
     name: Opera Mobile
     version: 60.3.3004.55692
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: ZTE
@@ -5280,7 +5280,7 @@
     name: Chrome Webview
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Kyocera
@@ -5298,7 +5298,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Sony
@@ -5316,7 +5316,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: portable media player
     brand: Sony
@@ -5334,7 +5334,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Fujitsu
@@ -5352,7 +5352,7 @@
     name: Chrome Webview
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Fujitsu
@@ -5370,7 +5370,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Fujitsu
@@ -5406,7 +5406,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Asus
@@ -5424,7 +5424,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: iVooMi
@@ -5460,7 +5460,7 @@
     name: Yandex Browser
     version: 20.4.5.63.00
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Asus
@@ -5478,7 +5478,7 @@
     name: Yandex Browser
     version: 20.2.2.128.01
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.117"
   device:
     type: smartphone
     brand: Huawei
@@ -5496,7 +5496,7 @@
     name: Yandex Browser
     version: 20.6.0.211.01
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Huawei
@@ -5514,7 +5514,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: OnePlus
@@ -5532,7 +5532,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: OnePlus
@@ -5550,7 +5550,7 @@
     name: Chrome Mobile
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: smartphone
     brand: OnePlus
@@ -5568,7 +5568,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Huawei
@@ -5586,7 +5586,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: 'Krüger&Matz'
@@ -5604,7 +5604,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: CUBOT
@@ -5622,7 +5622,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5640,7 +5640,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5658,7 +5658,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5676,7 +5676,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5694,7 +5694,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: OnePlus
@@ -5712,7 +5712,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: OnePlus
@@ -5730,7 +5730,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: OnePlus
@@ -5748,7 +5748,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Huawei
@@ -5766,7 +5766,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Realme
@@ -5784,7 +5784,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Realme
@@ -5802,7 +5802,7 @@
     name: Opera Mobile
     version: 60.2.3004.55409
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Realme
@@ -5820,7 +5820,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Realme
@@ -5838,7 +5838,7 @@
     name: Chrome Webview
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Realme
@@ -5856,7 +5856,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Sony
@@ -5874,7 +5874,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Sony
@@ -5892,7 +5892,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Sony
@@ -5910,7 +5910,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: Sony
@@ -5928,7 +5928,7 @@
     name: Opera Mobile
     version: 60.0.3004.55063
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Sony
@@ -5946,7 +5946,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Sony
@@ -5964,7 +5964,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Sony
@@ -5982,7 +5982,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Blu
@@ -6000,7 +6000,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: RCA Tablets
@@ -6018,7 +6018,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: RoverPad
@@ -6036,7 +6036,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Pixelphone
@@ -6070,7 +6070,7 @@
     name: Chrome
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: Alcatel
@@ -6106,7 +6106,7 @@
     name: Chrome Mobile
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: LG
@@ -6124,7 +6124,7 @@
     name: Chrome Mobile
     version: 59.0.3071.125
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -6142,7 +6142,7 @@
     name: Chrome
     version: 59.0.3071.125
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Vivax
@@ -6160,7 +6160,7 @@
     name: Chrome Mobile
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: InnJoo
@@ -6196,7 +6196,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Logicom
@@ -6214,7 +6214,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: LeEco
@@ -6232,7 +6232,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: LeEco
@@ -6250,7 +6250,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Logicom
@@ -6268,7 +6268,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Logicom
@@ -6286,7 +6286,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Motorola
@@ -6304,7 +6304,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Motorola
@@ -6322,7 +6322,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Elephone
@@ -6340,7 +6340,7 @@
     name: Chrome Mobile
     version: 75.0.3770.67
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: smartphone
     brand: Huawei
@@ -6358,7 +6358,7 @@
     name: Chrome Mobile
     version: 75.0.3770.89
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Huawei
@@ -6376,7 +6376,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: AIS
@@ -6394,7 +6394,7 @@
     name: Opera Mobile
     version: 44.0.2254.140702
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: teXet
@@ -6412,7 +6412,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Jinga
@@ -6430,7 +6430,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: DEXP
@@ -6448,7 +6448,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: DEXP
@@ -6466,7 +6466,7 @@
     name: Yandex Browser
     version: 20.7.5.84.00
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
   device:
     type: smartphone
     brand: bq
@@ -6484,7 +6484,7 @@
     name: Yandex Browser
     version: 20.7.5.84.00
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
   device:
     type: smartphone
     brand: bq
@@ -6502,7 +6502,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Highscreen
@@ -6664,7 +6664,7 @@
     name: Yandex Browser
     version: 20.7.0.101.00
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
   device:
     type: smartphone
     brand: bq
@@ -6682,7 +6682,7 @@
     name: Yandex Browser
     version: "20.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
   device:
     type: smartphone
     brand: bq
@@ -6700,7 +6700,7 @@
     name: Yandex Browser
     version: 20.7.5.84.00
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
   device:
     type: smartphone
     brand: bq
@@ -6718,7 +6718,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Huawei
@@ -6736,7 +6736,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Aligator
@@ -6754,7 +6754,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Aligator
@@ -6772,7 +6772,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Condor
@@ -6790,7 +6790,7 @@
     name: Opera
     version: 43.3.2254.141404
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: DEXP
@@ -6808,7 +6808,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Bush
@@ -6826,7 +6826,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Huawei
@@ -6844,7 +6844,7 @@
     name: Chrome Mobile
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: smartphone
     brand: Asus
@@ -6862,7 +6862,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Realme
@@ -6880,7 +6880,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Alcatel
@@ -6898,7 +6898,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Alcatel
@@ -6916,7 +6916,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Alcatel
@@ -6934,7 +6934,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Alcatel
@@ -6952,7 +6952,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Alcatel
@@ -6970,7 +6970,7 @@
     name: Chrome Webview
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Unihertz
@@ -6988,7 +6988,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Huawei
@@ -7006,7 +7006,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Aligator
@@ -7024,7 +7024,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Fonos
@@ -7042,7 +7042,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: NOA
@@ -7060,7 +7060,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Maxtron
@@ -7078,7 +7078,7 @@
     name: Opera Mobile
     version: 51.0.2254.150807
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Oukitel
@@ -7096,7 +7096,7 @@
     name: Opera Mobile
     version: 52.1.2254.54298
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Oukitel
@@ -7114,7 +7114,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Oukitel
@@ -7132,7 +7132,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Oukitel
@@ -7150,7 +7150,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Lenovo
@@ -7168,7 +7168,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Irbis
@@ -7186,7 +7186,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Huawei
@@ -7204,7 +7204,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Pixus
@@ -7222,7 +7222,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tv
     brand: Xiaomi
@@ -7240,7 +7240,7 @@
     name: Chrome
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: tv
     brand: Invin
@@ -7258,7 +7258,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: bq
@@ -7276,7 +7276,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: bq
@@ -7294,7 +7294,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: bq
@@ -7312,7 +7312,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Black Fox
@@ -7330,7 +7330,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Ulefone
@@ -7348,7 +7348,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Ulefone
@@ -7366,7 +7366,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: DEXP
@@ -7384,7 +7384,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: DEXP
@@ -7402,7 +7402,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Alcatel
@@ -7420,7 +7420,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Alcatel
@@ -7438,7 +7438,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Alcatel
@@ -7456,7 +7456,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Ark
@@ -7474,7 +7474,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Wiko
@@ -7492,7 +7492,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Vestel
@@ -7510,7 +7510,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Odys
@@ -7528,7 +7528,7 @@
     name: Chrome Webview
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Conquest
@@ -7546,7 +7546,7 @@
     name: Chrome Webview
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Conquest
@@ -7564,7 +7564,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Conquest
@@ -7582,7 +7582,7 @@
     name: Chrome Mobile
     version: 86.0.4240.114
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.114"
   device:
     type: smartphone
     brand: Conquest
@@ -7636,7 +7636,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Conquest
@@ -7654,7 +7654,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Acer
@@ -7672,7 +7672,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Oukitel
@@ -7690,7 +7690,7 @@
     name: Chrome Mobile
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: smartphone
     brand: Coolpad
@@ -7708,7 +7708,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Coolpad
@@ -7726,7 +7726,7 @@
     name: Chrome
     version: 86.0.4240.114
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.114"
   device:
     type: tv
     brand: Kivi
@@ -7744,7 +7744,7 @@
     name: Chrome Webview
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Xtouch
@@ -7762,7 +7762,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Vertex
@@ -7780,7 +7780,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Vertex
@@ -7798,7 +7798,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Multilaser
@@ -7816,7 +7816,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: bq
@@ -7834,7 +7834,7 @@
     name: Opera Mobile
     version: 60.2.3004.55409
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Blackview
@@ -7852,7 +7852,7 @@
     name: Yandex Browser
     version: 20.93.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Haier
@@ -7870,7 +7870,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Nomu
@@ -7888,7 +7888,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Asus
@@ -7906,7 +7906,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Nomi
@@ -7924,7 +7924,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: EvroMedia
@@ -7942,7 +7942,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Vestel
@@ -7960,7 +7960,7 @@
     name: Chrome Mobile
     version: 85.0.4183.120
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: smartphone
     brand: Vestel
@@ -7978,7 +7978,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Vestel
@@ -7996,7 +7996,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Pixus
@@ -8014,7 +8014,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Pixus
@@ -8032,7 +8032,7 @@
     name: Chrome Mobile
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Prestigio
@@ -8050,7 +8050,7 @@
     name: Chrome Mobile
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Qumo
@@ -8068,7 +8068,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Qumo
@@ -8086,7 +8086,7 @@
     name: Opera Mobile
     version: 50.3.2426.136976
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Qumo
@@ -8104,7 +8104,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Qumo
@@ -8122,7 +8122,7 @@
     name: Chrome Mobile
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Qumo
@@ -8140,7 +8140,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Qumo
@@ -8158,7 +8158,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Qumo
@@ -8176,7 +8176,7 @@
     name: Yandex Browser
     version: 18.11.1.1011.01
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: tablet
     brand: Qumo
@@ -8194,7 +8194,7 @@
     name: Chrome
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tablet
     brand: RoverPad
@@ -8212,7 +8212,7 @@
     name: Chrome Mobile
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Gigabyte
@@ -8230,7 +8230,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Wexler
@@ -8248,7 +8248,7 @@
     name: Yandex Browser
     version: 18.11.1.1011.01
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: tablet
     brand: BB Mobile
@@ -8266,7 +8266,7 @@
     name: Yandex Browser
     version: 15.12.1.6403.01
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.86"
   device:
     type: tablet
     brand: BB Mobile
@@ -8284,7 +8284,7 @@
     name: Yandex Browser
     version: 18.11.1.1011.01
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: tablet
     brand: Oysters
@@ -8302,7 +8302,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Huawei
@@ -8320,7 +8320,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Wiko
@@ -8338,7 +8338,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Ramos
@@ -8356,7 +8356,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Blu
@@ -8374,7 +8374,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Wiko
@@ -8392,7 +8392,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Wiko
@@ -8410,7 +8410,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Wiko
@@ -8428,7 +8428,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Wiko
@@ -8446,7 +8446,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Wiko
@@ -8482,7 +8482,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Wieppo
@@ -8500,7 +8500,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Jinga
@@ -8518,7 +8518,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Zatec
@@ -8536,7 +8536,7 @@
     name: Chrome Mobile
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Zatec
@@ -8554,7 +8554,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -8572,7 +8572,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: LeEco
@@ -8590,7 +8590,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: LeEco
@@ -8626,7 +8626,7 @@
     name: Opera Mobile
     version: 60.2.3004.55409
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Leagoo
@@ -8644,7 +8644,7 @@
     name: Opera
     version: 60.2.3004.55409
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: desktop
     brand: Asus
@@ -8662,7 +8662,7 @@
     name: Chrome Webview
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: desktop
     brand: Asus
@@ -8680,7 +8680,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Blackview
@@ -8698,7 +8698,7 @@
     name: Yandex Browser
     version: 20.93.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Philips
@@ -8716,7 +8716,7 @@
     name: Yandex Browser
     version: 20.9.1.66.00
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Doogee
@@ -8734,7 +8734,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Doogee
@@ -8752,7 +8752,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Doogee
@@ -8770,7 +8770,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Doogee
@@ -8788,7 +8788,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Lenovo
@@ -8806,7 +8806,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Doogee
@@ -8824,7 +8824,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tv
     brand: Selenga
@@ -8842,7 +8842,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tv
     brand: Selenga
@@ -8860,7 +8860,7 @@
     name: Chrome
     version: 75.0.3770.67
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: tv
     brand: Selenga
@@ -8878,7 +8878,7 @@
     name: Yandex Browser
     version: "9.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: DEXP
@@ -8896,7 +8896,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Lenovo
@@ -8914,7 +8914,7 @@
     name: Opera Mobile
     version: 60.3.3004.55692
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Oukitel
@@ -8932,7 +8932,7 @@
     name: Opera Mobile
     version: 60.2.3004.55409
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Evolveo
@@ -8950,7 +8950,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Bravis
@@ -8968,7 +8968,7 @@
     name: Chrome Webview
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Gigabyte
@@ -8986,7 +8986,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Gigabyte
@@ -9004,7 +9004,7 @@
     name: Chrome Webview
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Navon
@@ -9022,7 +9022,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: MTC
@@ -9040,7 +9040,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Digma
@@ -9058,7 +9058,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Digma
@@ -9076,7 +9076,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Digma
@@ -9094,7 +9094,7 @@
     name: Chrome Webview
     version: 85.0.4183.120
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: smartphone
     brand: Digma
@@ -9112,7 +9112,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Digma
@@ -9130,7 +9130,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Digma
@@ -9148,7 +9148,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Digma
@@ -9166,7 +9166,7 @@
     name: Chrome Webview
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Digma
@@ -9184,7 +9184,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Digma
@@ -9202,7 +9202,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Conquest
@@ -9220,7 +9220,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -9238,7 +9238,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -9256,7 +9256,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -9274,7 +9274,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: MyPhone
@@ -9292,7 +9292,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: MyPhone
@@ -9310,7 +9310,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: LG
@@ -9328,7 +9328,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Huawei
@@ -9346,7 +9346,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tv
     brand: NEXON
@@ -9364,7 +9364,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: ONN
@@ -9382,7 +9382,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: AllDocube
@@ -9400,7 +9400,7 @@
     name: Opera
     version: 60.2.3004.55409
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tv
     brand: Vinga
@@ -9418,7 +9418,7 @@
     name: Chrome Webview
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tv
     brand: Vinga
@@ -9436,7 +9436,7 @@
     name: Yandex Browser
     version: 20.93.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: bq
@@ -9454,7 +9454,7 @@
     name: Yandex Browser
     version: 20.92.1
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: bq
@@ -9472,7 +9472,7 @@
     name: Yandex Browser
     version: 20.91.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Digma
@@ -9490,7 +9490,7 @@
     name: Yandex Browser
     version: 20.91.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: MTC
@@ -9508,7 +9508,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Haier
@@ -9526,7 +9526,7 @@
     name: Yandex Browser
     version: 20.91.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: MAXVI
@@ -9544,7 +9544,7 @@
     name: Yandex Browser
     version: 20.90.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.121"
   device:
     type: smartphone
     brand: MAXVI
@@ -9562,7 +9562,7 @@
     name: Yandex Browser
     version: 20.90.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.121"
   device:
     type: smartphone
     brand: teXet
@@ -9580,7 +9580,7 @@
     name: Yandex Browser
     version: 20.90.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.121"
   device:
     type: smartphone
     brand: teXet
@@ -9598,7 +9598,7 @@
     name: Yandex Browser
     version: 20.92.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: teXet
@@ -9616,7 +9616,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: teXet
@@ -9634,7 +9634,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: teXet
@@ -9652,7 +9652,7 @@
     name: Yandex Browser
     version: "8.70"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: teXet
@@ -9670,7 +9670,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Starlight
@@ -9688,7 +9688,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Starlight
@@ -9706,7 +9706,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Starlight
@@ -9724,7 +9724,7 @@
     name: Chrome Mobile
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Coolpad
@@ -9742,7 +9742,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Sony
@@ -9760,7 +9760,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Vivo
@@ -9778,7 +9778,7 @@
     name: Chrome
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: MiXzo
@@ -9796,7 +9796,7 @@
     name: Chrome Webview
     version: 71.0.3578.141
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.141"
   device:
     type: smartphone
     brand: Xiaomi
@@ -9814,7 +9814,7 @@
     name: Chrome Webview
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Manta Multimedia
@@ -9832,7 +9832,7 @@
     name: Chrome
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: DEXP
@@ -9850,7 +9850,7 @@
     name: Chrome Webview
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: RugGear
@@ -9868,7 +9868,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -9886,7 +9886,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Vernee
@@ -9922,7 +9922,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Karbonn

--- a/Tests/fixtures/smartphone-18.yml
+++ b/Tests/fixtures/smartphone-18.yml
@@ -10,7 +10,7 @@
     name: Opera Mobile
     version: "52.0.2517.139457"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Samsung
@@ -64,7 +64,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Samsung
@@ -82,7 +82,7 @@
     name: Yandex Browser
     version: "20.2.0.215.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.117"
   device:
     type: smartphone
     brand: Samsung
@@ -100,7 +100,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Samsung
@@ -136,7 +136,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Samsung
@@ -172,7 +172,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Samsung
@@ -190,7 +190,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Samsung
@@ -208,7 +208,7 @@
     name: Chrome
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Samsung
@@ -226,7 +226,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Samsung
@@ -244,7 +244,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Samsung
@@ -262,7 +262,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Samsung
@@ -280,7 +280,7 @@
     name: Chrome
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Samsung
@@ -298,7 +298,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: phablet
     brand: Samsung
@@ -316,7 +316,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: phablet
     brand: Samsung
@@ -334,7 +334,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: phablet
     brand: Samsung
@@ -352,7 +352,7 @@
     name: Chrome Mobile
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: phablet
     brand: Samsung
@@ -370,7 +370,7 @@
     name: Chrome Mobile
     version: "83.0.4103.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: phablet
     brand: Samsung
@@ -388,7 +388,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Samsung
@@ -406,7 +406,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Samsung
@@ -424,7 +424,7 @@
     name: Yandex Browser
     version: "19.3.3.285.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: phablet
     brand: Samsung
@@ -442,7 +442,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Samsung
@@ -478,7 +478,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Samsung
@@ -496,7 +496,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Samsung
@@ -514,7 +514,7 @@
     name: Chrome
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: tablet
     brand: Samsung
@@ -532,7 +532,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: phablet
     brand: Samsung
@@ -568,7 +568,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Samsung
@@ -586,7 +586,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -604,7 +604,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Samsung
@@ -622,7 +622,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: phablet
     brand: Samsung
@@ -640,7 +640,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Samsung
@@ -658,7 +658,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -676,7 +676,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Samsung
@@ -694,7 +694,7 @@
     name: Chrome Mobile
     version: "81.0.4044.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: Samsung
@@ -730,7 +730,7 @@
     name: Chrome
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Samsung
@@ -748,7 +748,7 @@
     name: Chrome
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Samsung
@@ -766,7 +766,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -784,7 +784,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tv
     brand: Soundmax
@@ -802,7 +802,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Samsung
@@ -820,7 +820,7 @@
     name: Chrome
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: Samsung
@@ -838,7 +838,7 @@
     name: Chrome
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Samsung
@@ -856,7 +856,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Samsung
@@ -874,7 +874,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -892,7 +892,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: phablet
     brand: Samsung
@@ -910,7 +910,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Samsung
@@ -946,7 +946,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Samsung
@@ -964,7 +964,7 @@
     name: Chrome Mobile
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: smartphone
     brand: Samsung
@@ -982,7 +982,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Samsung
@@ -1000,7 +1000,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Samsung
@@ -1072,7 +1072,7 @@
     name: Chrome
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Samsung
@@ -1090,7 +1090,7 @@
     name: Chrome
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Samsung
@@ -1108,7 +1108,7 @@
     name: Chrome
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: tablet
     brand: Samsung
@@ -1126,7 +1126,7 @@
     name: Chrome
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Samsung
@@ -1144,7 +1144,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Samsung
@@ -1162,7 +1162,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Panasonic
@@ -1180,7 +1180,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Panasonic
@@ -1198,7 +1198,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Samsung
@@ -1216,7 +1216,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: phablet
     brand: Samsung
@@ -1234,7 +1234,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Samsung
@@ -1252,7 +1252,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: OPPO
@@ -1270,7 +1270,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: OPPO
@@ -1288,7 +1288,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: OPPO
@@ -1306,7 +1306,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: OPPO
@@ -1324,7 +1324,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: OPPO
@@ -1342,7 +1342,7 @@
     name: Chrome Webview
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Ziox
@@ -1360,7 +1360,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: bq
@@ -1378,7 +1378,7 @@
     name: Chrome
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Alcor
@@ -1396,7 +1396,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Luna
@@ -1414,7 +1414,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Irbis
@@ -1432,7 +1432,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Irbis
@@ -1450,7 +1450,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Irbis
@@ -1468,7 +1468,7 @@
     name: Chrome
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: Irbis
@@ -1486,7 +1486,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Irbis
@@ -1504,7 +1504,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Irbis
@@ -1522,7 +1522,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Irbis
@@ -1540,7 +1540,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: iBrit
@@ -1558,7 +1558,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: iBrit
@@ -1576,7 +1576,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: iBrit
@@ -1594,7 +1594,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: iBrit
@@ -1612,7 +1612,7 @@
     name: Chrome
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: Odys
@@ -1630,7 +1630,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: iPro
@@ -1648,7 +1648,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Ovvi
@@ -1666,7 +1666,7 @@
     name: Chrome Mobile
     version: "79.0.3945.56"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.56"
   device:
     type: smartphone
     brand: ThL
@@ -1684,7 +1684,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: iTel
@@ -1702,7 +1702,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: iTel
@@ -1720,7 +1720,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Highscreen
@@ -1738,7 +1738,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Highscreen
@@ -1756,7 +1756,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: AllCall
@@ -1774,7 +1774,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Ginzzu
@@ -1792,7 +1792,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Fero
@@ -1810,7 +1810,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Fero
@@ -1828,7 +1828,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Sony
@@ -1846,7 +1846,7 @@
     name: Chrome
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Sony
@@ -1864,7 +1864,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Sony
@@ -1882,7 +1882,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Sony
@@ -1900,7 +1900,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: phablet
     brand: Sony
@@ -1918,7 +1918,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Sony
@@ -1936,7 +1936,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Sony
@@ -1954,7 +1954,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Sony
@@ -1972,7 +1972,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Sony
@@ -1990,7 +1990,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Sony
@@ -2008,7 +2008,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: OPPO
@@ -2026,7 +2026,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: InnJoo
@@ -2044,7 +2044,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: InnJoo
@@ -2062,7 +2062,7 @@
     name: Chrome Webview
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: InnJoo
@@ -2080,7 +2080,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: InnJoo
@@ -2098,7 +2098,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: InnJoo
@@ -2134,7 +2134,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: InnJoo
@@ -2152,7 +2152,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: InnJoo
@@ -2170,7 +2170,7 @@
     name: Chrome Webview
     version: "48.0.2564.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.106"
   device:
     type: smartphone
     brand: InnJoo
@@ -2188,7 +2188,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: InnJoo
@@ -2206,7 +2206,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: InnJoo
@@ -2224,7 +2224,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: InnJoo
@@ -2242,7 +2242,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Jinga
@@ -2260,7 +2260,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Cube
@@ -2278,7 +2278,7 @@
     name: Chrome
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: Cube
@@ -2296,7 +2296,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Cube
@@ -2314,7 +2314,7 @@
     name: Chrome
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Cube
@@ -2332,7 +2332,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Cube
@@ -2350,7 +2350,7 @@
     name: Chrome
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Cube
@@ -2368,7 +2368,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Cube
@@ -2386,7 +2386,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: ZTE
@@ -2440,7 +2440,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Realme
@@ -2458,7 +2458,7 @@
     name: Chrome Webview
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -2476,7 +2476,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -2512,7 +2512,7 @@
     name: Chrome Mobile
     version: "84.0.4147.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: X-TIGI
@@ -2530,7 +2530,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: OPPO
@@ -2566,7 +2566,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Meitu
@@ -2584,7 +2584,7 @@
     name: Chrome Webview
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: OPPO
@@ -2602,7 +2602,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Luna
@@ -2638,7 +2638,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Asus
@@ -2656,7 +2656,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: CUBOT
@@ -2674,7 +2674,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Hotwav
@@ -2692,7 +2692,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Nextbit
@@ -2710,7 +2710,7 @@
     name: Chrome
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: Transpeed
@@ -2728,7 +2728,7 @@
     name: Chrome
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tv
     brand: Transpeed
@@ -2746,7 +2746,7 @@
     name: Chrome
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tv
     brand: Transpeed
@@ -2800,7 +2800,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Anry
@@ -2818,7 +2818,7 @@
     name: Chrome
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: Anry
@@ -2836,7 +2836,7 @@
     name: Chrome Webview
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Chuwi
@@ -2854,7 +2854,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: desktop
     brand: Chuwi
@@ -2872,7 +2872,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Chuwi
@@ -2890,7 +2890,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Chuwi
@@ -2908,7 +2908,7 @@
     name: Chrome
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Chuwi
@@ -2926,7 +2926,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Chuwi
@@ -2944,7 +2944,7 @@
     name: Chrome Webview
     version: "58.0.3029.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.125"
   device:
     type: tablet
     brand: AllDocube
@@ -2962,7 +2962,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: phablet
     brand: Hisense
@@ -2980,7 +2980,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Asus
@@ -2998,7 +2998,7 @@
     name: Chrome Webview
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Hisense
@@ -3016,7 +3016,7 @@
     name: Chrome Webview
     version: "56.0.2924.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.116"
   device:
     type: smartphone
     brand: Coolpad
@@ -3034,7 +3034,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Hisense
@@ -3052,7 +3052,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Hisense
@@ -3070,7 +3070,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Hisense
@@ -3088,7 +3088,7 @@
     name: Chrome Webview
     version: "48.0.2564.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.116"
   device:
     type: smartphone
     brand: Hisense
@@ -3106,7 +3106,7 @@
     name: Chrome Webview
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Hisense
@@ -3124,7 +3124,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Hisense
@@ -3214,7 +3214,7 @@
     name: Chrome Webview
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Hisense
@@ -3250,7 +3250,7 @@
     name: Chrome Webview
     version: "48.0.2564.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.116"
   device:
     type: smartphone
     brand: Hisense
@@ -3304,7 +3304,7 @@
     name: Chrome Webview
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Vivo
@@ -3322,7 +3322,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -3340,7 +3340,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -3358,7 +3358,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -3376,7 +3376,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -3394,7 +3394,7 @@
     name: Chrome Webview
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Melrose
@@ -3412,7 +3412,7 @@
     name: Chrome Webview
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Realme
@@ -3430,7 +3430,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Realme
@@ -3448,7 +3448,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Realme
@@ -3482,7 +3482,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: "360"
@@ -3500,7 +3500,7 @@
     name: Microsoft Edge
     version: "45.07.4.5057"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Sony
@@ -3518,7 +3518,7 @@
     name: Chrome Webview
     version: "52.0.2743.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: smartphone
     brand: Coolpad
@@ -3536,7 +3536,7 @@
     name: Chrome Webview
     version: "75.0.3770.156"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.156"
   device:
     type: smartphone
     brand: Huawei
@@ -3572,7 +3572,7 @@
     name: Chrome Webview
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: OPPO
@@ -3590,7 +3590,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: OPPO
@@ -3608,7 +3608,7 @@
     name: Chrome Webview
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: OPPO
@@ -3626,7 +3626,7 @@
     name: Chrome Webview
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: OPPO
@@ -3644,7 +3644,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: "8848"
@@ -3698,7 +3698,7 @@
     name: Chrome Webview
     version: "74.0.3729.186"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.186"
   device:
     type: smartphone
     brand: "8848"
@@ -3716,7 +3716,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -3734,7 +3734,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: VVETIME
@@ -3752,7 +3752,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Gionee
@@ -3770,7 +3770,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Gome
@@ -3788,7 +3788,7 @@
     name: Chrome Mobile
     version: "85.0.4183.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Sony
@@ -3806,7 +3806,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Xiaomi
@@ -3824,7 +3824,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Asus
@@ -3842,7 +3842,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Sony
@@ -3860,7 +3860,7 @@
     name: Chrome Mobile
     version: "85.0.4183.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Fujitsu
@@ -3878,7 +3878,7 @@
     name: Chrome Mobile
     version: "85.0.4183.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Sharp
@@ -3896,7 +3896,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Sharp
@@ -3914,7 +3914,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Samsung
@@ -3932,7 +3932,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Samsung
@@ -3950,7 +3950,7 @@
     name: Chrome Mobile
     version: "84.0.4147.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Sony
@@ -3968,7 +3968,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Kyocera
@@ -3986,7 +3986,7 @@
     name: Chrome Mobile
     version: "84.0.4147.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Sharp
@@ -4004,7 +4004,7 @@
     name: Chrome Mobile
     version: "84.0.4147.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Fujitsu
@@ -4022,7 +4022,7 @@
     name: Chrome
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Kyocera
@@ -4040,7 +4040,7 @@
     name: Chrome Mobile
     version: "85.0.4183.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Fujitsu
@@ -4058,7 +4058,7 @@
     name: Chrome Mobile
     version: "86.0.4240.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Huawei
@@ -4076,7 +4076,7 @@
     name: Chrome Mobile
     version: "85.0.4183.120"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: smartphone
     brand: Huawei
@@ -4094,7 +4094,7 @@
     name: Chrome Mobile
     version: "86.0.4240.75"
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: smartphone
     brand: Huawei
@@ -4112,7 +4112,7 @@
     name: Chrome Mobile
     version: "83.0.4103.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: LG
@@ -4130,7 +4130,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sony
@@ -4148,7 +4148,7 @@
     name: Chrome
     version: "85.0.4183.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Kyocera
@@ -4166,7 +4166,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Kyocera
@@ -4184,7 +4184,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Kyocera
@@ -4202,7 +4202,7 @@
     name: Chrome Mobile
     version: "85.0.4183.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Kyocera
@@ -4220,7 +4220,7 @@
     name: Chrome Mobile
     version: "85.0.4183.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Kyocera
@@ -4238,7 +4238,7 @@
     name: Chrome Mobile
     version: "86.0.4240.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: phablet
     brand: Samsung
@@ -4256,7 +4256,7 @@
     name: Chrome Mobile
     version: "85.0.4183.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Huawei
@@ -4274,7 +4274,7 @@
     name: Chrome Mobile
     version: "84.0.4147.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Sharp
@@ -4292,7 +4292,7 @@
     name: Chrome Mobile
     version: "86.0.4240.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4310,7 +4310,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4328,7 +4328,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Huawei
@@ -4346,7 +4346,7 @@
     name: Chrome Mobile
     version: "85.0.4183.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Huawei
@@ -4364,7 +4364,7 @@
     name: Chrome Mobile
     version: "84.0.4147.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Huawei
@@ -4382,7 +4382,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Huawei
@@ -4400,7 +4400,7 @@
     name: Chrome
     version: 85.0.4183.120
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: tablet
     brand: Huawei
@@ -4418,7 +4418,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Asus
@@ -4436,7 +4436,7 @@
     name: Chrome Mobile
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: smartphone
     brand: Asus
@@ -4454,7 +4454,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Pixus
@@ -4472,7 +4472,7 @@
     name: Aloha Browser
     version: 2.20.3
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Oukitel
@@ -4490,7 +4490,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Asus
@@ -4508,7 +4508,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Huawei
@@ -4526,7 +4526,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Iris
@@ -4544,7 +4544,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Iris
@@ -4562,7 +4562,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Iris
@@ -4580,7 +4580,7 @@
     name: Chrome Mobile
     version: 66.0.3359.126
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Iris
@@ -4598,7 +4598,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Iris
@@ -4616,7 +4616,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Vivax
@@ -4634,7 +4634,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Oukitel
@@ -4670,7 +4670,7 @@
     name: Opera Mobile
     version: 50.0.2254.149182
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Neffos
@@ -4796,7 +4796,7 @@
     name: Chrome
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tv
     brand: Atom
@@ -4814,7 +4814,7 @@
     name: Chrome Webview
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: MiXzo
@@ -4832,7 +4832,7 @@
     name: Chrome Webview
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Vivo
@@ -4850,7 +4850,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Karbonn
@@ -4868,7 +4868,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Coolpad
@@ -4886,7 +4886,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Karbonn
@@ -4904,7 +4904,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Karbonn
@@ -4922,7 +4922,7 @@
     name: Chrome Webview
     version: 42.0.2311.137
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.137"
   device:
     type: smartphone
     brand: Karbonn
@@ -4940,7 +4940,7 @@
     name: Chrome Mobile
     version: 36.0.1985.135
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Karbonn
@@ -4958,7 +4958,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Karbonn
@@ -4976,7 +4976,7 @@
     name: Chrome Mobile
     version: 47.0.2526.83
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Karbonn
@@ -4994,7 +4994,7 @@
     name: Chrome Mobile
     version: 40.0.2214.109
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Karbonn
@@ -5012,7 +5012,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Karbonn
@@ -5048,7 +5048,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Karbonn
@@ -5066,7 +5066,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Karbonn
@@ -5084,7 +5084,7 @@
     name: Chrome Mobile
     version: 50.0.2661.89
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Karbonn
@@ -5102,7 +5102,7 @@
     name: Yandex Browser
     version: 20.93.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Digma
@@ -5120,7 +5120,7 @@
     name: Chrome Webview
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Yu
@@ -5156,7 +5156,7 @@
     name: Yandex Browser
     version: 20.93.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: DEXP
@@ -5174,7 +5174,7 @@
     name: Yandex Browser
     version: 20.93.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Irbis
@@ -5192,7 +5192,7 @@
     name: Chrome Mobile
     version: 49.0.2623.105
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: smartphone
     brand: OPPO
@@ -5210,7 +5210,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: DEXP
@@ -5246,7 +5246,7 @@
     name: Chrome Webview
     version: 69.0.3497.109
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.109"
   device:
     type: tablet
     brand: Lenovo
@@ -5264,7 +5264,7 @@
     name: Chrome
     version: 30.0.1599.92
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.92"
   device:
     type: tablet
     brand: Onda
@@ -5282,7 +5282,7 @@
     name: Chrome Webview
     version: 45.0.2454.87
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.87"
   device:
     type: smartphone
     brand: Asus
@@ -5300,7 +5300,7 @@
     name: Chrome
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: GEOFOX
@@ -5336,7 +5336,7 @@
     name: Opera
     version: 50.3.2426.136976
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Telefunken
@@ -5372,7 +5372,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Telefunken
@@ -5390,7 +5390,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Telefunken
@@ -5408,7 +5408,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Telefunken
@@ -5426,7 +5426,7 @@
     name: Opera Mobile
     version: 50.3.2426.136976
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Telefunken
@@ -5444,7 +5444,7 @@
     name: Yandex Browser
     version: 18.11.1.1011.00
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: smartphone
     brand: Telefunken
@@ -5462,7 +5462,7 @@
     name: Chrome
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tablet
     brand: Telefunken
@@ -5480,7 +5480,7 @@
     name: Opera Mobile
     version: 50.3.2426.136976
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: teXet
@@ -5498,7 +5498,7 @@
     name: Opera Mobile
     version: 50.3.2426.136976
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: teXet
@@ -5570,7 +5570,7 @@
     name: Chrome
     version: 40.0.2214.89
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: tv
     brand: IconBIT
@@ -5588,7 +5588,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Polaroid
@@ -5606,7 +5606,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: BB Mobile
@@ -5624,7 +5624,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: BB Mobile
@@ -5642,7 +5642,7 @@
     name: Chrome Webview
     version: 38.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.0.0"
   device:
     type: smartphone
     brand: Lenovo
@@ -5660,7 +5660,7 @@
     name: Chrome
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Allview
@@ -5678,7 +5678,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Allview
@@ -5696,7 +5696,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Doogee
@@ -5714,7 +5714,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Tinmo
@@ -5732,7 +5732,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Tinmo
@@ -5750,7 +5750,7 @@
     name: Chrome
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tablet
     brand: Touchmate
@@ -5768,7 +5768,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tablet
     brand: Touchmate
@@ -5786,7 +5786,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: ArmPhone
@@ -5804,7 +5804,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tablet
     brand: Matrix
@@ -5822,7 +5822,7 @@
     name: Chrome Webview
     version: 73.0.3683.121
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.121"
   device:
     type: smartphone
     brand: Coolpad
@@ -5840,7 +5840,7 @@
     name: Opera
     version: 50.3.2426.136976
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Memup
@@ -5858,7 +5858,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Kazam
@@ -5876,7 +5876,7 @@
     name: Chrome
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Digma
@@ -5894,7 +5894,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Digma
@@ -5912,7 +5912,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Digma
@@ -5930,7 +5930,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Digma
@@ -5966,7 +5966,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: ZTE
@@ -5984,7 +5984,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Odys
@@ -6002,7 +6002,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Ginzzu
@@ -6020,7 +6020,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Ginzzu
@@ -6038,7 +6038,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Ginzzu
@@ -6056,7 +6056,7 @@
     name: Chrome Mobile
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: smartphone
     brand: Jinga
@@ -6074,7 +6074,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Jinga
@@ -6092,7 +6092,7 @@
     name: Chrome
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: iLife
@@ -6110,7 +6110,7 @@
     name: Yandex Browser
     version: 18.11.1.1011.00
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: smartphone
     brand: DEXP
@@ -6128,7 +6128,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Jinga
@@ -6146,7 +6146,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Mobicel
@@ -6164,7 +6164,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Blu
@@ -6182,7 +6182,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Ginzzu
@@ -6200,7 +6200,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Ginzzu
@@ -6218,7 +6218,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Ginzzu
@@ -6236,7 +6236,7 @@
     name: Yandex Browser
     version: "9.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Sharp
@@ -6254,7 +6254,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Blaupunkt
@@ -6272,7 +6272,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Doogee
@@ -6290,7 +6290,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Doogee
@@ -6308,7 +6308,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: IconBIT
@@ -6326,7 +6326,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: IconBIT
@@ -6344,7 +6344,7 @@
     name: Chrome Webview
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: Mio
@@ -6362,7 +6362,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: TTEC
@@ -6380,7 +6380,7 @@
     name: Chrome Webview
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: TTEC
@@ -6398,7 +6398,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: TTEC
@@ -6416,7 +6416,7 @@
     name: Chrome
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: eSTAR
@@ -6434,7 +6434,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: eSTAR
@@ -6452,7 +6452,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: eSTAR
@@ -6470,7 +6470,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: eSTAR
@@ -6488,7 +6488,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: eSTAR
@@ -6506,7 +6506,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: eSTAR
@@ -6524,7 +6524,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: eSTAR
@@ -6542,7 +6542,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: eSTAR
@@ -6560,7 +6560,7 @@
     name: Chrome
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: eSTAR
@@ -6578,7 +6578,7 @@
     name: Chrome
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: eSTAR
@@ -6596,7 +6596,7 @@
     name: Chrome
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tablet
     brand: eSTAR
@@ -6614,7 +6614,7 @@
     name: Chrome
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: eSTAR
@@ -6632,7 +6632,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: eSTAR
@@ -6650,7 +6650,7 @@
     name: Chrome
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: eSTAR
@@ -6668,7 +6668,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: eSTAR
@@ -6686,7 +6686,7 @@
     name: Chrome Webview
     version: 43.0.2357.121
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: tablet
     brand: eSTAR
@@ -6704,7 +6704,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: Evolveo
@@ -6722,7 +6722,7 @@
     name: Chrome
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: tv
     brand: Ergo
@@ -6740,7 +6740,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6758,7 +6758,7 @@
     name: Chrome
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: Alcatel
@@ -6776,7 +6776,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Wiko
@@ -6794,7 +6794,7 @@
     name: Chrome
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: EXO
@@ -6830,7 +6830,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Evolveo
@@ -6848,7 +6848,7 @@
     name: Chrome
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Ergo
@@ -6866,7 +6866,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Sencor
@@ -6884,7 +6884,7 @@
     name: Opera
     version: 54.3.2672.50220
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Easypix
@@ -6902,7 +6902,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: BenQ
@@ -6920,7 +6920,7 @@
     name: Chrome Webview
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Hometech
@@ -6938,7 +6938,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Hometech
@@ -6956,7 +6956,7 @@
     name: Chrome Webview
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Hometech
@@ -6974,7 +6974,7 @@
     name: Chrome
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Hometech
@@ -6992,7 +6992,7 @@
     name: Chrome
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: iGet
@@ -7010,7 +7010,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: iGet
@@ -7028,7 +7028,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: ExMobile
@@ -7064,7 +7064,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Jiayu
@@ -7082,7 +7082,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: DEXP
@@ -7100,7 +7100,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Alcatel
@@ -7118,7 +7118,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: iBall
@@ -7136,7 +7136,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Coolpad
@@ -7154,7 +7154,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Sharp
@@ -7172,7 +7172,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Sharp
@@ -7190,7 +7190,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: Kyocera
@@ -7208,7 +7208,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Hipstreet
@@ -7226,7 +7226,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Cloudpad
@@ -7244,7 +7244,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Cloudpad
@@ -7262,7 +7262,7 @@
     name: Yandex Browser
     version: "8.05"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Vertex
@@ -7280,7 +7280,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Vertex
@@ -7298,7 +7298,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -7316,7 +7316,7 @@
     name: Chrome Webview
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Lava
@@ -7334,7 +7334,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Klipad
@@ -7352,7 +7352,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Klipad
@@ -7370,7 +7370,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Klipad
@@ -7388,7 +7388,7 @@
     name: Chrome
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: tablet
     brand: Klipad
@@ -7406,7 +7406,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Lephone
@@ -7424,7 +7424,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tv
     brand: Mystery
@@ -7442,7 +7442,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tv
     brand: NEXON
@@ -7460,7 +7460,7 @@
     name: Chrome
     version: 73.0.3683.75
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.75"
   device:
     type: tablet
     brand: Navitech
@@ -7514,7 +7514,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Navitech
@@ -7550,7 +7550,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Navitech
@@ -7568,7 +7568,7 @@
     name: Chrome Webview
     version: 33.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: Navitech
@@ -7586,7 +7586,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Navitech
@@ -7638,7 +7638,7 @@
     name: Chrome Webview
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Odys
@@ -7656,7 +7656,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: MyPhone
@@ -7674,7 +7674,7 @@
     name: Chrome
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: tablet
     brand: NorthTech
@@ -7692,7 +7692,7 @@
     name: Chrome
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Odys
@@ -7728,7 +7728,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -7746,7 +7746,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Mediacom
@@ -7764,7 +7764,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Mediacom
@@ -7782,7 +7782,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Mediacom
@@ -7800,7 +7800,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Mediacom
@@ -7818,7 +7818,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Mediacom
@@ -7836,7 +7836,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Mediacom
@@ -7854,7 +7854,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Jinga
@@ -7872,7 +7872,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: MyPhone
@@ -7890,7 +7890,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Vsun
@@ -7908,7 +7908,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: NextBook
@@ -7926,7 +7926,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: NextBook
@@ -7944,7 +7944,7 @@
     name: Chrome
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: NextBook
@@ -7962,7 +7962,7 @@
     name: Chrome
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: tablet
     brand: SWISSMOBILITY
@@ -7980,7 +7980,7 @@
     name: Chrome
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: tablet
     brand: SWISSMOBILITY
@@ -7998,7 +7998,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: SWISSMOBILITY
@@ -8016,7 +8016,7 @@
     name: Chrome
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: SWISSMOBILITY
@@ -8034,7 +8034,7 @@
     name: Chrome
     version: 80.0.3987.117
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: tablet
     brand: SWISSMOBILITY
@@ -8052,7 +8052,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Symphony
@@ -8070,7 +8070,7 @@
     name: Chrome
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tv
     brand: Zidoo
@@ -8088,7 +8088,7 @@
     name: Chrome Webview
     version: 49.0.2623.105
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: tablet
     brand: Odys
@@ -8106,7 +8106,7 @@
     name: Chrome
     version: 75.0.3770.16
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.16"
   device:
     type: tablet
     brand: Odys
@@ -8124,7 +8124,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Odys
@@ -8143,7 +8143,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Danew
@@ -8161,7 +8161,7 @@
     name: Yandex Browser
     version: "7.52"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: bq
@@ -8179,7 +8179,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8197,7 +8197,7 @@
     name: Chrome
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tv
     brand: Vinga
@@ -8215,7 +8215,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Highscreen
@@ -8233,7 +8233,7 @@
     name: Chrome Webview
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: UNIWA
@@ -8251,7 +8251,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: TCL
@@ -8269,7 +8269,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Bravis
@@ -8287,7 +8287,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Vertex
@@ -8305,7 +8305,7 @@
     name: Chrome
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tv
     brand: MTC
@@ -8323,7 +8323,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Zopo
@@ -8341,7 +8341,7 @@
     name: Chrome
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: tablet
     brand: Digma
@@ -8359,7 +8359,7 @@
     name: Chrome Webview
     version: 54.0.2840.85
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: tablet
     brand: MiXzo
@@ -8377,7 +8377,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Celkon
@@ -8395,7 +8395,7 @@
     name: Yandex Browser
     version: 20.94.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: DEXP
@@ -8413,7 +8413,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Highscreen
@@ -8431,7 +8431,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: MyPhone
@@ -8449,7 +8449,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: MyPhone
@@ -8467,7 +8467,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: MyPhone
@@ -8485,7 +8485,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: MyPhone
@@ -8503,7 +8503,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: MyPhone
@@ -8521,7 +8521,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Nomu
@@ -8539,7 +8539,7 @@
     name: Chrome Mobile
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Oukitel
@@ -8557,7 +8557,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Oukitel
@@ -8575,7 +8575,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tv
     brand: OzoneHD
@@ -8593,7 +8593,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Wiko
@@ -8611,7 +8611,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Wiko
@@ -8629,7 +8629,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Wiko
@@ -8647,7 +8647,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Wiko
@@ -8665,7 +8665,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Wiko
@@ -8683,7 +8683,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Wiko
@@ -8701,7 +8701,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Wiko
@@ -8719,7 +8719,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Wiko
@@ -8737,7 +8737,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Wiko
@@ -8755,7 +8755,7 @@
     name: Hawk Quick Browser
     version: 2.4.21.22910
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: General Mobile
@@ -8773,7 +8773,7 @@
     name: Hawk Quick Browser
     version: 1.1.8
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: General Mobile
@@ -8791,7 +8791,7 @@
     name: Hawk Quick Browser
     version: 1.1.8
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Vestel
@@ -8809,7 +8809,7 @@
     name: Chrome Webview
     version: 43.0.2357.65
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.65"
   device:
     type: smartphone
     brand: Vestel
@@ -8827,7 +8827,7 @@
     name: Hawk Quick Browser
     version: 2.4.18.22855
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: FORME
@@ -8845,7 +8845,7 @@
     name: Chrome Webview
     version: 53.0.2785.135
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.135"
   device:
     type: smartphone
     brand: General Mobile
@@ -8863,7 +8863,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Vernee
@@ -8881,7 +8881,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Vernee
@@ -8899,7 +8899,7 @@
     name: Chrome
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: desktop
     brand: Acer
@@ -8917,7 +8917,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: desktop
     brand: Acer
@@ -8935,7 +8935,7 @@
     name: Chrome
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tv
     brand: Andowl
@@ -8953,7 +8953,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tv
     brand: Andowl
@@ -8971,7 +8971,7 @@
     name: Chrome Mobile
     version: 75.0.3770.89
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Blackview
@@ -8989,7 +8989,7 @@
     name: Chrome Webview
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Highscreen
@@ -9007,7 +9007,7 @@
     name: Chrome
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tv
     brand: Atom
@@ -9025,7 +9025,7 @@
     name: Chrome
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: tablet
     brand: X-View
@@ -9043,7 +9043,7 @@
     name: Chrome
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: X-View
@@ -9061,7 +9061,7 @@
     name: Chrome
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: X-View
@@ -9079,7 +9079,7 @@
     name: Chrome
     version: 75.0.3770.89
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: tv
     brand: Rombica
@@ -9097,7 +9097,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: Rombica
@@ -9115,7 +9115,7 @@
     name: Chrome
     version: 77.0.3865.73
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: tv
     brand: Rombica
@@ -9133,7 +9133,7 @@
     name: Chrome
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tv
     brand: Rombica
@@ -9151,7 +9151,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Huawei
@@ -9169,7 +9169,7 @@
     name: Chrome
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: tablet
     brand: Sencor
@@ -9187,7 +9187,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Hyundai
@@ -9205,7 +9205,7 @@
     name: Chrome
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: tv
     brand: Silelis
@@ -9223,7 +9223,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Sugar
@@ -9241,7 +9241,7 @@
     name: Chrome Mobile
     version: 85.0.4183.120
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: smartphone
     brand: Sugar
@@ -9259,7 +9259,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Huawei
@@ -9277,7 +9277,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: TCL
@@ -9295,7 +9295,7 @@
     name: Chrome Mobile
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Condor
@@ -9313,7 +9313,7 @@
     name: Chrome Mobile
     version: 61.0.3163.140
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.140"
   device:
     type: tablet
     brand: PocketBook
@@ -9331,7 +9331,7 @@
     name: Chrome Mobile
     version: 61.0.3163.140
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.140"
   device:
     type: tablet
     brand: PocketBook
@@ -9349,7 +9349,7 @@
     name: Chrome Mobile
     version: 65.0.3325.230
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.230"
   device:
     type: tablet
     brand: PocketBook
@@ -9367,7 +9367,7 @@
     name: Chrome Mobile
     version: 65.0.3325.230
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.230"
   device:
     type: tablet
     brand: PocketBook
@@ -9385,7 +9385,7 @@
     name: Chrome Mobile
     version: 65.0.3325.230
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.230"
   device:
     type: tablet
     brand: PocketBook
@@ -9403,7 +9403,7 @@
     name: Chrome Mobile
     version: 65.0.3325.230
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.230"
   device:
     type: tablet
     brand: PocketBook
@@ -9421,7 +9421,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Sharp
@@ -9439,7 +9439,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Sharp
@@ -9457,7 +9457,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Lenovo
@@ -9475,7 +9475,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Lenovo
@@ -9493,7 +9493,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Sharp
@@ -9511,7 +9511,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Xiaomi
@@ -9529,7 +9529,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -9547,7 +9547,7 @@
     name: Chrome Webview
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Fujitsu
@@ -9565,7 +9565,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Sharp
@@ -9601,7 +9601,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Kyocera
@@ -9619,7 +9619,7 @@
     name: Chrome Webview
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Sony
@@ -9655,7 +9655,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Ainol
@@ -9673,7 +9673,7 @@
     name: Chrome
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Ainol
@@ -9691,7 +9691,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Sugar
@@ -9709,7 +9709,7 @@
     name: Chrome Webview
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: LG
@@ -9727,7 +9727,7 @@
     name: Chrome
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: tablet
     brand: NEC
@@ -9779,7 +9779,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Sharp

--- a/Tests/fixtures/smartphone-19.yml
+++ b/Tests/fixtures/smartphone-19.yml
@@ -10,7 +10,7 @@
     name: Chrome Webview
     version: 33.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Sharp
@@ -28,7 +28,7 @@
     name: Chrome Webview
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Sharp
@@ -46,7 +46,7 @@
     name: Chrome Webview
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Kyocera
@@ -64,7 +64,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Sony
@@ -82,7 +82,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: OnePlus
@@ -118,7 +118,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Sharp
@@ -136,7 +136,7 @@
     name: Chrome
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: Chuwi
@@ -154,7 +154,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Rakuten
@@ -172,7 +172,7 @@
     name: Chrome Webview
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Fujitsu
@@ -190,7 +190,7 @@
     name: Chrome
     version: 53.0.2785.124
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: tablet
     brand: NEC
@@ -208,7 +208,7 @@
     name: Chrome Webview
     version: 67.0.3396.127
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.127"
   device:
     type: smartphone
     brand: Fujitsu
@@ -226,7 +226,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Fujitsu
@@ -244,7 +244,7 @@
     name: Chrome
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: tablet
     brand: NEC
@@ -280,7 +280,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: NEC
@@ -298,7 +298,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: NEC
@@ -316,7 +316,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: TCL
@@ -334,7 +334,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Alcatel
@@ -352,7 +352,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: NEC
@@ -370,7 +370,7 @@
     name: Chrome Mobile
     version: 38.0.2125.102
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: smartphone
     brand: Lenovo
@@ -388,7 +388,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Lenovo
@@ -406,7 +406,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Polaroid
@@ -424,7 +424,7 @@
     name: Chrome
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: Polaroid
@@ -442,7 +442,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: phablet
     brand: Mediacom
@@ -460,7 +460,7 @@
     name: Chrome Webview
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Mediacom
@@ -478,7 +478,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Mediacom
@@ -496,7 +496,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Mediacom
@@ -514,7 +514,7 @@
     name: Chrome
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Mediacom
@@ -532,7 +532,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Mediacom
@@ -550,7 +550,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: ZTE
@@ -568,7 +568,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Highscreen
@@ -586,7 +586,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Echo Mobiles
@@ -604,7 +604,7 @@
     name: Opera Mobile
     version: 51.0.2254.150807
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Leagoo
@@ -622,7 +622,7 @@
     name: Opera
     version: 51.0.2254.150807
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Chuwi
@@ -640,7 +640,7 @@
     name: Opera
     version: 51.0.2254.150807
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Irbis
@@ -676,7 +676,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Oukitel
@@ -694,7 +694,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Oukitel
@@ -712,7 +712,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Oukitel
@@ -730,7 +730,7 @@
     name: Chrome Webview
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Hyundai
@@ -748,7 +748,7 @@
     name: Chrome Webview
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: tablet
     brand: Bluedot
@@ -766,7 +766,7 @@
     name: Chrome Webview
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -784,7 +784,7 @@
     name: Chrome
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: Nvidia
@@ -802,7 +802,7 @@
     name: Chrome Mobile
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Sharp
@@ -820,7 +820,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Sharp
@@ -838,7 +838,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: tablet
     brand: Planet Computers
@@ -856,7 +856,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Lenovo
@@ -874,7 +874,7 @@
     name: Chrome
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: tablet
     brand: NEC
@@ -892,7 +892,7 @@
     name: Chrome Webview
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Sharp
@@ -910,7 +910,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: NEC
@@ -928,7 +928,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Reach
@@ -946,7 +946,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Reach
@@ -964,7 +964,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Reach
@@ -982,7 +982,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Reach
@@ -1000,7 +1000,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Reach
@@ -1018,7 +1018,7 @@
     name: Huawei Browser Mobile
     version: 11.0.3.304
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Huawei
@@ -1036,7 +1036,7 @@
     name: Huawei Browser Mobile
     version: 10.0.2.331
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: Huawei
@@ -1054,7 +1054,7 @@
     name: Huawei Browser Mobile
     version: 11.0.4.300
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Huawei
@@ -1072,7 +1072,7 @@
     name: Huawei Browser Mobile
     version: 11.0.3.304
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Huawei
@@ -1090,7 +1090,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: MobiWire
@@ -1108,7 +1108,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: MobiWire
@@ -1126,7 +1126,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: MobiWire
@@ -1144,7 +1144,7 @@
     name: Chrome Webview
     version: 58.0.3029.125
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.125"
   device:
     type: wearable
     brand: ELARI
@@ -1162,7 +1162,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: MobiWire
@@ -1180,7 +1180,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: MobiWire
@@ -1198,7 +1198,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: MobiWire
@@ -1216,7 +1216,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: MobiWire
@@ -1234,7 +1234,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: MobiWire
@@ -1252,7 +1252,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: MobiWire
@@ -1270,7 +1270,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: MobiWire
@@ -1288,7 +1288,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: MobiWire
@@ -1306,7 +1306,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: MobiWire
@@ -1324,7 +1324,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Starmobile
@@ -1342,7 +1342,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Starmobile
@@ -1360,7 +1360,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -1378,7 +1378,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Inco
@@ -1396,7 +1396,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Inco
@@ -1414,7 +1414,7 @@
     name: Chrome
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Inco
@@ -1432,7 +1432,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: TechPad
@@ -1450,7 +1450,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: TechPad
@@ -1468,7 +1468,7 @@
     name: Chrome
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: TechPad
@@ -1486,7 +1486,7 @@
     name: Chrome
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: TechPad
@@ -1522,7 +1522,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: TechPad
@@ -1540,7 +1540,7 @@
     name: Chrome
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: ONN
@@ -1558,7 +1558,7 @@
     name: Chrome
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tablet
     brand: ONN
@@ -1576,7 +1576,7 @@
     name: Chrome
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: ONN
@@ -1594,7 +1594,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: ONN
@@ -1612,7 +1612,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Sony
@@ -1630,7 +1630,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: LG
@@ -1648,7 +1648,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tv
     brand: 4ife
@@ -1666,7 +1666,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: RCA Tablets
@@ -1684,7 +1684,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: RCA Tablets
@@ -1702,7 +1702,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: RCA Tablets
@@ -1720,7 +1720,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: RCA Tablets
@@ -1738,7 +1738,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: RCA Tablets
@@ -1756,7 +1756,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: RCA Tablets
@@ -1774,7 +1774,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: RCA Tablets
@@ -1792,7 +1792,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: Hyundai
@@ -1810,7 +1810,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Hyundai
@@ -1828,7 +1828,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Vulcan
@@ -1846,7 +1846,7 @@
     name: Chrome
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: tablet
     brand: Hyundai
@@ -1864,7 +1864,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Hezire
@@ -1882,7 +1882,7 @@
     name: Chrome
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: tablet
     brand: Hometech
@@ -1900,7 +1900,7 @@
     name: Chrome
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tablet
     brand: Hometech
@@ -1918,7 +1918,7 @@
     name: Chrome Mobile
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Huawei
@@ -1936,7 +1936,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Hurricane
@@ -1954,7 +1954,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Hurricane
@@ -1972,7 +1972,7 @@
     name: Chrome Mobile
     version: 60.0.3112.116
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Hurricane
@@ -1990,7 +1990,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Hurricane
@@ -2008,7 +2008,7 @@
     name: Chrome Mobile
     version: 85.0.4183.120
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: tablet
     brand: Hoozo
@@ -2026,7 +2026,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: Lanix
@@ -2044,7 +2044,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Lanix
@@ -2062,7 +2062,7 @@
     name: Chrome
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: tablet
     brand: Lanix
@@ -2080,7 +2080,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Lanix
@@ -2098,7 +2098,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Lanix
@@ -2116,7 +2116,7 @@
     name: Chrome
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: Lanix
@@ -2134,7 +2134,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Lanix
@@ -2152,7 +2152,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Lanix
@@ -2170,7 +2170,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Lanix
@@ -2188,7 +2188,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Lanix
@@ -2206,7 +2206,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: IMO Mobile
@@ -2224,7 +2224,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: IMO Mobile
@@ -2242,7 +2242,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: iBall
@@ -2260,7 +2260,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: tablet
     brand: iBall
@@ -2278,7 +2278,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: iBall
@@ -2296,7 +2296,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: iSWAG
@@ -2314,7 +2314,7 @@
     name: Chrome Webview
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: iSWAG
@@ -2332,7 +2332,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: iSWAG
@@ -2350,7 +2350,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: iSWAG
@@ -2368,7 +2368,7 @@
     name: Yandex Browser
     version: "20.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Inoi
@@ -2386,7 +2386,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: LG
@@ -2404,7 +2404,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Reeder
@@ -2422,7 +2422,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Reeder
@@ -2440,7 +2440,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Reeder
@@ -2458,7 +2458,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Reeder
@@ -2476,7 +2476,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Reeder
@@ -2494,7 +2494,7 @@
     name: Chrome Webview
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Reeder
@@ -2512,7 +2512,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Reeder
@@ -2530,7 +2530,7 @@
     name: Chrome
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Reeder
@@ -2548,7 +2548,7 @@
     name: Chrome
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Reeder
@@ -2566,7 +2566,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Reeder
@@ -2584,7 +2584,7 @@
     name: Chrome
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: RCA Tablets
@@ -2602,7 +2602,7 @@
     name: Chrome
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: RCA Tablets
@@ -2620,7 +2620,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: ZTE
@@ -2638,7 +2638,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Karbonn
@@ -2656,7 +2656,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Huawei
@@ -2674,7 +2674,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Hyundai
@@ -2692,7 +2692,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Lava
@@ -2710,7 +2710,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Lava
@@ -2728,7 +2728,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Lava
@@ -2746,7 +2746,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Lava
@@ -2764,7 +2764,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Lava
@@ -2782,7 +2782,7 @@
     name: Huawei Browser Mobile
     version: 11.0.3.304
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Huawei
@@ -2800,7 +2800,7 @@
     name: Yandex Browser
     version: 20.9.4.99.01
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Lenovo
@@ -2818,7 +2818,7 @@
     name: Yandex Browser
     version: 19.12.4.87.01
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Lenovo
@@ -2836,7 +2836,7 @@
     name: Yandex Browser
     version: 20.9.4.99.01
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Lenovo
@@ -2854,7 +2854,7 @@
     name: Chrome
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: Lenovo
@@ -2872,7 +2872,7 @@
     name: Yandex Browser
     version: 20.94.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Lenovo
@@ -2890,7 +2890,7 @@
     name: Chrome
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: tablet
     brand: Lenovo
@@ -2908,7 +2908,7 @@
     name: Yandex Browser
     version: 20.9.2.95.01
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Lenovo
@@ -2926,7 +2926,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Lenovo
@@ -2944,7 +2944,7 @@
     name: Yandex Browser
     version: 20.9.4.99.01
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Lenovo
@@ -2962,7 +2962,7 @@
     name: Chrome
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: Lenovo
@@ -2980,7 +2980,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Lenovo
@@ -2998,7 +2998,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Lenovo
@@ -3016,7 +3016,7 @@
     name: Yandex Browser
     version: 20.110.0
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Meizu
@@ -3034,7 +3034,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: Rombica
@@ -3052,7 +3052,7 @@
     name: Yandex Browser
     version: 20.94.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Huawei
@@ -3070,7 +3070,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: Lenovo
@@ -3088,7 +3088,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Lenovo
@@ -3106,7 +3106,7 @@
     name: Yandex Browser
     version: 20.111.0
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: Lenovo
@@ -3124,7 +3124,7 @@
     name: Yandex Browser
     version: 20.11.0.180.01
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: Chuwi
@@ -3142,7 +3142,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Lenovo
@@ -3160,7 +3160,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tv
     brand: Leff
@@ -3178,7 +3178,7 @@
     name: Chrome
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: tablet
     brand: Lenovo
@@ -3196,7 +3196,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Vivax
@@ -3214,7 +3214,7 @@
     name: Chrome
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tv
     brand: Tanix
@@ -3232,7 +3232,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: QMobile
@@ -3250,7 +3250,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: QMobile
@@ -3268,7 +3268,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: QMobile
@@ -3286,7 +3286,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Kalley
@@ -3304,7 +3304,7 @@
     name: Chrome
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: tablet
     brand: Kalley
@@ -3322,7 +3322,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Epik One
@@ -3340,7 +3340,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Epik One
@@ -3358,7 +3358,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Epik One
@@ -3376,7 +3376,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Epik One
@@ -3394,7 +3394,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Epik One
@@ -3412,7 +3412,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Epik One
@@ -3430,7 +3430,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Epik One
@@ -3448,7 +3448,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Epik One
@@ -3466,7 +3466,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Epik One
@@ -3484,7 +3484,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Epik One
@@ -3502,7 +3502,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Epik One
@@ -3520,7 +3520,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Epik One
@@ -3538,7 +3538,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Epik One
@@ -3556,7 +3556,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Epik One
@@ -3574,7 +3574,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Epik One
@@ -3592,7 +3592,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Epik One
@@ -3610,7 +3610,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Epik One
@@ -3628,7 +3628,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: Epik One
@@ -3646,7 +3646,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Epik One
@@ -3664,7 +3664,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Jinga
@@ -3682,7 +3682,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: MyPhone
@@ -3700,7 +3700,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: Explay
@@ -3718,7 +3718,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: ComTrade Tesla
@@ -3736,7 +3736,7 @@
     name: Chrome
     version: 80.0.3987.117
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: tablet
     brand: Inco
@@ -3754,7 +3754,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Inco
@@ -3772,7 +3772,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: TWM
@@ -3790,7 +3790,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Altice
@@ -3808,7 +3808,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Altice
@@ -3826,7 +3826,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Altice
@@ -3844,7 +3844,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: TWM
@@ -3862,7 +3862,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: TWM
@@ -3880,7 +3880,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: TWM
@@ -3898,7 +3898,7 @@
     name: Chrome Mobile
     version: 31.0.1650.59
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: TWM
@@ -3916,7 +3916,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: TWM
@@ -3934,7 +3934,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: TWM
@@ -3952,7 +3952,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Asus
@@ -3970,7 +3970,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Asus
@@ -3988,7 +3988,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: TWM
@@ -4006,7 +4006,7 @@
     name: Chrome
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: TWM
@@ -4024,7 +4024,7 @@
     name: Chrome Mobile
     version: 85.0.4183.120
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: smartphone
     brand: Blu
@@ -4042,7 +4042,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Kult
@@ -4060,7 +4060,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Kult
@@ -4078,7 +4078,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: BioRugged
@@ -4096,7 +4096,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: BioRugged
@@ -4114,7 +4114,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: BioRugged
@@ -4132,7 +4132,7 @@
     name: Chrome Mobile
     version: 80.0.3987.18
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.18"
   device:
     type: smartphone
     brand: ZTE
@@ -4150,7 +4150,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Ace
@@ -4168,7 +4168,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Ace
@@ -4186,7 +4186,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Ace
@@ -4204,7 +4204,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Digiland
@@ -4222,7 +4222,7 @@
     name: Chrome Mobile
     version: 84.0.4147.44
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.44"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -4240,7 +4240,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -4258,7 +4258,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -4276,7 +4276,7 @@
     name: Chrome
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: tablet
     brand: Cherry Mobile
@@ -4294,7 +4294,7 @@
     name: Chrome
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Cherry Mobile
@@ -4312,7 +4312,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: General Mobile
@@ -4330,7 +4330,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: General Mobile
@@ -4348,7 +4348,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: General Mobile
@@ -4366,7 +4366,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Huawei
@@ -4384,7 +4384,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Zuum
@@ -4402,7 +4402,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: SPC
@@ -4420,7 +4420,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: SPC
@@ -4438,7 +4438,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Maxwest
@@ -4456,7 +4456,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Maxwest
@@ -4474,7 +4474,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Condor
@@ -4492,7 +4492,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Gigaset
@@ -4510,7 +4510,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: DEXP
@@ -4528,7 +4528,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: DEXP
@@ -4546,7 +4546,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: DEXP
@@ -4564,7 +4564,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Gigaset
@@ -4582,7 +4582,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Gigaset
@@ -4600,7 +4600,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Gigaset
@@ -4618,7 +4618,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Gigaset
@@ -4636,7 +4636,7 @@
     name: Chrome
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tv
     brand: Beelink
@@ -4654,7 +4654,7 @@
     name: Chrome
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tv
     brand: Beelink
@@ -4672,7 +4672,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Helio
@@ -4690,7 +4690,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Helio
@@ -4708,7 +4708,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Gigaset
@@ -4726,7 +4726,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Gigaset
@@ -4744,7 +4744,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Gigaset
@@ -4762,7 +4762,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Gigaset
@@ -4780,7 +4780,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tv
     brand: Beelink
@@ -4798,7 +4798,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Highscreen
@@ -4816,7 +4816,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: DNS
@@ -4834,7 +4834,7 @@
     name: Chrome
     version: 70.0.3538.102
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: tablet
     brand: DNS
@@ -4852,7 +4852,7 @@
     name: Chrome Mobile
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: DNS
@@ -4870,7 +4870,7 @@
     name: Chrome Mobile
     version: 70.0.3538.102
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: smartphone
     brand: DNS
@@ -4888,7 +4888,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Elephone
@@ -4906,7 +4906,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Elephone
@@ -4924,7 +4924,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Elephone
@@ -4942,7 +4942,7 @@
     name: Opera Mobile
     version: 54.1.2672.49808
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Elephone
@@ -4960,7 +4960,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Elephone
@@ -4978,7 +4978,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Jinga
@@ -4996,7 +4996,7 @@
     name: Chrome Webview
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: tablet
     brand: Contixo
@@ -5014,7 +5014,7 @@
     name: Chrome Webview
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Echo Mobiles
@@ -5032,7 +5032,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Santin
@@ -5050,7 +5050,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: HTC
@@ -5068,7 +5068,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Huawei
@@ -5086,7 +5086,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: DEXP
@@ -5104,7 +5104,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: MiXzo
@@ -5122,7 +5122,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Coolpad
@@ -5140,7 +5140,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: EvroMedia
@@ -5158,7 +5158,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Twoe
@@ -5176,7 +5176,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Twoe
@@ -5194,7 +5194,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Konrow
@@ -5212,7 +5212,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Echo Mobiles
@@ -5230,7 +5230,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -5248,7 +5248,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Artel
@@ -5266,7 +5266,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: DEXP
@@ -5284,7 +5284,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Blu
@@ -5302,7 +5302,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -5320,7 +5320,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -5338,7 +5338,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Teclast
@@ -5356,7 +5356,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Winmax
@@ -5374,7 +5374,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Winmax
@@ -5392,7 +5392,7 @@
     name: Chrome Mobile
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: smartphone
     brand: Winmax
@@ -5410,7 +5410,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Winmax
@@ -5428,7 +5428,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Ulefone
@@ -5446,7 +5446,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: ZTE
@@ -5464,7 +5464,7 @@
     name: Chrome Mobile
     version: 63.0.3239.84
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.84"
   device:
     type: smartphone
     brand: ZTE
@@ -5482,7 +5482,7 @@
     name: Chrome Mobile
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: smartphone
     brand: Huawei
@@ -5500,7 +5500,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Vestel
@@ -5518,7 +5518,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Vestel
@@ -5536,7 +5536,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Navon
@@ -5554,7 +5554,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Navon
@@ -5572,7 +5572,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: HTC
@@ -5590,7 +5590,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Sharp
@@ -5608,7 +5608,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Sharp
@@ -5626,7 +5626,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Gigabyte
@@ -5644,7 +5644,7 @@
     name: Chrome Webview
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Lenovo
@@ -5680,7 +5680,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Zebra
@@ -5698,7 +5698,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Zebra
@@ -5716,7 +5716,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Zebra
@@ -5734,7 +5734,7 @@
     name: Chrome Webview
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Zebra
@@ -5752,7 +5752,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Zebra
@@ -5770,7 +5770,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Zebra
@@ -5788,7 +5788,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Zebra
@@ -5806,7 +5806,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: TechPad
@@ -5824,7 +5824,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: TechPad
@@ -5842,7 +5842,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: TechPad
@@ -5860,7 +5860,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Tele2
@@ -5878,7 +5878,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tv
     brand: Savio
@@ -5896,7 +5896,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tv
     brand: Savio
@@ -5914,7 +5914,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Blu
@@ -5932,7 +5932,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Blu
@@ -5950,7 +5950,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Blu
@@ -5968,7 +5968,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Blu
@@ -5986,7 +5986,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Blu
@@ -6004,7 +6004,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Blu
@@ -6022,7 +6022,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Blu
@@ -6040,7 +6040,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Blu
@@ -6058,7 +6058,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Blu
@@ -6076,7 +6076,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Thuraya
@@ -6094,7 +6094,7 @@
     name: Chrome
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Wortmann
@@ -6112,7 +6112,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Black Fox
@@ -6130,7 +6130,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Bkav
@@ -6148,7 +6148,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Bkav
@@ -6166,7 +6166,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Bkav
@@ -6184,7 +6184,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Brandt
@@ -6202,7 +6202,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Brandt
@@ -6220,7 +6220,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Brandt
@@ -6238,7 +6238,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Brandt
@@ -6256,7 +6256,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Brandt
@@ -6274,7 +6274,7 @@
     name: Chrome
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Bigben
@@ -6292,7 +6292,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Aiwa
@@ -6310,7 +6310,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Aiwa
@@ -6328,7 +6328,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Aiwa
@@ -6346,7 +6346,7 @@
     name: Chrome
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: tablet
     brand: iBall
@@ -6364,7 +6364,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: FireFly Mobile
@@ -6382,7 +6382,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: FireFly Mobile
@@ -6400,7 +6400,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Vestel
@@ -6418,7 +6418,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Huawei
@@ -6436,7 +6436,7 @@
     name: Chrome Webview
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: SPC
@@ -6454,7 +6454,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: LG
@@ -6472,7 +6472,7 @@
     name: Chrome
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: tablet
     brand: Lenovo
@@ -6490,7 +6490,7 @@
     name: Chrome
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: desktop
     brand: Asus
@@ -6508,7 +6508,7 @@
     name: Chrome
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: Logicom
@@ -6526,7 +6526,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Motorola
@@ -6544,7 +6544,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Kalley
@@ -6562,7 +6562,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: LG
@@ -6580,7 +6580,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Logicom
@@ -6598,7 +6598,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Logicom
@@ -6616,7 +6616,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Logicom
@@ -6652,7 +6652,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: iVA
@@ -6670,7 +6670,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Logicom
@@ -6688,7 +6688,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Logicom
@@ -6706,7 +6706,7 @@
     name: Chrome
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: Logicom
@@ -6724,7 +6724,7 @@
     name: Chrome
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: Pixus
@@ -6742,7 +6742,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: iVA
@@ -6760,7 +6760,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: SMARTEC
@@ -6778,7 +6778,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Asanzo
@@ -6796,7 +6796,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Asanzo
@@ -6814,7 +6814,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Asanzo
@@ -6832,7 +6832,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Asanzo
@@ -6850,7 +6850,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Asanzo
@@ -6868,7 +6868,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Asanzo
@@ -6886,7 +6886,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Artizlee
@@ -6904,7 +6904,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Artizlee
@@ -6922,7 +6922,7 @@
     name: Chrome
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Artizlee
@@ -6940,7 +6940,7 @@
     name: Chrome
     version: 60.0.3112.116
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: tablet
     brand: Artizlee
@@ -6958,7 +6958,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Artizlee
@@ -6976,7 +6976,7 @@
     name: Chrome
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Artizlee
@@ -6994,7 +6994,7 @@
     name: Chrome
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Artizlee
@@ -7012,7 +7012,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Artizlee
@@ -7030,7 +7030,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Accent
@@ -7048,7 +7048,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Accent
@@ -7066,7 +7066,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Accent
@@ -7084,7 +7084,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Contixo
@@ -7102,7 +7102,7 @@
     name: Chrome
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: tablet
     brand: Contixo
@@ -7120,7 +7120,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Contixo
@@ -7138,7 +7138,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Mintt
@@ -7156,7 +7156,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Mintt
@@ -7174,7 +7174,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Mintt
@@ -7192,7 +7192,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Mintt
@@ -7210,7 +7210,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Mintt
@@ -7228,7 +7228,7 @@
     name: Chrome Mobile
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Mintt
@@ -7246,7 +7246,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Mintt
@@ -7264,7 +7264,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Mintt
@@ -7282,7 +7282,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Mintt
@@ -7300,7 +7300,7 @@
     name: Chrome
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Mintt
@@ -7318,7 +7318,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -7336,7 +7336,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -7354,7 +7354,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -7372,7 +7372,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -7390,7 +7390,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -7408,7 +7408,7 @@
     name: Chrome Mobile
     version: 80.0.3987.117
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -7426,7 +7426,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -7444,7 +7444,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Avvio
@@ -7462,7 +7462,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Konrow
@@ -7480,7 +7480,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Clarmin
@@ -7498,7 +7498,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Ace
@@ -7516,7 +7516,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Ace
@@ -7534,7 +7534,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Ace
@@ -7552,7 +7552,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Ace
@@ -7570,7 +7570,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Bush
@@ -7588,7 +7588,7 @@
     name: Chrome
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: Hometech
@@ -7606,7 +7606,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Hometech
@@ -7624,7 +7624,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Hometech
@@ -7642,7 +7642,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: Hometech
@@ -7660,7 +7660,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Hometech
@@ -7678,7 +7678,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: iPro
@@ -7696,7 +7696,7 @@
     name: Chrome Mobile
     version: 81.0.4044.18
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.18"
   device:
     type: smartphone
     brand: iPro
@@ -7714,7 +7714,7 @@
     name: Chrome Webview
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: iPro
@@ -7732,7 +7732,7 @@
     name: Chrome Mobile
     version: 85.0.4183.120
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: smartphone
     brand: Blaupunkt
@@ -7750,7 +7750,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Mobicel
@@ -7768,7 +7768,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Mobicel
@@ -7786,7 +7786,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Mobicel
@@ -7804,7 +7804,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Mobicel
@@ -7822,7 +7822,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Premio
@@ -7840,7 +7840,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Premio
@@ -7858,7 +7858,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Premio
@@ -7876,7 +7876,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Premio
@@ -7894,7 +7894,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Premio
@@ -7912,7 +7912,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: Kivi
@@ -7930,7 +7930,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -7948,7 +7948,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -7966,7 +7966,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -7984,7 +7984,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8002,7 +8002,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8020,7 +8020,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8038,7 +8038,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8056,7 +8056,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8074,7 +8074,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8092,7 +8092,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8110,7 +8110,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8128,7 +8128,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8146,7 +8146,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8164,7 +8164,7 @@
     name: Chrome Mobile
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8182,7 +8182,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8200,7 +8200,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8218,7 +8218,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8236,7 +8236,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8254,7 +8254,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8272,7 +8272,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Lava
@@ -8290,7 +8290,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Phonemax
@@ -8308,7 +8308,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Accent
@@ -8326,7 +8326,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Accent
@@ -8344,7 +8344,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Accent
@@ -8362,7 +8362,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Trifone
@@ -8380,7 +8380,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Trifone
@@ -8398,7 +8398,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Trifone
@@ -8416,7 +8416,7 @@
     name: Chrome Mobile
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Plum
@@ -8434,7 +8434,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Plum
@@ -8452,7 +8452,7 @@
     name: Chrome
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Plum
@@ -8470,7 +8470,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Plum
@@ -8488,7 +8488,7 @@
     name: Chrome Mobile
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tablet
     brand: Plum
@@ -8570,7 +8570,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Casper
@@ -8588,7 +8588,7 @@
     name: Chrome
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: tv
     brand: Vivax
@@ -8606,7 +8606,7 @@
     name: Chrome
     version: 80.0.3987.117
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: tablet
     brand: Bluewave
@@ -8624,7 +8624,7 @@
     name: Chrome Mobile
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Kyocera
@@ -8642,7 +8642,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tv
     brand: Vivax
@@ -8660,7 +8660,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tv
     brand: Kivi
@@ -8678,7 +8678,7 @@
     name: Chrome Webview
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: tablet
     brand: Bluewave
@@ -8696,7 +8696,7 @@
     name: Chrome
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tablet
     brand: Bluewave
@@ -8714,7 +8714,7 @@
     name: Chrome
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: Bluewave
@@ -8732,7 +8732,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: Kivi
@@ -8750,7 +8750,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: Kivi
@@ -8768,7 +8768,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: Kivi
@@ -8786,7 +8786,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tv
     brand: Kivi
@@ -8804,7 +8804,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: BBK
@@ -8822,7 +8822,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: BBK
@@ -8840,7 +8840,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: BBK
@@ -8858,7 +8858,7 @@
     name: Chrome
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tv
     brand: BBK
@@ -8876,7 +8876,7 @@
     name: Chrome
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Lenovo
@@ -8894,7 +8894,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tv
     brand: Kivi
@@ -8912,7 +8912,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: Kivi
@@ -8930,7 +8930,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Alcatel
@@ -8948,7 +8948,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Alcatel
@@ -8966,7 +8966,7 @@
     name: Chrome Mobile
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -8984,7 +8984,7 @@
     name: Chrome
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: iView
@@ -9002,7 +9002,7 @@
     name: Chrome
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: iView
@@ -9020,7 +9020,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: iView
@@ -9038,7 +9038,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Polaroid
@@ -9056,7 +9056,7 @@
     name: Chrome
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Denver
@@ -9074,7 +9074,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Vivax
@@ -9092,7 +9092,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Poppox
@@ -9110,7 +9110,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Starmobile
@@ -9128,7 +9128,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Starmobile
@@ -9146,7 +9146,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Starmobile
@@ -9164,7 +9164,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Starmobile
@@ -9182,7 +9182,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tv
     brand: BBK
@@ -9200,7 +9200,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tv
     brand: BBK
@@ -9218,7 +9218,7 @@
     name: Chrome
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: tv
     brand: BBK
@@ -9236,7 +9236,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: BBK
@@ -9254,7 +9254,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tv
     brand: BBK
@@ -9272,7 +9272,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tv
     brand: BBK
@@ -9290,7 +9290,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tv
     brand: BBK
@@ -9308,7 +9308,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: BBK
@@ -9326,7 +9326,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tv
     brand: BBK
@@ -9344,7 +9344,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tv
     brand: BBK
@@ -9362,7 +9362,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tv
     brand: BBK
@@ -9380,7 +9380,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tv
     brand: BBK
@@ -9398,7 +9398,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: BBK
@@ -9416,7 +9416,7 @@
     name: Chrome
     version: 68.0.3440.70
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.70"
   device:
     type: tv
     brand: BBK
@@ -9434,7 +9434,7 @@
     name: Chrome
     version: 68.0.3440.70
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.70"
   device:
     type: tv
     brand: BBK
@@ -9452,7 +9452,7 @@
     name: Chrome
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: tv
     brand: BBK
@@ -9470,7 +9470,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tv
     brand: BBK
@@ -9488,7 +9488,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: BBK
@@ -9506,7 +9506,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: BBK
@@ -9524,7 +9524,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Starmobile
@@ -9542,7 +9542,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Asus
@@ -9560,7 +9560,7 @@
     name: Chrome
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Asus
@@ -9578,7 +9578,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Asus
@@ -9596,7 +9596,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Accent
@@ -9614,7 +9614,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Accent
@@ -9632,7 +9632,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: iPro
@@ -9650,7 +9650,7 @@
     name: Chrome Mobile
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: smartphone
     brand: X-TIGI
@@ -9668,7 +9668,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Sky
@@ -9686,7 +9686,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Sky
@@ -9704,7 +9704,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Sky
@@ -9722,7 +9722,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Sky
@@ -9740,7 +9740,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Sky
@@ -9758,7 +9758,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Sky
@@ -9776,7 +9776,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sky
@@ -9794,7 +9794,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Sky
@@ -9812,7 +9812,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Sky
@@ -9830,7 +9830,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Sky
@@ -9866,7 +9866,7 @@
     name: Chrome Mobile
     version: 54.0.2840.85
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: ZTE
@@ -9884,7 +9884,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: ZTE
@@ -9902,7 +9902,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: HP

--- a/Tests/fixtures/smartphone-2.yml
+++ b/Tests/fixtures/smartphone-2.yml
@@ -10,7 +10,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -28,7 +28,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Alcatel
@@ -46,7 +46,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Alcatel
@@ -64,7 +64,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Alcatel
@@ -82,7 +82,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Azumi Mobile
@@ -100,7 +100,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Azumi Mobile
@@ -118,7 +118,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Azumi Mobile
@@ -136,7 +136,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Azumi Mobile
@@ -154,7 +154,7 @@
     name: Chrome Webview
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: smartphone
     brand: Azumi Mobile
@@ -1117,7 +1117,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Archos
@@ -1153,7 +1153,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Archos
@@ -1171,7 +1171,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Archos
@@ -1189,7 +1189,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Archos
@@ -1225,7 +1225,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Archos
@@ -1243,7 +1243,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Archos
@@ -1261,7 +1261,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Archos
@@ -1333,7 +1333,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Archos
@@ -1369,7 +1369,7 @@
     name: Yandex Browser
     version: "16.10.0.1326.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.116"
   device:
     type: smartphone
     brand: Asus
@@ -1405,7 +1405,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Asus
@@ -1423,7 +1423,7 @@
     name: Chrome Mobile
     version: "33.0.1750.170"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.170"
   device:
     type: smartphone
     brand: Asus
@@ -1441,7 +1441,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Asus
@@ -1459,7 +1459,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Asus
@@ -1477,7 +1477,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Asus
@@ -1495,7 +1495,7 @@
     name: Yandex Browser
     version: "19.6.1.396.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.169"
   device:
     type: smartphone
     brand: Asus
@@ -1513,7 +1513,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Asus
@@ -1531,7 +1531,7 @@
     name: Chrome Mobile
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: smartphone
     brand: Asus
@@ -1549,7 +1549,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Asus
@@ -1567,7 +1567,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Asus
@@ -1585,7 +1585,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Asus
@@ -1603,7 +1603,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Asus
@@ -1639,7 +1639,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Asus
@@ -1657,7 +1657,7 @@
     name: Chrome Webview
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: Asus
@@ -1675,7 +1675,7 @@
     name: Chrome Webview
     version: "45.0.2454.95"
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.95"
   device:
     type: smartphone
     brand: Asus
@@ -1745,7 +1745,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Asus
@@ -1763,7 +1763,7 @@
     name: Chrome Webview
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: Asus
@@ -1781,7 +1781,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Asus
@@ -1799,7 +1799,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Asus
@@ -1817,7 +1817,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Asus
@@ -1851,7 +1851,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Asus
@@ -1869,7 +1869,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Asus
@@ -1887,7 +1887,7 @@
     name: Opera Mobile
     version: "20.0.2254.109835"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Asus
@@ -1937,7 +1937,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Asus
@@ -1955,7 +1955,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Asus
@@ -1973,7 +1973,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Asus
@@ -1991,7 +1991,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Asus
@@ -2009,7 +2009,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Asus
@@ -2027,7 +2027,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Asus
@@ -2045,7 +2045,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Asus
@@ -2063,7 +2063,7 @@
     name: Opera Mobile
     version: "35.3.2254.129226"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Asus
@@ -2099,7 +2099,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Asus
@@ -2117,7 +2117,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Asus
@@ -2135,7 +2135,7 @@
     name: Opera Mobile
     version: "35.3.2254.129219"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Asus
@@ -2171,7 +2171,7 @@
     name: Chrome Mobile
     version: "37.0.2062.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.117"
   device:
     type: smartphone
     brand: Asus
@@ -2207,7 +2207,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Asus
@@ -2225,7 +2225,7 @@
     name: Opera Mobile
     version: "36.2.2254.130496"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Asus
@@ -2259,7 +2259,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Asus
@@ -2277,7 +2277,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Asus
@@ -2295,7 +2295,7 @@
     name: Chrome Mobile
     version: "67.0.3371.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3371.0"
   device:
     type: smartphone
     brand: Asus
@@ -2313,7 +2313,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Asus
@@ -2331,7 +2331,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Asus
@@ -2367,7 +2367,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Asus
@@ -2385,7 +2385,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Asus
@@ -2403,7 +2403,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Asus
@@ -2421,7 +2421,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Asus
@@ -2439,7 +2439,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Asus
@@ -2457,7 +2457,7 @@
     name: Chrome Mobile
     version: "72.0.3626.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Asus
@@ -2475,7 +2475,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Asus
@@ -2529,7 +2529,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Asus
@@ -2547,7 +2547,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Asus
@@ -2565,7 +2565,7 @@
     name: Opera Mobile
     version: "35.1.2254.128344"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Asus
@@ -2599,7 +2599,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Asus
@@ -2617,7 +2617,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Asus
@@ -2635,7 +2635,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Asus
@@ -2653,7 +2653,7 @@
     name: Yandex Browser
     version: "14.12.2125.9740.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.122"
   device:
     type: smartphone
     brand: Asus
@@ -2671,7 +2671,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Asus
@@ -2689,7 +2689,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Asus
@@ -2743,7 +2743,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Asus
@@ -2761,7 +2761,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Asus
@@ -2779,7 +2779,7 @@
     name: Chrome Mobile
     version: "79.0.3945.8"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.8"
   device:
     type: smartphone
     brand: Asus
@@ -2797,7 +2797,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Asus
@@ -2815,7 +2815,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Asus
@@ -2867,7 +2867,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Asus
@@ -2885,7 +2885,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Asus
@@ -2903,7 +2903,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Asus
@@ -2921,7 +2921,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Asus
@@ -2939,7 +2939,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Asus
@@ -2993,7 +2993,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Asus
@@ -3011,7 +3011,7 @@
     name: Chrome Mobile
     version: "77.0.3828.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3828.0"
   device:
     type: smartphone
     brand: Asus
@@ -3029,7 +3029,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Asus
@@ -3047,7 +3047,7 @@
     name: Chrome Webview
     version: "49.0.2623.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.108"
   device:
     type: smartphone
     brand: Asus
@@ -3065,7 +3065,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Asus
@@ -3083,7 +3083,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Asus
@@ -3101,7 +3101,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Asus
@@ -3119,7 +3119,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Asus
@@ -3137,7 +3137,7 @@
     name: Opera Mobile
     version: "35.3.2254.129226"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Asus
@@ -3155,7 +3155,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Asus
@@ -3173,7 +3173,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Asus
@@ -3191,7 +3191,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Asus
@@ -3209,7 +3209,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Asus
@@ -3227,7 +3227,7 @@
     name: Opera Mobile
     version: "28.0.2254.119224"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Asus
@@ -3245,7 +3245,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Asus
@@ -3263,7 +3263,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Asus
@@ -3281,7 +3281,7 @@
     name: Chrome Mobile
     version: "78.0.3871.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3871.0"
   device:
     type: smartphone
     brand: Asus
@@ -3299,7 +3299,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Asus
@@ -3317,7 +3317,7 @@
     name: Opera Mobile
     version: "37.0.2254.130605"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: smartphone
     brand: Asus
@@ -3335,7 +3335,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Asus
@@ -3353,7 +3353,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Asus
@@ -3371,7 +3371,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Asus
@@ -3389,7 +3389,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Asus
@@ -3407,7 +3407,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Asus
@@ -3425,7 +3425,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Asus
@@ -3443,7 +3443,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Asus
@@ -3461,7 +3461,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Asus
@@ -3479,7 +3479,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Asus
@@ -3497,7 +3497,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Asus
@@ -3515,7 +3515,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Asus
@@ -3533,7 +3533,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Asus
@@ -3551,7 +3551,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Asus
@@ -3587,7 +3587,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Avvio
@@ -3641,7 +3641,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Avvio
@@ -3659,7 +3659,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Aiwa
@@ -3677,7 +3677,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Aiwa
@@ -3695,7 +3695,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Aiwa
@@ -3713,7 +3713,7 @@
     name: Chrome Mobile
     version: "41.0.2272.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.96"
   device:
     type: smartphone
     brand: Bush
@@ -3747,7 +3747,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Blackview
@@ -3765,7 +3765,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Blackview
@@ -3783,7 +3783,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Blackview
@@ -3801,7 +3801,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Blackview
@@ -3819,7 +3819,7 @@
     name: Yandex Browser
     version: "16.2.2.7988.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.111"
   device:
     type: smartphone
     brand: Blackview
@@ -3837,7 +3837,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Blackview
@@ -3855,7 +3855,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blackview
@@ -3891,7 +3891,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blackview
@@ -3927,7 +3927,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Blackview
@@ -3963,7 +3963,7 @@
     name: Yandex Browser
     version: "17.1.1.359.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.95"
   device:
     type: smartphone
     brand: Blackview
@@ -3981,7 +3981,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blackview
@@ -3999,7 +3999,7 @@
     name: Chrome Webview
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: smartphone
     brand: Blackview
@@ -4017,7 +4017,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Blackview
@@ -4035,7 +4035,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blackview
@@ -4053,7 +4053,7 @@
     name: Chrome Webview
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Blackview
@@ -4071,7 +4071,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Blackview
@@ -4089,7 +4089,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Blackview
@@ -4107,7 +4107,7 @@
     name: Opera Mobile
     version: "44.1.2254.143214"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Blackview
@@ -4125,7 +4125,7 @@
     name: Chrome Webview
     version: "58.0.3029.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.125"
   device:
     type: smartphone
     brand: Blackview
@@ -4143,7 +4143,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Blackview
@@ -4179,7 +4179,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Blackview
@@ -4197,7 +4197,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Blackview
@@ -4215,7 +4215,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Blackview
@@ -4233,7 +4233,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Blackview
@@ -4251,7 +4251,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blackview
@@ -4269,7 +4269,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Bluboo
@@ -4287,7 +4287,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Bluboo
@@ -4305,7 +4305,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Bluboo
@@ -4323,7 +4323,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Bluboo
@@ -4341,7 +4341,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Bluboo
@@ -4377,7 +4377,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Bluboo
@@ -4395,7 +4395,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: bogo
@@ -4413,7 +4413,7 @@
     name: Chrome Mobile
     version: "37.0.2062.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.117"
   device:
     type: smartphone
     brand: bogo
@@ -4431,7 +4431,7 @@
     name: Chrome Mobile
     version: "37.0.2062.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.117"
   device:
     type: smartphone
     brand: bogo
@@ -4449,7 +4449,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: bogo
@@ -4467,7 +4467,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: bogo
@@ -4485,7 +4485,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Beeline
@@ -4521,7 +4521,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Beeline
@@ -4539,7 +4539,7 @@
     name: Yandex Browser
     version: "19.7.7.115.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Beeline
@@ -4575,7 +4575,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Beeline
@@ -4593,7 +4593,7 @@
     name: Chrome Mobile
     version: "71.0.3578.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.98"
   device:
     type: smartphone
     brand: Beeline
@@ -4611,7 +4611,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Beeline
@@ -4629,7 +4629,7 @@
     name: Chrome Mobile
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: smartphone
     brand: Beeline
@@ -4647,7 +4647,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Beeline
@@ -4665,7 +4665,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Beeline
@@ -4683,7 +4683,7 @@
     name: Chrome Webview
     version: "48.0.2564.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.116"
   device:
     type: smartphone
     brand: BIHEE
@@ -4701,7 +4701,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: BIHEE
@@ -4791,7 +4791,7 @@
     name: Chrome Webview
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Bluegood
@@ -4809,7 +4809,7 @@
     name: Chrome Webview
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Black Fox
@@ -4827,7 +4827,7 @@
     name: Chrome Webview
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Black Fox
@@ -4845,7 +4845,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Black Fox
@@ -4863,7 +4863,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Black Fox
@@ -4881,7 +4881,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Black Fox
@@ -4899,7 +4899,7 @@
     name: Yandex Browser
     version: "18.7.1.595.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.103"
   device:
     type: smartphone
     brand: Black Fox
@@ -4917,7 +4917,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Black Fox
@@ -4935,7 +4935,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Black Fox
@@ -4953,7 +4953,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Black Fox
@@ -4971,7 +4971,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Black Fox
@@ -4989,7 +4989,7 @@
     name: Yandex Browser
     version: "19.4.0.535.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.103"
   device:
     type: smartphone
     brand: Black Fox
@@ -5007,7 +5007,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Black Fox
@@ -5025,7 +5025,7 @@
     name: Yandex Browser
     version: "20.2.5.120.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Black Fox
@@ -5043,7 +5043,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Black Fox
@@ -5061,7 +5061,7 @@
     name: Chrome Webview
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: smartphone
     brand: Black Fox
@@ -5079,7 +5079,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Black Fox
@@ -5097,7 +5097,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Black Fox
@@ -5115,7 +5115,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Black Fox
@@ -5133,7 +5133,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: BGH
@@ -5151,7 +5151,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: BGH
@@ -5169,7 +5169,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: BGH
@@ -5187,7 +5187,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: BGH
@@ -5205,7 +5205,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: BGH
@@ -5223,7 +5223,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: BGH
@@ -5241,7 +5241,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: BGH
@@ -5259,7 +5259,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: BGH
@@ -5277,7 +5277,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: BGH
@@ -5295,7 +5295,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: BGH
@@ -5313,7 +5313,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: BGH
@@ -5457,7 +5457,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Bmobile
@@ -5475,7 +5475,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Bmobile
@@ -5493,7 +5493,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Bmobile
@@ -5511,7 +5511,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Bmobile
@@ -5529,7 +5529,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Bmobile
@@ -5547,7 +5547,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Bmobile
@@ -5565,7 +5565,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Bmobile
@@ -5583,7 +5583,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Bmobile
@@ -5601,7 +5601,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Bmobile
@@ -5619,7 +5619,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Bmobile
@@ -5637,7 +5637,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Bmobile
@@ -5655,7 +5655,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Bmobile
@@ -5673,7 +5673,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Bmobile
@@ -5691,7 +5691,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Bmobile
@@ -5709,7 +5709,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Bmobile
@@ -5727,7 +5727,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Bmobile
@@ -5745,7 +5745,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Bmobile
@@ -5763,7 +5763,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Bmobile
@@ -5781,7 +5781,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Bmobile
@@ -5799,7 +5799,7 @@
     name: Chrome Mobile
     version: "68.0.3440.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.85"
   device:
     type: smartphone
     brand: Bmobile
@@ -5817,7 +5817,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Bmobile
@@ -5835,7 +5835,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Bmobile
@@ -5853,7 +5853,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Bmobile
@@ -5871,7 +5871,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Bmobile
@@ -5889,7 +5889,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Bmobile
@@ -5943,7 +5943,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Bmobile
@@ -5997,7 +5997,7 @@
     name: Chrome Mobile
     version: "62.0.3202.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.73"
   device:
     type: smartphone
     brand: Bmobile
@@ -6051,7 +6051,7 @@
     name: Chrome Mobile
     version: "69.0.3497.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: smartphone
     brand: Bmobile
@@ -6087,7 +6087,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Bmobile
@@ -6105,7 +6105,7 @@
     name: Chrome Mobile
     version: "64.0.3282.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.116"
   device:
     type: smartphone
     brand: Bmobile
@@ -6123,7 +6123,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Bmobile
@@ -6177,7 +6177,7 @@
     name: Opera Mobile
     version: "30.0.1856.93524"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.78"
   device:
     type: smartphone
     brand: Bmobile
@@ -6213,7 +6213,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Bmobile
@@ -6231,7 +6231,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Bmobile
@@ -6249,7 +6249,7 @@
     name: Chrome Mobile
     version: "64.0.3282.123"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: smartphone
     brand: Bmobile
@@ -6267,7 +6267,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Bmobile
@@ -6285,7 +6285,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Bmobile
@@ -6303,7 +6303,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Bmobile
@@ -6321,7 +6321,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Bmobile
@@ -6339,7 +6339,7 @@
     name: Chrome Mobile
     version: "69.0.3497.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: smartphone
     brand: Bmobile
@@ -6375,7 +6375,7 @@
     name: Chrome Mobile
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: smartphone
     brand: Bmobile
@@ -6393,7 +6393,7 @@
     name: Chrome Mobile
     version: "68.0.3440.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.85"
   device:
     type: smartphone
     brand: Bmobile
@@ -6411,7 +6411,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Bmobile
@@ -6447,7 +6447,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Bmobile
@@ -6465,7 +6465,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Bmobile
@@ -6483,7 +6483,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Bmobile
@@ -6501,7 +6501,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Bmobile
@@ -6519,7 +6519,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Bmobile
@@ -6537,7 +6537,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Bmobile
@@ -6555,7 +6555,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Bmobile
@@ -6591,7 +6591,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Blaupunkt
@@ -6609,7 +6609,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Blaupunkt
@@ -6627,7 +6627,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Blaupunkt
@@ -6645,7 +6645,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Blaupunkt
@@ -6663,7 +6663,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Brondi
@@ -6681,7 +6681,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Brondi
@@ -6699,7 +6699,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Brondi
@@ -6735,7 +6735,7 @@
     name: Chrome Mobile
     version: "41.0.2272.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.96"
   device:
     type: smartphone
     brand: Brondi
@@ -6771,7 +6771,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Brondi
@@ -6807,7 +6807,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Brondi
@@ -6879,7 +6879,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Brondi
@@ -6951,7 +6951,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Brondi
@@ -7023,7 +7023,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Brondi
@@ -7041,7 +7041,7 @@
     name: Chrome Mobile
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: smartphone
     brand: Bitel
@@ -7059,7 +7059,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Bitel
@@ -7077,7 +7077,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Bitel
@@ -7095,7 +7095,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Bitel
@@ -7113,7 +7113,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Bitel
@@ -7131,7 +7131,7 @@
     name: Chrome Mobile
     version: "48.0.2564.95"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.95"
   device:
     type: smartphone
     brand: Bitel
@@ -7149,7 +7149,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Bitel
@@ -7167,7 +7167,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Bitel
@@ -7185,7 +7185,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Bitel
@@ -7203,7 +7203,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Bitel
@@ -7221,7 +7221,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Bitel
@@ -7239,7 +7239,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Bitel
@@ -7257,7 +7257,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Bitel
@@ -7275,7 +7275,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Bitel
@@ -7293,7 +7293,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Bitel
@@ -7311,7 +7311,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Bitel
@@ -7329,7 +7329,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Bitel
@@ -7347,7 +7347,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Bitel
@@ -7365,7 +7365,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Bitel
@@ -7383,7 +7383,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Bitel
@@ -7401,7 +7401,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Bitel
@@ -7419,7 +7419,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Bitel
@@ -7437,7 +7437,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -7455,7 +7455,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -7473,7 +7473,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Blu
@@ -7491,7 +7491,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Blu
@@ -7509,7 +7509,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -7617,7 +7617,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -7635,7 +7635,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Blu
@@ -7671,7 +7671,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Blu
@@ -7689,7 +7689,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Blu
@@ -7707,7 +7707,7 @@
     name: Chrome Mobile
     version: "60.0.3112.107"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.107"
   device:
     type: smartphone
     brand: Blu
@@ -7725,7 +7725,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Blu
@@ -7743,7 +7743,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Blu
@@ -7779,7 +7779,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -7797,7 +7797,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Blu
@@ -7815,7 +7815,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Blu
@@ -7833,7 +7833,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Blu
@@ -7851,7 +7851,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Blu
@@ -7869,7 +7869,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -7887,7 +7887,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Blu
@@ -7905,7 +7905,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Blu
@@ -7923,7 +7923,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Blu
@@ -7941,7 +7941,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Blu
@@ -7959,7 +7959,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -7977,7 +7977,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Blu
@@ -7995,7 +7995,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Blu
@@ -8013,7 +8013,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Blu
@@ -8031,7 +8031,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Blu
@@ -8049,7 +8049,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Blu
@@ -8067,7 +8067,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Blu
@@ -8085,7 +8085,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -8121,7 +8121,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Blu
@@ -8139,7 +8139,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -8157,7 +8157,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Blu
@@ -8175,7 +8175,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -8193,7 +8193,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -8229,7 +8229,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -8247,7 +8247,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -8283,7 +8283,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Blu
@@ -8337,7 +8337,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Blu
@@ -8373,7 +8373,7 @@
     name: Chrome Mobile
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: Blu
@@ -8391,7 +8391,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -8409,7 +8409,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -8427,7 +8427,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -8445,7 +8445,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Blu
@@ -8463,7 +8463,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Blu
@@ -8481,7 +8481,7 @@
     name: Chrome Mobile
     version: "64.0.3282.123"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: smartphone
     brand: Blu
@@ -8499,7 +8499,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Blu
@@ -8517,7 +8517,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -8535,7 +8535,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -8553,7 +8553,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Blu
@@ -8571,7 +8571,7 @@
     name: Chrome Mobile
     version: "71.0.3578.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: smartphone
     brand: Blu
@@ -8589,7 +8589,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Blu
@@ -8607,7 +8607,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Blu
@@ -8625,7 +8625,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Blu
@@ -8643,7 +8643,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Blu
@@ -8661,7 +8661,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Blu
@@ -8679,7 +8679,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Blu
@@ -8715,7 +8715,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Blu
@@ -8733,7 +8733,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Bravis
@@ -8805,7 +8805,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Bravis
@@ -8823,7 +8823,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Bravis
@@ -8841,7 +8841,7 @@
     name: Chrome Mobile
     version: "82.0.4077.2"
     engine: Blink
-    engine_version: ""
+    engine_version: "82.0.4077.2"
   device:
     type: smartphone
     brand: Bravis
@@ -8895,7 +8895,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Bravis
@@ -8913,7 +8913,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Bravis
@@ -8931,7 +8931,7 @@
     name: Opera Touch
     version: "2.6"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Nubia
@@ -8949,7 +8949,7 @@
     name: Opera Mobile
     version: 60.3.3004.55692
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Nubia
@@ -8967,7 +8967,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Huawei
@@ -8985,7 +8985,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: iHunt
@@ -9003,7 +9003,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Siragon
@@ -9021,7 +9021,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Vivo
@@ -9039,7 +9039,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Vivo
@@ -9057,7 +9057,7 @@
     name: Chrome Webview
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Vivo
@@ -9075,7 +9075,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: OnePlus
@@ -9093,7 +9093,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: OnePlus
@@ -9111,7 +9111,7 @@
     name: Chrome Webview
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Vivo
@@ -9129,7 +9129,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Blu
@@ -9147,7 +9147,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: STF Mobile
@@ -9165,7 +9165,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: STF Mobile
@@ -9183,7 +9183,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Kalley
@@ -9201,7 +9201,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Gol Mobile
@@ -9219,7 +9219,7 @@
     name: Chrome Mobile
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: smartphone
     brand: Advance
@@ -9237,7 +9237,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Hisense
@@ -9255,7 +9255,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: 'Kempler & Strauss'
@@ -9273,7 +9273,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Sonim
@@ -9291,7 +9291,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Colors
@@ -9309,7 +9309,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: KRONO
@@ -9327,7 +9327,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Spark
@@ -9345,7 +9345,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Huawei
@@ -9363,7 +9363,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: OnePlus
@@ -9381,7 +9381,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: OnePlus
@@ -9399,7 +9399,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: OnePlus
@@ -9417,7 +9417,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -9435,7 +9435,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Blu
@@ -9453,7 +9453,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Blu
@@ -9471,7 +9471,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Huawei
@@ -9489,7 +9489,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Huawei
@@ -9507,7 +9507,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Vivo
@@ -9525,7 +9525,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: KRONO
@@ -9543,7 +9543,7 @@
     name: Chrome Mobile
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Vivo
@@ -9561,7 +9561,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: MDC Store
@@ -9579,7 +9579,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Zuum
@@ -9597,7 +9597,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: CORN
@@ -9615,7 +9615,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Colors
@@ -9633,7 +9633,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -9651,7 +9651,7 @@
     name: Chrome Mobile
     version: 88.0.4324.152
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.152"
   device:
     type: smartphone
     brand: Samsung
@@ -9669,7 +9669,7 @@
     name: Chrome Mobile
     version: 88.0.4324.152
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.152"
   device:
     type: smartphone
     brand: Samsung
@@ -9723,7 +9723,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Samsung
@@ -9757,7 +9757,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Samsung
@@ -9775,7 +9775,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: ZTE
@@ -9793,7 +9793,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: ZTE
@@ -9811,7 +9811,7 @@
     name: Chrome Mobile
     version: 88.0.4324.141
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.141"
   device:
     type: smartphone
     brand: ZTE
@@ -9829,7 +9829,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: ZTE
@@ -9847,7 +9847,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: ZTE
@@ -9865,7 +9865,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: ZTE
@@ -9883,7 +9883,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: ZTE
@@ -9901,7 +9901,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: ZTE
@@ -9919,7 +9919,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: ZTE
@@ -9937,7 +9937,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: ZTE
@@ -10043,7 +10043,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Samsung
@@ -10061,7 +10061,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -10079,7 +10079,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Samsung
@@ -10115,7 +10115,7 @@
     name: Chrome Mobile
     version: 43.0.2357.93
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Samsung
@@ -10133,7 +10133,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Samsung
@@ -10151,7 +10151,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Samsung
@@ -10169,7 +10169,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Samsung
@@ -10187,7 +10187,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Samsung
@@ -10205,7 +10205,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Samsung
@@ -10257,7 +10257,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Samsung
@@ -10275,7 +10275,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Samsung
@@ -10293,7 +10293,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Samsung
@@ -10311,7 +10311,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Samsung
@@ -10329,7 +10329,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Samsung
@@ -10365,7 +10365,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Samsung
@@ -10383,7 +10383,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Samsung
@@ -10401,7 +10401,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Samsung
@@ -10419,7 +10419,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Samsung
@@ -10437,7 +10437,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Samsung
@@ -10491,7 +10491,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -10509,7 +10509,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -10527,7 +10527,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -10641,7 +10641,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -10659,7 +10659,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -10677,7 +10677,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Samsung
@@ -10695,7 +10695,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Samsung
@@ -10713,7 +10713,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Samsung
@@ -10731,7 +10731,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Samsung
@@ -10785,7 +10785,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Samsung
@@ -10911,7 +10911,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Samsung
@@ -10929,7 +10929,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Samsung
@@ -10947,7 +10947,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Samsung
@@ -10965,7 +10965,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Samsung
@@ -11083,7 +11083,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -11119,7 +11119,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -11137,7 +11137,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Samsung
@@ -11155,7 +11155,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -11173,7 +11173,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -11191,7 +11191,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Samsung
@@ -11209,7 +11209,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Samsung
@@ -11279,7 +11279,7 @@
     name: Chrome Webview
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Samsung
@@ -11297,7 +11297,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Samsung
@@ -11315,7 +11315,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Samsung
@@ -11459,7 +11459,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Samsung
@@ -11531,7 +11531,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Samsung
@@ -11549,7 +11549,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Samsung
@@ -11657,7 +11657,7 @@
     name: Yandex Browser
     version: 20.81.0
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: smartphone
     brand: Samsung
@@ -11675,7 +11675,7 @@
     name: Chrome Mobile
     version: 51.0.2704.81
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Samsung
@@ -11693,7 +11693,7 @@
     name: Chrome Mobile
     version: 51.0.2704.81
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Samsung
@@ -11711,7 +11711,7 @@
     name: Chrome Mobile
     version: 66.0.3359.126
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Samsung
@@ -11729,7 +11729,7 @@
     name: Chrome Mobile
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Samsung
@@ -11747,7 +11747,7 @@
     name: Chrome Webview
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Samsung
@@ -11765,7 +11765,7 @@
     name: Chrome Webview
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Samsung
@@ -11837,7 +11837,7 @@
     name: Chrome Webview
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Samsung
@@ -11927,7 +11927,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Samsung
@@ -11981,7 +11981,7 @@
     name: Chrome Mobile
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Samsung
@@ -11999,7 +11999,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Samsung
@@ -12017,7 +12017,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Samsung
@@ -12035,7 +12035,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Samsung
@@ -12053,7 +12053,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Samsung
@@ -12071,7 +12071,7 @@
     name: Yandex Browser
     version: "10.20"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Samsung
@@ -12089,7 +12089,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Samsung
@@ -12107,7 +12107,7 @@
     name: Chrome Mobile
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Samsung
@@ -12215,7 +12215,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Samsung

--- a/Tests/fixtures/smartphone-20.yml
+++ b/Tests/fixtures/smartphone-20.yml
@@ -10,7 +10,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Sky
@@ -28,7 +28,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Sky
@@ -46,7 +46,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Sky
@@ -64,7 +64,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Sky
@@ -82,7 +82,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: tablet
     brand: Sky
@@ -100,7 +100,7 @@
     name: Chrome Webview
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Condor
@@ -118,7 +118,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Condor
@@ -136,7 +136,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: Vonino
@@ -154,7 +154,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: 'True'
@@ -172,7 +172,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: 'True'
@@ -190,7 +190,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: 'True'
@@ -208,7 +208,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Viumee
@@ -226,7 +226,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Viumee
@@ -244,7 +244,7 @@
     name: Chrome Mobile
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Viumee
@@ -262,7 +262,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Kyocera
@@ -280,7 +280,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Sharp
@@ -298,7 +298,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: VAIO
@@ -316,7 +316,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Bluedot
@@ -334,7 +334,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: HTC
@@ -370,7 +370,7 @@
     name: Chrome Webview
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Sharp
@@ -388,7 +388,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Sharp
@@ -406,7 +406,7 @@
     name: Chrome
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: tablet
     brand: Huawei
@@ -424,7 +424,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: tablet
     brand: Blaupunkt
@@ -442,7 +442,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Siragon
@@ -460,7 +460,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -478,7 +478,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: True Slim
@@ -496,7 +496,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Starmobile
@@ -514,7 +514,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Sugar
@@ -532,7 +532,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Sugar
@@ -550,7 +550,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Sugar
@@ -568,7 +568,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Sugar
@@ -586,7 +586,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Sugar
@@ -604,7 +604,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Sugar
@@ -622,7 +622,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Sugar
@@ -640,7 +640,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: STF Mobile
@@ -658,7 +658,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: STF Mobile
@@ -676,7 +676,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Blu
@@ -694,7 +694,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tv
     brand: Alfawise
@@ -712,7 +712,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: iHunt
@@ -730,7 +730,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: iHunt
@@ -748,7 +748,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: iHunt
@@ -766,7 +766,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: iHunt
@@ -784,7 +784,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: TWM
@@ -802,7 +802,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Oale
@@ -820,7 +820,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Oale
@@ -838,7 +838,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Mobo
@@ -892,7 +892,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Jinga
@@ -910,7 +910,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Jinga
@@ -928,7 +928,7 @@
     name: Chrome Mobile
     version: 74.0.3729.112
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: smartphone
     brand: Jinga
@@ -946,7 +946,7 @@
     name: Chrome Mobile
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Jinga
@@ -964,7 +964,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Jinga
@@ -982,7 +982,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: bq
@@ -1000,7 +1000,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Fortis
@@ -1018,7 +1018,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: Alcatel
@@ -1036,7 +1036,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Sky
@@ -1054,7 +1054,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sky
@@ -1072,7 +1072,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Sky
@@ -1090,7 +1090,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sky
@@ -1108,7 +1108,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Blu
@@ -1126,7 +1126,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Blu
@@ -1144,7 +1144,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Blu
@@ -1162,7 +1162,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Wiko
@@ -1180,7 +1180,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: phablet
     brand: Alcatel
@@ -1198,7 +1198,7 @@
     name: Chrome Mobile
     version: 83.0.4103.60
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.60"
   device:
     type: smartphone
     brand: iSWAG
@@ -1216,7 +1216,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Zuum
@@ -1234,7 +1234,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: LG
@@ -1270,7 +1270,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Samsung
@@ -1288,7 +1288,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Samsung
@@ -1306,7 +1306,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Samsung
@@ -1324,7 +1324,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Samsung
@@ -1342,7 +1342,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Samsung
@@ -1360,7 +1360,7 @@
     name: Chrome Mobile
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: smartphone
     brand: Samsung
@@ -1378,7 +1378,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -1396,7 +1396,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Mediacom
@@ -1414,7 +1414,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -1432,7 +1432,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -1450,7 +1450,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Alcatel
@@ -1468,7 +1468,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Alcatel
@@ -1486,7 +1486,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Alcatel
@@ -1504,7 +1504,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: phablet
     brand: Alcatel
@@ -1522,7 +1522,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Alcatel
@@ -1540,7 +1540,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Alcatel
@@ -1558,7 +1558,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: phablet
     brand: Alcatel
@@ -1576,7 +1576,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Huawei
@@ -1594,7 +1594,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Maxwest
@@ -1612,7 +1612,7 @@
     name: Chrome Mobile
     version: 76.0.3809.45
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.45"
   device:
     type: smartphone
     brand: Elephone
@@ -1630,7 +1630,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Black Bear
@@ -1648,7 +1648,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Black Bear
@@ -1666,7 +1666,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: OpelMobile
@@ -1684,7 +1684,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tv
     brand: Vorke
@@ -1823,7 +1823,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: NuAns
@@ -1841,7 +1841,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Nubia
@@ -1859,7 +1859,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tv
     brand: Eltex
@@ -1877,7 +1877,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tv
     brand: Eltex
@@ -1895,7 +1895,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -1945,7 +1945,7 @@
     name: Yandex Browser
     version: 20.11.3.88.00
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Lenovo
@@ -1963,7 +1963,7 @@
     name: Chrome Mobile
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: smartphone
     brand: Vsmart
@@ -1981,7 +1981,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: bq
@@ -1999,7 +1999,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: bq
@@ -2017,7 +2017,7 @@
     name: Chrome Mobile
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: smartphone
     brand: Ulefone
@@ -2035,7 +2035,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Ulefone
@@ -2053,7 +2053,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Ulefone
@@ -2071,7 +2071,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Ulefone
@@ -2089,7 +2089,7 @@
     name: Chrome Mobile
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: smartphone
     brand: Ulefone
@@ -2107,7 +2107,7 @@
     name: Chrome Webview
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Ulefone
@@ -2125,7 +2125,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Ulefone
@@ -2143,7 +2143,7 @@
     name: Chrome Mobile
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: smartphone
     brand: Ulefone
@@ -2177,7 +2177,7 @@
     name: Chrome
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Tesco
@@ -2195,7 +2195,7 @@
     name: Chrome Webview
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Mobicel
@@ -2213,7 +2213,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Orange
@@ -2231,7 +2231,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Homtom
@@ -2249,7 +2249,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Huawei
@@ -2267,7 +2267,7 @@
     name: Chrome
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: Voyo
@@ -2285,7 +2285,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Koolnee
@@ -2303,7 +2303,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: Yoka TV
@@ -2321,7 +2321,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: Mecool
@@ -2339,7 +2339,7 @@
     name: Chrome
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tv
     brand: Mecool
@@ -2357,7 +2357,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: Mecool
@@ -2375,7 +2375,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tv
     brand: Invin
@@ -2393,7 +2393,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: Invin
@@ -2411,7 +2411,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Meizu
@@ -2429,7 +2429,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Meizu
@@ -2447,7 +2447,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Vsun
@@ -2465,7 +2465,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Sansui
@@ -2483,7 +2483,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Sansui
@@ -2501,7 +2501,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Sansui
@@ -2555,7 +2555,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Sansui
@@ -2591,7 +2591,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Sansui
@@ -2609,7 +2609,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Sansui
@@ -2627,7 +2627,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Sansui
@@ -2645,7 +2645,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Sico
@@ -2663,7 +2663,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Sico
@@ -2681,7 +2681,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Smadl
@@ -2699,7 +2699,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Karbonn
@@ -2717,7 +2717,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: iBall
@@ -2735,7 +2735,7 @@
     name: Chrome Webview
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Tymes
@@ -2753,7 +2753,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Thomson
@@ -2771,7 +2771,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Blu
@@ -2789,7 +2789,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Blu
@@ -2807,7 +2807,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Blu
@@ -2825,7 +2825,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Blu
@@ -2843,7 +2843,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Mobicel
@@ -2861,7 +2861,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Solone
@@ -2879,7 +2879,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Solone
@@ -2897,7 +2897,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Solone
@@ -2915,7 +2915,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Vulcan
@@ -2933,7 +2933,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Vulcan
@@ -2951,7 +2951,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Vulcan
@@ -2969,7 +2969,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Iris
@@ -2987,7 +2987,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Iris
@@ -3005,7 +3005,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Iris
@@ -3023,7 +3023,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: iMars
@@ -3041,7 +3041,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: FarEasTone
@@ -3059,7 +3059,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: FarEasTone
@@ -3077,7 +3077,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: FarEasTone
@@ -3113,7 +3113,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: öwn
@@ -3131,7 +3131,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Smailo
@@ -3149,7 +3149,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Smadl
@@ -3167,7 +3167,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Smadl
@@ -3185,7 +3185,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Sky
@@ -3203,7 +3203,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Sky
@@ -3221,7 +3221,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Premio
@@ -3239,7 +3239,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Allview
@@ -3257,7 +3257,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Allview
@@ -3275,7 +3275,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Allview
@@ -3293,7 +3293,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Allview
@@ -3311,7 +3311,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Timovi
@@ -3329,7 +3329,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Umax
@@ -3347,7 +3347,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: Umax
@@ -3365,7 +3365,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Umax
@@ -3383,7 +3383,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Timovi
@@ -3401,7 +3401,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Kzen
@@ -3419,7 +3419,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Casper
@@ -3437,7 +3437,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Colors
@@ -3455,7 +3455,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Colors
@@ -3473,7 +3473,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Colors
@@ -3491,7 +3491,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Colors
@@ -3509,7 +3509,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Colors
@@ -3527,7 +3527,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Colors
@@ -3545,7 +3545,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Colors
@@ -3563,7 +3563,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Avvio
@@ -3581,7 +3581,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: Cloudfone
@@ -3599,7 +3599,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: AVH
@@ -3617,7 +3617,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Honeywell
@@ -3635,7 +3635,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Honeywell
@@ -3653,7 +3653,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Honeywell
@@ -3671,7 +3671,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Honeywell
@@ -3689,7 +3689,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Electroneum
@@ -3707,7 +3707,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Sky
@@ -3725,7 +3725,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Sky
@@ -3743,7 +3743,7 @@
     name: Chrome
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: tablet
     brand: High Q
@@ -3761,7 +3761,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: High Q
@@ -3779,7 +3779,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: High Q
@@ -3797,7 +3797,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Energizer
@@ -3815,7 +3815,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Energizer
@@ -3833,7 +3833,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Timovi
@@ -3851,7 +3851,7 @@
     name: Chrome Mobile
     version: 84.0.4147.53
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.53"
   device:
     type: smartphone
     brand: Xolo
@@ -3869,7 +3869,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Xolo
@@ -3887,7 +3887,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Xolo
@@ -3905,7 +3905,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Hyundai
@@ -3923,7 +3923,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Premio
@@ -3941,7 +3941,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Premio
@@ -3959,7 +3959,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Colors
@@ -3977,7 +3977,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Mobicel
@@ -3995,7 +3995,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Accent
@@ -4013,7 +4013,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: EXO
@@ -4031,7 +4031,7 @@
     name: Chrome
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: Cherry Mobile
@@ -4049,7 +4049,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Sky
@@ -4067,7 +4067,7 @@
     name: Chrome
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: ProScan
@@ -4085,7 +4085,7 @@
     name: Chrome
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: tablet
     brand: Concord
@@ -4103,7 +4103,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Concord
@@ -4121,7 +4121,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Pluzz
@@ -4139,7 +4139,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Pluzz
@@ -4157,7 +4157,7 @@
     name: Chrome Mobile
     version: 60.0.3112.116
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Pluzz
@@ -4175,7 +4175,7 @@
     name: Chrome Webview
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Pluzz
@@ -4193,7 +4193,7 @@
     name: Chrome Mobile
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Pluzz
@@ -4211,7 +4211,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Pluzz
@@ -4229,7 +4229,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Pluzz
@@ -4247,7 +4247,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Polytron
@@ -4265,7 +4265,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Polytron
@@ -4283,7 +4283,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Polytron
@@ -4301,7 +4301,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Polaroid
@@ -4319,7 +4319,7 @@
     name: Chrome
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: tablet
     brand: Positivo BGH
@@ -4337,7 +4337,7 @@
     name: Chrome
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: tablet
     brand: Positivo BGH
@@ -4355,7 +4355,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: IKU Mobile
@@ -4373,7 +4373,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Primux
@@ -4391,7 +4391,7 @@
     name: Chrome
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Primux
@@ -4409,7 +4409,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Primux
@@ -4427,7 +4427,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Primux
@@ -4445,7 +4445,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Prixton
@@ -4463,7 +4463,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Magnus
@@ -4481,7 +4481,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Magnus
@@ -4499,7 +4499,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Magnus
@@ -4517,7 +4517,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Magnus
@@ -4535,7 +4535,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Vsun
@@ -4553,7 +4553,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Vsun
@@ -4571,7 +4571,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Hotwav
@@ -4589,7 +4589,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Oukitel
@@ -4607,7 +4607,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: OKWU
@@ -4625,7 +4625,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: CG Mobile
@@ -4643,7 +4643,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: CG Mobile
@@ -4661,7 +4661,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -4679,7 +4679,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: 'ZH&K'
@@ -4697,7 +4697,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: 'ZH&K'
@@ -4715,7 +4715,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: VGO TEL
@@ -4733,7 +4733,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: VGO TEL
@@ -4751,7 +4751,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: VGO TEL
@@ -4769,7 +4769,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: VGO TEL
@@ -4787,7 +4787,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: NUU Mobile
@@ -4805,7 +4805,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Hotwav
@@ -4823,7 +4823,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Hotwav
@@ -4841,7 +4841,7 @@
     name: Chrome Mobile
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Hotwav
@@ -4859,7 +4859,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Hotwav
@@ -4877,7 +4877,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Hotwav
@@ -4895,7 +4895,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Mito
@@ -4913,7 +4913,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Mito
@@ -4931,7 +4931,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Mito
@@ -4949,7 +4949,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Mito
@@ -4967,7 +4967,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Mito
@@ -4985,7 +4985,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Avvio
@@ -5003,7 +5003,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Senwa
@@ -5021,7 +5021,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Senwa
@@ -5039,7 +5039,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Senwa
@@ -5057,7 +5057,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Senwa
@@ -5075,7 +5075,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: Senwa
@@ -5093,7 +5093,7 @@
     name: Chrome Mobile
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: smartphone
     brand: QMobile
@@ -5111,7 +5111,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Ordissimo
@@ -5129,7 +5129,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Leagoo
@@ -5147,7 +5147,7 @@
     name: Chrome
     version: 80.0.3987.117
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: tablet
     brand: Leagoo
@@ -5165,7 +5165,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Logicom
@@ -5183,7 +5183,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Logicom
@@ -5201,7 +5201,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Logicom
@@ -5219,7 +5219,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Explay
@@ -5237,7 +5237,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: Lark
@@ -5255,7 +5255,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: LAIQ
@@ -5273,7 +5273,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Logicom
@@ -5291,7 +5291,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Logicom
@@ -5309,7 +5309,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Logicom
@@ -5327,7 +5327,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Logicom
@@ -5345,7 +5345,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Logicom
@@ -5363,7 +5363,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Logicom
@@ -5381,7 +5381,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Logicom
@@ -5399,7 +5399,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Logicom
@@ -5417,7 +5417,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Logicom
@@ -5435,7 +5435,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Logicom
@@ -5453,7 +5453,7 @@
     name: Chrome
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: tablet
     brand: Logicom
@@ -5471,7 +5471,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Logicom
@@ -5489,7 +5489,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Logicom
@@ -5507,7 +5507,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Logicom
@@ -5525,7 +5525,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Logicom
@@ -5543,7 +5543,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Logicom
@@ -5561,7 +5561,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Logicom
@@ -5579,7 +5579,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Logicom
@@ -5597,7 +5597,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Logicom
@@ -5615,7 +5615,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tv
     brand: JVC
@@ -5633,7 +5633,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: NEC
@@ -5651,7 +5651,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Lanix
@@ -5669,7 +5669,7 @@
     name: Chrome Mobile
     version: 74.0.3729.11
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.11"
   device:
     type: smartphone
     brand: IUNI
@@ -5687,7 +5687,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: IUNI
@@ -5705,7 +5705,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Doogee
@@ -5723,7 +5723,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Vivax
@@ -5741,7 +5741,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Mediacom
@@ -5759,7 +5759,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Mediacom
@@ -5777,7 +5777,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Mediacom
@@ -5795,7 +5795,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Mediacom
@@ -5813,7 +5813,7 @@
     name: Chrome
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: tablet
     brand: Mediacom
@@ -5831,7 +5831,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Mediacom
@@ -5849,7 +5849,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Mediacom
@@ -5867,7 +5867,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Mediacom
@@ -5885,7 +5885,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Mediacom
@@ -5903,7 +5903,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: Necnot
@@ -5921,7 +5921,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: Necnot
@@ -5939,7 +5939,7 @@
     name: Chrome
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: Necnot
@@ -5957,7 +5957,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: Necnot
@@ -5975,7 +5975,7 @@
     name: Chrome
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: Necnot
@@ -5993,7 +5993,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Necnot
@@ -6011,7 +6011,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: Necnot
@@ -6029,7 +6029,7 @@
     name: Chrome
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Necnot
@@ -6047,7 +6047,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Alcatel
@@ -6065,7 +6065,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Multilaser
@@ -6083,7 +6083,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Multilaser
@@ -6101,7 +6101,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Multilaser
@@ -6119,7 +6119,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Sky
@@ -6137,7 +6137,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Sky
@@ -6155,7 +6155,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Sky
@@ -6173,7 +6173,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Navon
@@ -6191,7 +6191,7 @@
     name: Chrome
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: Sky
@@ -6209,7 +6209,7 @@
     name: Chrome
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: tablet
     brand: Navon
@@ -6227,7 +6227,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Sky
@@ -6245,7 +6245,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Sky
@@ -6263,7 +6263,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Sky
@@ -6281,7 +6281,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Onda
@@ -6299,7 +6299,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Overmax
@@ -6317,7 +6317,7 @@
     name: Chrome
     version: 30.0.1599.92
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.92"
   device:
     type: car browser
     brand: Allwinner
@@ -6335,7 +6335,7 @@
     name: Chrome
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Allwinner
@@ -6353,7 +6353,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Q-Touch
@@ -6371,7 +6371,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Q-Touch
@@ -6389,7 +6389,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Q.Bell
@@ -6407,7 +6407,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Q.Bell
@@ -6425,7 +6425,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Q.Bell
@@ -6443,7 +6443,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Qilive
@@ -6461,7 +6461,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Q.Bell
@@ -6479,7 +6479,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: MyPhone
@@ -6497,7 +6497,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Symphony
@@ -6515,7 +6515,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Symphony
@@ -6533,7 +6533,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Symphony
@@ -6551,7 +6551,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Fero
@@ -6569,7 +6569,7 @@
     name: Chrome Mobile
     version: 68.0.3440.85
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.85"
   device:
     type: smartphone
     brand: Fero
@@ -6587,7 +6587,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Fero
@@ -6605,7 +6605,7 @@
     name: Chrome Mobile
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Ruio
@@ -6623,7 +6623,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Ruio
@@ -6641,7 +6641,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Qilive
@@ -6659,7 +6659,7 @@
     name: Chrome
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: Qilive
@@ -6677,7 +6677,7 @@
     name: Chrome Mobile
     version: 85.0.4183.120
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: smartphone
     brand: Highscreen
@@ -6695,7 +6695,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Highscreen
@@ -6713,7 +6713,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Invens
@@ -6731,7 +6731,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Invens
@@ -6749,7 +6749,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tv
     brand: Eagle
@@ -6767,7 +6767,7 @@
     name: Chrome
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tv
     brand: Eagle
@@ -6785,7 +6785,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tv
     brand: Eagle
@@ -6803,7 +6803,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Myros
@@ -6821,7 +6821,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Sky
@@ -6839,7 +6839,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Sky
@@ -6857,7 +6857,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Einstein
@@ -6875,7 +6875,7 @@
     name: Chrome Webview
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Mobicel
@@ -6893,7 +6893,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: phablet
     brand: AfriOne
@@ -6911,7 +6911,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: phablet
     brand: AfriOne
@@ -6929,7 +6929,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: AfriOne
@@ -6947,7 +6947,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: AfriOne
@@ -6965,7 +6965,7 @@
     name: Chrome
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: Connex
@@ -6983,7 +6983,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Connex
@@ -7001,7 +7001,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Connectce
@@ -7019,7 +7019,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Clementoni
@@ -7037,7 +7037,7 @@
     name: Chrome
     version: 75.0.3770.89
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: tablet
     brand: Clementoni
@@ -7091,7 +7091,7 @@
     name: Chrome
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Clementoni
@@ -7109,7 +7109,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Clementoni
@@ -7127,7 +7127,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Clementoni
@@ -7145,7 +7145,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: Clementoni
@@ -7163,7 +7163,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Clementoni
@@ -7181,7 +7181,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Clementoni
@@ -7199,7 +7199,7 @@
     name: Chrome
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: Clementoni
@@ -7217,7 +7217,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Digma
@@ -7235,7 +7235,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Digma
@@ -7253,7 +7253,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: Digma
@@ -7271,7 +7271,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: Digma
@@ -7289,7 +7289,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Changhong
@@ -7307,7 +7307,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Changhong
@@ -7325,7 +7325,7 @@
     name: Opera
     version: 42.9.2246.119956
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tv
     brand: Changhong
@@ -7343,7 +7343,7 @@
     name: Chrome Mobile
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Changhong
@@ -7361,7 +7361,7 @@
     name: Chrome Mobile
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Changhong
@@ -7397,7 +7397,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Changhong
@@ -7415,7 +7415,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Changhong
@@ -7433,7 +7433,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: CG Mobile
@@ -7451,7 +7451,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: FiGO
@@ -7469,7 +7469,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Cell-C
@@ -7487,7 +7487,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Cell-C
@@ -7505,7 +7505,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Casper
@@ -7523,7 +7523,7 @@
     name: Chrome
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: tablet
     brand: Cell-C
@@ -7541,7 +7541,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: VC
@@ -7559,7 +7559,7 @@
     name: Chrome Mobile
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: VC
@@ -7577,7 +7577,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: VC
@@ -7595,7 +7595,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: VC
@@ -7631,7 +7631,7 @@
     name: Chrome Webview
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: VC
@@ -7649,7 +7649,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: VC
@@ -7667,7 +7667,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Accent
@@ -7685,7 +7685,7 @@
     name: Chrome
     version: 50.0.2661.89
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: tablet
     brand: Digma
@@ -7703,7 +7703,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Digma
@@ -7721,7 +7721,7 @@
     name: Chrome
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: Digma
@@ -7739,7 +7739,7 @@
     name: Chrome
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: tablet
     brand: Digma
@@ -7757,7 +7757,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: Digma
@@ -7775,7 +7775,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Digma
@@ -7793,7 +7793,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Amoi
@@ -7811,7 +7811,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Amoi
@@ -7829,7 +7829,7 @@
     name: Chrome
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Amoi
@@ -7847,7 +7847,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Amoi
@@ -7865,7 +7865,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Amoi
@@ -7883,7 +7883,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Amoi
@@ -7901,7 +7901,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Amoi
@@ -7919,7 +7919,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: CellAllure
@@ -7937,7 +7937,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: CellAllure
@@ -7955,7 +7955,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: CellAllure
@@ -7973,7 +7973,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: CellAllure
@@ -7991,7 +7991,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: CellAllure
@@ -8009,7 +8009,7 @@
     name: Chrome Webview
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Hurricane
@@ -8027,7 +8027,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Colors
@@ -8045,7 +8045,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Vivax
@@ -8063,7 +8063,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: Chico Mobile
@@ -8081,7 +8081,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Chico Mobile
@@ -8099,7 +8099,7 @@
     name: Chrome Mobile
     version: 80.0.3987.117
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: smartphone
     brand: Chico Mobile
@@ -8117,7 +8117,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Chico Mobile
@@ -8135,7 +8135,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Chico Mobile
@@ -8153,7 +8153,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Chico Mobile
@@ -8171,7 +8171,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Chico Mobile
@@ -8189,7 +8189,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Chico Mobile
@@ -8207,7 +8207,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Chico Mobile
@@ -8225,7 +8225,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Chico Mobile
@@ -8243,7 +8243,7 @@
     name: Chrome Mobile
     version: 60.0.3112.107
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.107"
   device:
     type: smartphone
     brand: Chico Mobile
@@ -8261,7 +8261,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Chico Mobile
@@ -8279,7 +8279,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: CellAllure
@@ -8297,7 +8297,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Claresta
@@ -8315,7 +8315,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Claresta
@@ -8333,7 +8333,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Claresta
@@ -8351,7 +8351,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Claresta
@@ -8387,7 +8387,7 @@
     name: Chrome Webview
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: ConCorde
@@ -8405,7 +8405,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Colors
@@ -8423,7 +8423,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Colors
@@ -8441,7 +8441,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Clarmin
@@ -8459,7 +8459,7 @@
     name: Chrome Webview
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: MIVO
@@ -8477,7 +8477,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: MIVO
@@ -8495,7 +8495,7 @@
     name: Chrome Webview
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: MIVO
@@ -8513,7 +8513,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: MIVO
@@ -8531,7 +8531,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: MIVO
@@ -8549,7 +8549,7 @@
     name: Chrome Mobile
     version: 77.0.3865.73
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: MIVO
@@ -8567,7 +8567,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: MIVO
@@ -8585,7 +8585,7 @@
     name: Chrome Webview
     version: 69.0.3497.91
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: smartphone
     brand: Jesy
@@ -8603,7 +8603,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: MIVO
@@ -8621,7 +8621,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: MIVO
@@ -8639,7 +8639,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Fero
@@ -8657,7 +8657,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Fero
@@ -8675,7 +8675,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Fero
@@ -8693,7 +8693,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Fero
@@ -8711,7 +8711,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Fero
@@ -8729,7 +8729,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Fero
@@ -8747,7 +8747,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Fero
@@ -8765,7 +8765,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: phablet
     brand: Gome
@@ -8783,7 +8783,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Mobicel
@@ -8801,7 +8801,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: phablet
     brand: Accent
@@ -8819,7 +8819,7 @@
     name: Chrome
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: tablet
     brand: Sico
@@ -8837,7 +8837,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: tablet
     brand: EXCEED
@@ -8855,7 +8855,7 @@
     name: Chrome
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: tablet
     brand: EXCEED
@@ -8873,7 +8873,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: EXCEED
@@ -8891,7 +8891,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: CUBOT
@@ -8909,7 +8909,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: MyPhone
@@ -8927,7 +8927,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Voyo
@@ -8945,7 +8945,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Navon
@@ -8963,7 +8963,7 @@
     name: Chrome Mobile
     version: 84.0.4147.69
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.69"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8981,7 +8981,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Camfone
@@ -8999,7 +8999,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Camfone
@@ -9017,7 +9017,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Camfone
@@ -9035,7 +9035,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Camfone
@@ -9053,7 +9053,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Camfone
@@ -9071,7 +9071,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Camfone
@@ -9089,7 +9089,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Camfone
@@ -9107,7 +9107,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Camfone
@@ -9125,7 +9125,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Camfone
@@ -9143,7 +9143,7 @@
     name: Chrome Mobile
     version: 81.0.4044.26
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.26"
   device:
     type: smartphone
     brand: Camfone
@@ -9161,7 +9161,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Camfone
@@ -9179,7 +9179,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Camfone
@@ -9197,7 +9197,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Gome
@@ -9215,7 +9215,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: IKI Mobile
@@ -9233,7 +9233,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: IKI Mobile
@@ -9251,7 +9251,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: IKI Mobile
@@ -9269,7 +9269,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: iBall
@@ -9287,7 +9287,7 @@
     name: Chrome
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: iBall
@@ -9305,7 +9305,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Bellphone
@@ -9323,7 +9323,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Gome
@@ -9341,7 +9341,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Sony
@@ -9359,7 +9359,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Gini
@@ -9377,7 +9377,7 @@
     name: Opera Mobile
     version: 54.3.2672.50220
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Gini
@@ -9395,7 +9395,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Gini
@@ -9413,7 +9413,7 @@
     name: Chrome
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: tablet
     brand: Gini
@@ -9431,7 +9431,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Gini
@@ -9449,7 +9449,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: iTel
@@ -9467,7 +9467,7 @@
     name: Chrome
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: tablet
     brand: Chuwi
@@ -9485,7 +9485,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Mpman
@@ -9503,7 +9503,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Mpman
@@ -9521,7 +9521,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Reeder
@@ -9539,7 +9539,7 @@
     name: Chrome
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: Navon
@@ -9557,7 +9557,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: SWISSMOBILITY
@@ -9575,7 +9575,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: SWISSMOBILITY
@@ -9593,7 +9593,7 @@
     name: Chrome
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: tablet
     brand: Advance
@@ -9611,7 +9611,7 @@
     name: Chrome
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: tablet
     brand: Advance
@@ -9629,7 +9629,7 @@
     name: Chrome
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: tablet
     brand: Advance
@@ -9647,7 +9647,7 @@
     name: Chrome
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: Advance
@@ -9665,7 +9665,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Advance
@@ -9683,7 +9683,7 @@
     name: Chrome
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: Advance
@@ -9701,7 +9701,7 @@
     name: Yandex Browser
     version: 21.56.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: ZTE
@@ -9719,7 +9719,7 @@
     name: Chrome Mobile
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: M-Tech
@@ -9737,7 +9737,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: M-Tech
@@ -9755,7 +9755,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: M-Tech

--- a/Tests/fixtures/smartphone-21.yml
+++ b/Tests/fixtures/smartphone-21.yml
@@ -10,7 +10,7 @@
     name: Chrome
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: tablet
     brand: Advance
@@ -28,7 +28,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: MyPhone
@@ -46,7 +46,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: MyPhone
@@ -64,7 +64,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Walton
@@ -82,7 +82,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Walton
@@ -100,7 +100,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Walton
@@ -118,7 +118,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Walton
@@ -136,7 +136,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Walton
@@ -154,7 +154,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Walton
@@ -172,7 +172,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Walton
@@ -190,7 +190,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Walton
@@ -208,7 +208,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Walton
@@ -226,7 +226,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Walton
@@ -244,7 +244,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Walton
@@ -262,7 +262,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Walton
@@ -280,7 +280,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Walton
@@ -298,7 +298,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Walton
@@ -334,7 +334,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Walton
@@ -352,7 +352,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Teknosa
@@ -370,7 +370,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Teknosa
@@ -388,7 +388,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Teknosa
@@ -406,7 +406,7 @@
     name: Chrome Mobile
     version: 75.0.3770.89
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Primux
@@ -424,7 +424,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Primux
@@ -442,7 +442,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Primux
@@ -478,7 +478,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Primux
@@ -496,7 +496,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Cavion
@@ -514,7 +514,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: EWIS
@@ -532,7 +532,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Cavion
@@ -550,7 +550,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: AMGOO
@@ -568,7 +568,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Leader Phone
@@ -586,7 +586,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: GLX
@@ -604,7 +604,7 @@
     name: Chrome
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: GLX
@@ -622,7 +622,7 @@
     name: Chrome Webview
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: GLX
@@ -658,7 +658,7 @@
     name: Chrome Mobile
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: GLX
@@ -676,7 +676,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: GLX
@@ -694,7 +694,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Hyve
@@ -712,7 +712,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Hyve
@@ -730,7 +730,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Azumi Mobile
@@ -748,7 +748,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Karbonn
@@ -766,7 +766,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Seeken
@@ -784,7 +784,7 @@
     name: Chrome Webview
     version: 50.0.2661.86
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Seeken
@@ -802,7 +802,7 @@
     name: Chrome Webview
     version: 54.0.2840.85
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: tablet
     brand: Seeken
@@ -820,7 +820,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Extrem
@@ -838,7 +838,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Polytron
@@ -856,7 +856,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Denver
@@ -874,7 +874,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Denver
@@ -892,7 +892,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Denver
@@ -910,7 +910,7 @@
     name: Chrome Mobile
     version: 66.0.3359.126
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Denver
@@ -928,7 +928,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Denver
@@ -946,7 +946,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Denver
@@ -964,7 +964,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: FireFly Mobile
@@ -982,7 +982,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Kyocera
@@ -1000,7 +1000,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: LG
@@ -1018,7 +1018,7 @@
     name: Chrome Mobile
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Kyocera
@@ -1036,7 +1036,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Fujitsu
@@ -1054,7 +1054,7 @@
     name: Chrome Webview
     version: 67.0.3396.127
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.127"
   device:
     type: smartphone
     brand: Sharp
@@ -1090,7 +1090,7 @@
     name: Chrome Webview
     version: 33.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Sharp
@@ -1108,7 +1108,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: LG
@@ -1126,7 +1126,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Jivi
@@ -1144,7 +1144,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Jivi
@@ -1162,7 +1162,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Jivi
@@ -1180,7 +1180,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Jivi
@@ -1198,7 +1198,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Jivi
@@ -1216,7 +1216,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Jivi
@@ -1234,7 +1234,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Jivi
@@ -1252,7 +1252,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Vonino
@@ -1270,7 +1270,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Xtouch
@@ -1288,7 +1288,7 @@
     name: Chrome
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: Odys
@@ -1306,7 +1306,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: WE
@@ -1324,7 +1324,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: WE
@@ -1342,7 +1342,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: WE
@@ -1360,7 +1360,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: WE
@@ -1378,7 +1378,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: WE
@@ -1396,7 +1396,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: WE
@@ -1414,7 +1414,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: WE
@@ -1432,7 +1432,7 @@
     name: Chrome Mobile
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: WE
@@ -1450,7 +1450,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: WE
@@ -1468,7 +1468,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: WE
@@ -1486,7 +1486,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: WE
@@ -1504,7 +1504,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: WE
@@ -1522,7 +1522,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: WE
@@ -1540,7 +1540,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: WE
@@ -1558,7 +1558,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: WE
@@ -1576,7 +1576,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: WE
@@ -1594,7 +1594,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: WE
@@ -1612,7 +1612,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: WE
@@ -1630,7 +1630,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: WE
@@ -1648,7 +1648,7 @@
     name: Chrome
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: Allview
@@ -1666,7 +1666,7 @@
     name: Chrome
     version: 86.0.4240.114
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.114"
   device:
     type: tablet
     brand: Lenovo
@@ -1684,7 +1684,7 @@
     name: Chrome
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: tablet
     brand: Klipad
@@ -1702,7 +1702,7 @@
     name: Chrome
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: tablet
     brand: Lenovo
@@ -1720,7 +1720,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Teclast
@@ -1738,7 +1738,7 @@
     name: Chrome
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: tablet
     brand: Samsung
@@ -1756,7 +1756,7 @@
     name: Chrome
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: tablet
     brand: Samsung
@@ -1774,7 +1774,7 @@
     name: Chrome
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: tablet
     brand: Samsung
@@ -1792,7 +1792,7 @@
     name: Chrome
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: tablet
     brand: Hometech
@@ -1810,7 +1810,7 @@
     name: Chrome
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: tablet
     brand: iBall
@@ -1828,7 +1828,7 @@
     name: Chrome Mobile
     version: 87.0.4280.20
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.20"
   device:
     type: smartphone
     brand: Xiaomi
@@ -1846,7 +1846,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Innos
@@ -1864,7 +1864,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Lumus
@@ -1882,7 +1882,7 @@
     name: Chrome
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: tablet
     brand: Hometech
@@ -1900,7 +1900,7 @@
     name: Chrome
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: tablet
     brand: RCA Tablets
@@ -1918,7 +1918,7 @@
     name: Chrome
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: tablet
     brand: Concord
@@ -1936,7 +1936,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -1954,7 +1954,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Samsung
@@ -1972,7 +1972,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Samsung
@@ -1990,7 +1990,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Samsung
@@ -2008,7 +2008,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Samsung
@@ -2026,7 +2026,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Samsung
@@ -2044,7 +2044,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Samsung
@@ -2062,7 +2062,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Hometech
@@ -2080,7 +2080,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Lenovo
@@ -2098,7 +2098,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Lenovo
@@ -2116,7 +2116,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: LG
@@ -2134,7 +2134,7 @@
     name: Chrome Mobile
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: smartphone
     brand: LG
@@ -2152,7 +2152,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: LG
@@ -2170,7 +2170,7 @@
     name: Chrome Webview
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: LG
@@ -2206,7 +2206,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: phablet
     brand: LG
@@ -2224,7 +2224,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: LG
@@ -2242,7 +2242,7 @@
     name: Chrome Webview
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: smartphone
     brand: LG
@@ -2260,7 +2260,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: LG
@@ -2278,7 +2278,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: LG
@@ -2296,7 +2296,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: LG
@@ -2314,7 +2314,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: LG
@@ -2332,7 +2332,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: LG
@@ -2350,7 +2350,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: LG
@@ -2368,7 +2368,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: LG
@@ -2386,7 +2386,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: LG
@@ -2404,7 +2404,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: LG
@@ -2422,7 +2422,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: LG
@@ -2440,7 +2440,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: LG
@@ -2458,7 +2458,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: LG
@@ -2476,7 +2476,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: LG
@@ -2494,7 +2494,7 @@
     name: Chrome Mobile
     version: 88.0.4292.0
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4292.0"
   device:
     type: phablet
     brand: LG
@@ -2512,7 +2512,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Condor
@@ -2530,7 +2530,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Vertex
@@ -2548,7 +2548,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Vertex
@@ -2566,7 +2566,7 @@
     name: Chrome Mobile
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: smartphone
     brand: Vertex
@@ -2584,7 +2584,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Vertex
@@ -2602,7 +2602,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Intex
@@ -2620,7 +2620,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Intex
@@ -2638,7 +2638,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Intex
@@ -2656,7 +2656,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Condor
@@ -2674,7 +2674,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Trio
@@ -2692,7 +2692,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Huawei
@@ -2710,7 +2710,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Soyes
@@ -2728,7 +2728,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Condor
@@ -2746,7 +2746,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Condor
@@ -2764,7 +2764,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Condor
@@ -2782,7 +2782,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Condor
@@ -2800,7 +2800,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: iPro
@@ -2818,7 +2818,7 @@
     name: Chrome
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: tablet
     brand: iNew
@@ -2836,7 +2836,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Chico Mobile
@@ -2854,7 +2854,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Chico Mobile
@@ -2872,7 +2872,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Chico Mobile
@@ -2890,7 +2890,7 @@
     name: Chrome Webview
     version: 44.0.2403.119
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: tablet
     brand: Winnovo
@@ -2908,7 +2908,7 @@
     name: Chrome
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Winnovo
@@ -2926,7 +2926,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Winnovo
@@ -2944,7 +2944,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Winnovo
@@ -2962,7 +2962,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Winnovo
@@ -2980,7 +2980,7 @@
     name: Chrome Mobile
     version: 80.0.3987.117
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: smartphone
     brand: Winnovo
@@ -2998,7 +2998,7 @@
     name: Chrome Mobile
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Winnovo
@@ -3016,7 +3016,7 @@
     name: Chrome Webview
     version: 43.0.2357.121
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: tablet
     brand: Winnovo
@@ -3050,7 +3050,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Doogee
@@ -3068,7 +3068,7 @@
     name: Chrome Webview
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Kodak
@@ -3086,7 +3086,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Motorola
@@ -3104,7 +3104,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Essentielb
@@ -3122,7 +3122,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Seuic
@@ -3140,7 +3140,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Blu
@@ -3158,7 +3158,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Blaupunkt
@@ -3176,7 +3176,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Primux
@@ -3194,7 +3194,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Centric
@@ -3212,7 +3212,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Centric
@@ -3230,7 +3230,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Centric
@@ -3248,7 +3248,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: CG Mobile
@@ -3266,7 +3266,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Beyond
@@ -3284,7 +3284,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Beyond
@@ -3302,7 +3302,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Beyond
@@ -3320,7 +3320,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Beyond
@@ -3338,7 +3338,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Beyond
@@ -3356,7 +3356,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Beyond
@@ -3374,7 +3374,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Beyond
@@ -3392,7 +3392,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Ghia
@@ -3410,7 +3410,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Ghia
@@ -3428,7 +3428,7 @@
     name: Chrome
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: TWZ
@@ -3446,7 +3446,7 @@
     name: Chrome Webview
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: TWZ
@@ -3464,7 +3464,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: TWZ
@@ -3482,7 +3482,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: TWZ
@@ -3500,7 +3500,7 @@
     name: Opera Mobile
     version: 50.3.2426.136976
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: TWZ
@@ -3518,7 +3518,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: TWZ
@@ -3536,7 +3536,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: TWZ
@@ -3572,7 +3572,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: TWZ
@@ -3590,7 +3590,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: TWZ
@@ -3626,7 +3626,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: TWZ
@@ -3644,7 +3644,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Starmobile
@@ -3662,7 +3662,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Starmobile
@@ -3680,7 +3680,7 @@
     name: Chrome
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: LG
@@ -3698,7 +3698,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Sky
@@ -3716,7 +3716,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Sky
@@ -3734,7 +3734,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Sky
@@ -3752,7 +3752,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Sky
@@ -3770,7 +3770,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Sky
@@ -3788,7 +3788,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Swipe
@@ -3806,7 +3806,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Energizer
@@ -3824,7 +3824,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Geotel
@@ -3842,7 +3842,7 @@
     name: Chrome
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tablet
     brand: iBall
@@ -3860,7 +3860,7 @@
     name: Chrome
     version: 80.0.3987.117
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: tablet
     brand: iBall
@@ -3878,7 +3878,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: iBall
@@ -3896,7 +3896,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: tablet
     brand: iBall
@@ -3914,7 +3914,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Intex
@@ -3932,7 +3932,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: iLife
@@ -3950,7 +3950,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: iLife
@@ -3968,7 +3968,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Inoi
@@ -3986,7 +3986,7 @@
     name: Chrome
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Casper
@@ -4004,7 +4004,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: ZTE
@@ -4022,7 +4022,7 @@
     name: Yandex Browser
     version: 20.115.0
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Inoi
@@ -4040,7 +4040,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Iris
@@ -4058,7 +4058,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Iris
@@ -4076,7 +4076,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Iris
@@ -4094,7 +4094,7 @@
     name: Chrome
     version: 59.0.3071.125
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Lava
@@ -4112,7 +4112,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Lava
@@ -4130,7 +4130,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: iVooMi
@@ -4148,7 +4148,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Thomson
@@ -4166,7 +4166,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tv
     brand: Formuler
@@ -4184,7 +4184,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: tv
     brand: Formuler
@@ -4202,7 +4202,7 @@
     name: Chrome Mobile
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: FORME
@@ -4220,7 +4220,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: FORME
@@ -4238,7 +4238,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Advance
@@ -4256,7 +4256,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Advance
@@ -4274,7 +4274,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Advance
@@ -4292,7 +4292,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Advance
@@ -4310,7 +4310,7 @@
     name: Chrome Mobile
     version: 81.0.4044.26
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.26"
   device:
     type: smartphone
     brand: Kata
@@ -4328,7 +4328,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Kata
@@ -4346,7 +4346,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Kata
@@ -4364,7 +4364,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Kata
@@ -4382,7 +4382,7 @@
     name: Chrome
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: Kata
@@ -4400,7 +4400,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Kata
@@ -4418,7 +4418,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Kata
@@ -4436,7 +4436,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tv
     brand: Kata
@@ -4454,7 +4454,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Kata
@@ -4472,7 +4472,7 @@
     name: Chrome Webview
     version: 46.0.2490.76
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Kata
@@ -4490,7 +4490,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: IKI Mobile
@@ -4508,7 +4508,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: IKI Mobile
@@ -4526,7 +4526,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: i-Cherry
@@ -4544,7 +4544,7 @@
     name: Chrome Mobile
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: i-Cherry
@@ -4562,7 +4562,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: i-Cherry
@@ -4580,7 +4580,7 @@
     name: Chrome
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tablet
     brand: i-Cherry
@@ -4598,7 +4598,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Cavion
@@ -4616,7 +4616,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Camfone
@@ -4634,7 +4634,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Accent
@@ -4652,7 +4652,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Owwo
@@ -4670,7 +4670,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Centric
@@ -4688,7 +4688,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: CG Mobile
@@ -4706,7 +4706,7 @@
     name: Chrome
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: Digma
@@ -4724,7 +4724,7 @@
     name: Chrome
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: Digma
@@ -4742,7 +4742,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Digma
@@ -4760,7 +4760,7 @@
     name: Chrome
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: Digma
@@ -4778,7 +4778,7 @@
     name: Chrome
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: tablet
     brand: Digma
@@ -4796,7 +4796,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Digma
@@ -4814,7 +4814,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Hotwav
@@ -4832,7 +4832,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Hotwav
@@ -4850,7 +4850,7 @@
     name: Chrome Webview
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Hotwav
@@ -4868,7 +4868,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Hotwav
@@ -4886,7 +4886,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Hotwav
@@ -4904,7 +4904,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Hotwav
@@ -4922,7 +4922,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Hotwav
@@ -4940,7 +4940,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Hotwav
@@ -4958,7 +4958,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Hotwav
@@ -4976,7 +4976,7 @@
     name: Chrome Mobile
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: smartphone
     brand: Hotwav
@@ -4994,7 +4994,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Hotwav
@@ -5012,7 +5012,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Ghia
@@ -5030,7 +5030,7 @@
     name: Chrome Mobile
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Onix
@@ -5048,7 +5048,7 @@
     name: Chrome Mobile
     version: 88.0.4324.152
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.152"
   device:
     type: smartphone
     brand: VAIO
@@ -5066,7 +5066,7 @@
     name: Chrome Webview
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -5084,7 +5084,7 @@
     name: Chrome Mobile
     version: 88.0.4324.152
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.152"
   device:
     type: smartphone
     brand: Sharp
@@ -5102,7 +5102,7 @@
     name: Chrome Mobile
     version: 88.0.4324.152
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.152"
   device:
     type: smartphone
     brand: Freetel
@@ -5138,7 +5138,7 @@
     name: Chrome Mobile
     version: 85.0.4183.120
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: smartphone
     brand: iTel
@@ -5174,7 +5174,7 @@
     name: Chrome Mobile
     version: 88.0.4324.152
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.152"
   device:
     type: smartphone
     brand: Sony
@@ -5192,7 +5192,7 @@
     name: Chrome Webview
     version: 67.0.3396.127
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.127"
   device:
     type: smartphone
     brand: Sharp
@@ -5210,7 +5210,7 @@
     name: Chrome Mobile
     version: 54.0.2840.61
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.61"
   device:
     type: smartphone
     brand: Simply
@@ -5246,7 +5246,7 @@
     name: Chrome Mobile
     version: 87.0.4280.88
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.88"
   device:
     type: smartphone
     brand: Kyocera
@@ -5264,7 +5264,7 @@
     name: Chrome Mobile
     version: 50.0.2661.89
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: portable media player
     brand: Pioneer
@@ -5282,7 +5282,7 @@
     name: Chrome Webview
     version: 33.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Fujitsu
@@ -5318,7 +5318,7 @@
     name: Yandex Browser
     version: 20.122.0
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: POCO
@@ -5336,7 +5336,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: bq
@@ -5354,7 +5354,7 @@
     name: Yandex Browser
     version: "7.52"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: bq
@@ -5372,7 +5372,7 @@
     name: Chrome Mobile
     version: 88.0.4324.155
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.155"
   device:
     type: smartphone
     brand: bq
@@ -5390,7 +5390,7 @@
     name: Yandex Browser
     version: "9.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: bq
@@ -5408,7 +5408,7 @@
     name: Yandex Browser
     version: "8.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: bq
@@ -5426,7 +5426,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Alcatel
@@ -5444,7 +5444,7 @@
     name: Opera Mobile
     version: 58.2.2878.53403
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: phablet
     brand: Blackview
@@ -5462,7 +5462,7 @@
     name: Yandex Browser
     version: "7.52"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Irbis
@@ -5480,7 +5480,7 @@
     name: Chrome
     version: 88.0.4324.141
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.141"
   device:
     type: tablet
     brand: Irbis
@@ -5498,7 +5498,7 @@
     name: Chrome
     version: 80.0.3987.117
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: tablet
     brand: Irbis
@@ -5516,7 +5516,7 @@
     name: Opera
     version: 62.0.3146.57357
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: tablet
     brand: Irbis
@@ -5534,7 +5534,7 @@
     name: Chrome Mobile
     version: 88.0.4324.152
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.152"
   device:
     type: smartphone
     brand: Aligator
@@ -5552,7 +5552,7 @@
     name: Yandex Browser
     version: 20.122.0
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: tablet
     brand: bq
@@ -5570,7 +5570,7 @@
     name: Chrome
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: tablet
     brand: Aiuto
@@ -5588,7 +5588,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Sharp
@@ -5606,7 +5606,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Wiko
@@ -5624,7 +5624,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Videocon
@@ -5642,7 +5642,7 @@
     name: Chrome Webview
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Videocon
@@ -5660,7 +5660,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Videocon
@@ -5678,7 +5678,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Videocon
@@ -5696,7 +5696,7 @@
     name: Chrome Mobile
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Videocon
@@ -5714,7 +5714,7 @@
     name: Chrome Mobile
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: smartphone
     brand: Videocon
@@ -5732,7 +5732,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Videocon
@@ -5750,7 +5750,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Mobiistar
@@ -5768,7 +5768,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Mobiistar
@@ -5786,7 +5786,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Mobiistar
@@ -5804,7 +5804,7 @@
     name: Chrome Webview
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Mobiistar
@@ -5822,7 +5822,7 @@
     name: Chrome Webview
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Zopo
@@ -5840,7 +5840,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Ziox
@@ -5876,7 +5876,7 @@
     name: Chrome Webview
     version: 67.0.3396.127
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.127"
   device:
     type: smartphone
     brand: Fujitsu
@@ -5894,7 +5894,7 @@
     name: Chrome Webview
     version: 67.0.3396.127
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.127"
   device:
     type: smartphone
     brand: Sharp
@@ -5930,7 +5930,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: FireFly Mobile
@@ -5948,7 +5948,7 @@
     name: Chrome Webview
     version: 51.0.2704.91
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.91"
   device:
     type: smartphone
     brand: FireFly Mobile
@@ -5966,7 +5966,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: FireFly Mobile
@@ -5984,7 +5984,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Navon
@@ -6002,7 +6002,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Evolveo
@@ -6020,7 +6020,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6038,7 +6038,7 @@
     name: Chrome Mobile
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Seatel
@@ -6056,7 +6056,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Seatel
@@ -6074,7 +6074,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Seatel
@@ -6092,7 +6092,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Seatel
@@ -6110,7 +6110,7 @@
     name: Chrome Mobile
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: smartphone
     brand: Seatel
@@ -6128,7 +6128,7 @@
     name: Chrome Mobile
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Seatel
@@ -6146,7 +6146,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Seatel
@@ -6164,7 +6164,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Seatel
@@ -6182,7 +6182,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Seatel
@@ -6200,7 +6200,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Seatel
@@ -6218,7 +6218,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: iPro
@@ -6236,7 +6236,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Maxwest
@@ -6254,7 +6254,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Maxwest
@@ -6272,7 +6272,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Maxwest
@@ -6290,7 +6290,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Maxwest
@@ -6308,7 +6308,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Maxwest
@@ -6326,7 +6326,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Iris
@@ -6344,7 +6344,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Newsday
@@ -6362,7 +6362,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Newsday
@@ -6380,7 +6380,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Newsday
@@ -6398,7 +6398,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Maxwest
@@ -6578,7 +6578,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: iTel
@@ -6596,7 +6596,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: iTel
@@ -6614,7 +6614,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Jiake
@@ -6632,7 +6632,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Inco
@@ -6650,7 +6650,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Inco
@@ -6668,7 +6668,7 @@
     name: Chrome Webview
     version: 59.0.3071.125
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Inco
@@ -6686,7 +6686,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Pixela
@@ -6704,7 +6704,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Pixela
@@ -6722,7 +6722,7 @@
     name: Chrome Mobile
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: smartphone
     brand: 'iQ&T'
@@ -6740,7 +6740,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: 'iQ&T'
@@ -6758,7 +6758,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: IMO Mobile
@@ -6776,7 +6776,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: IMO Mobile
@@ -6794,7 +6794,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Blu
@@ -6812,7 +6812,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6830,7 +6830,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6848,7 +6848,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6866,7 +6866,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6884,7 +6884,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6902,7 +6902,7 @@
     name: Chrome Mobile
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: altron
@@ -6920,7 +6920,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: altron
@@ -6938,7 +6938,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: altron
@@ -6956,7 +6956,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Navcity
@@ -6974,7 +6974,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Maximus
@@ -6992,7 +6992,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Maximus
@@ -7010,7 +7010,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Datalogic
@@ -7028,7 +7028,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: MicroMax
@@ -7046,7 +7046,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: MicroMax
@@ -7064,7 +7064,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Naomi Phone
@@ -7082,7 +7082,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Lava
@@ -7100,7 +7100,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Evercoss
@@ -7118,7 +7118,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Leader Phone
@@ -7136,7 +7136,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Leader Phone
@@ -7154,7 +7154,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Leader Phone
@@ -7172,7 +7172,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Leader Phone
@@ -7190,7 +7190,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Lava
@@ -7208,7 +7208,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Linnex
@@ -7226,7 +7226,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Sugar
@@ -7244,7 +7244,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Sugar
@@ -7262,7 +7262,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sugar
@@ -7280,7 +7280,7 @@
     name: Chrome Webview
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Subor
@@ -7298,7 +7298,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Subor
@@ -7316,7 +7316,7 @@
     name: Chrome Webview
     version: 35.0.1916.138
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.138"
   device:
     type: smartphone
     brand: Subor
@@ -7334,7 +7334,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Lenovo
@@ -7352,7 +7352,7 @@
     name: Chrome Mobile
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Freetel
@@ -7370,7 +7370,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Freetel
@@ -7388,7 +7388,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Freetel
@@ -7406,7 +7406,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Sony
@@ -7424,7 +7424,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Siragon
@@ -7442,7 +7442,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Karbonn
@@ -7460,7 +7460,7 @@
     name: Chrome Mobile
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: StrawBerry
@@ -7478,7 +7478,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: StrawBerry
@@ -7496,7 +7496,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: Bitel
@@ -7514,7 +7514,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Bitel
@@ -7532,7 +7532,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Bitel
@@ -7550,7 +7550,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Bitel
@@ -7568,7 +7568,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Cloudfone
@@ -7586,7 +7586,7 @@
     name: Chrome Mobile
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Navon
@@ -7604,7 +7604,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Navon
@@ -7622,7 +7622,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Navon
@@ -7640,7 +7640,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: G-Touch
@@ -7674,7 +7674,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: G-Touch
@@ -7692,7 +7692,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Zuum
@@ -7710,7 +7710,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Zuum
@@ -7728,7 +7728,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Zuum
@@ -7746,7 +7746,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Zuum
@@ -7764,7 +7764,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Zuum
@@ -7782,7 +7782,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Zuum
@@ -7800,7 +7800,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: G-Touch
@@ -7818,7 +7818,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Starlight
@@ -7982,7 +7982,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Hotwav
@@ -8000,7 +8000,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Hotwav
@@ -8018,7 +8018,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Zatec
@@ -8036,7 +8036,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Zatec
@@ -8054,7 +8054,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Zatec
@@ -8072,7 +8072,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Blloc
@@ -8090,7 +8090,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Huskee
@@ -8108,7 +8108,7 @@
     name: Chrome Mobile
     version: 75.0.3770.89
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Condor
@@ -8126,7 +8126,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: QMobile
@@ -8144,7 +8144,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: QMobile
@@ -8162,7 +8162,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: QMobile
@@ -8180,7 +8180,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: QMobile
@@ -8216,7 +8216,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: QMobile
@@ -8234,7 +8234,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Q-Touch
@@ -8252,7 +8252,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: 'Kempler & Strauss'
@@ -8270,7 +8270,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Danew
@@ -8288,7 +8288,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Danew
@@ -8306,7 +8306,7 @@
     name: Chrome Webview
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: SKG
@@ -8324,7 +8324,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: SKG
@@ -8360,7 +8360,7 @@
     name: Chrome Mobile
     version: 67.0.3396.68
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.68"
   device:
     type: smartphone
     brand: SKG
@@ -8378,7 +8378,7 @@
     name: Chrome Webview
     version: 43.0.2357.121
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: SKG
@@ -8396,7 +8396,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: SKG
@@ -8414,7 +8414,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: SOLE
@@ -8432,7 +8432,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: SOLO
@@ -8450,7 +8450,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Solone
@@ -8522,7 +8522,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: SOLE
@@ -8540,7 +8540,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: SOLO
@@ -8558,7 +8558,7 @@
     name: Chrome Webview
     version: 74.0.3729.112
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: smartphone
     brand: Solone
@@ -8576,7 +8576,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Accent
@@ -8594,7 +8594,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Accent
@@ -8612,7 +8612,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Accent
@@ -8630,7 +8630,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Accent
@@ -8648,7 +8648,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Accent
@@ -8684,7 +8684,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: OINOM

--- a/Tests/fixtures/smartphone-22.yml
+++ b/Tests/fixtures/smartphone-22.yml
@@ -28,7 +28,7 @@
     name: Chrome Mobile
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: OINOM
@@ -46,7 +46,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: OINOM
@@ -64,7 +64,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Singtech
@@ -82,7 +82,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Singtech
@@ -100,7 +100,7 @@
     name: Chrome Webview
     version: 53.0.2785.124
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Singtech
@@ -118,7 +118,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Siragon
@@ -136,7 +136,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Singtech
@@ -154,7 +154,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Singtech
@@ -172,7 +172,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Singtech
@@ -190,7 +190,7 @@
     name: Chrome Mobile
     version: 81.0.4044.42
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.42"
   device:
     type: smartphone
     brand: FireFly Mobile
@@ -208,7 +208,7 @@
     name: Chrome Mobile
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: smartphone
     brand: FireFly Mobile
@@ -226,7 +226,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Blu
@@ -244,7 +244,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: SFR
@@ -262,7 +262,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: SFR
@@ -298,7 +298,7 @@
     name: Chrome Webview
     version: 52.0.2743.98
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: SFR
@@ -316,7 +316,7 @@
     name: Chrome Mobile
     version: 51.0.2704.81
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: SFR
@@ -334,7 +334,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Starmobile
@@ -352,7 +352,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Starlight
@@ -370,7 +370,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Sico
@@ -388,7 +388,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Sico
@@ -406,7 +406,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Maze Speed
@@ -424,7 +424,7 @@
     name: Chrome Webview
     version: 43.0.2357.121
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: True Slim
@@ -442,7 +442,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Maze Speed
@@ -460,7 +460,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Sico
@@ -478,7 +478,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Sunny
@@ -496,7 +496,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Sunny
@@ -514,7 +514,7 @@
     name: Chrome Webview
     version: 43.0.2357.65
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.65"
   device:
     type: smartphone
     brand: Sunny
@@ -532,7 +532,7 @@
     name: Chrome Webview
     version: 43.0.2357.65
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.65"
   device:
     type: smartphone
     brand: Sunny
@@ -550,7 +550,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Sunny
@@ -568,7 +568,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: iBrit
@@ -586,7 +586,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: iBrit
@@ -604,7 +604,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Casper
@@ -622,7 +622,7 @@
     name: Chrome Mobile
     version: 52.0.2743.98
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Lenovo
@@ -640,7 +640,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Lenovo
@@ -658,7 +658,7 @@
     name: Chrome Mobile
     version: 66.0.3359.126
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Lenovo
@@ -676,7 +676,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Lenovo
@@ -694,7 +694,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Lenovo
@@ -712,7 +712,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Lenovo
@@ -730,7 +730,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Lenovo
@@ -748,7 +748,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: TEENO
@@ -766,7 +766,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: TEENO
@@ -784,7 +784,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: TEENO
@@ -802,7 +802,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: v-mobile
@@ -820,7 +820,7 @@
     name: Chrome Mobile
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: smartphone
     brand: v-mobile
@@ -838,7 +838,7 @@
     name: Chrome Mobile
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Maxwest
@@ -856,7 +856,7 @@
     name: Chrome Webview
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: STF Mobile
@@ -874,7 +874,7 @@
     name: Chrome Mobile
     version: 59.0.3071.125
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Karbonn
@@ -892,7 +892,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Evercoss
@@ -910,7 +910,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Aspera
@@ -946,7 +946,7 @@
     name: Chrome Webview
     version: 52.0.2743.98
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Aspera
@@ -964,7 +964,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Aspera
@@ -982,7 +982,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Aspera
@@ -1000,7 +1000,7 @@
     name: Yandex Browser
     version: 19.12.1.121.00
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.97"
   device:
     type: smartphone
     brand: Aspera
@@ -1018,7 +1018,7 @@
     name: Chrome Mobile
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Sky
@@ -1036,7 +1036,7 @@
     name: Chrome Mobile
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Sky
@@ -1054,7 +1054,7 @@
     name: Chrome Mobile
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: ZTE
@@ -1072,7 +1072,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Maxwest
@@ -1090,7 +1090,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Karbonn
@@ -1108,7 +1108,7 @@
     name: Chrome Webview
     version: 53.0.2785.124
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Vision Touch
@@ -1126,7 +1126,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Vision Touch
@@ -1144,7 +1144,7 @@
     name: Chrome Mobile
     version: 51.0.2704.81
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: ZTE
@@ -1162,7 +1162,7 @@
     name: Chrome Webview
     version: 46.0.2490.76
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Azumi Mobile
@@ -1198,7 +1198,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Inco
@@ -1216,7 +1216,7 @@
     name: Chrome Mobile
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Alba
@@ -1234,7 +1234,7 @@
     name: Chrome Mobile
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Karbonn
@@ -1252,7 +1252,7 @@
     name: Chrome Mobile
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Lava
@@ -1270,7 +1270,7 @@
     name: Chrome Mobile
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -1288,7 +1288,7 @@
     name: Chrome Mobile
     version: 54.0.2840.85
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Blu
@@ -1306,7 +1306,7 @@
     name: Chrome Mobile
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Blu
@@ -1324,7 +1324,7 @@
     name: Chrome Mobile
     version: 50.0.2661.89
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Blu
@@ -1342,7 +1342,7 @@
     name: Chrome Webview
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: NOBUX
@@ -1360,7 +1360,7 @@
     name: Chrome Mobile
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: öwn
@@ -1378,7 +1378,7 @@
     name: Chrome Mobile
     version: 51.0.2704.81
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Wink
@@ -1414,7 +1414,7 @@
     name: Chrome Mobile
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Wink
@@ -1432,7 +1432,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Wink
@@ -1450,7 +1450,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Wink
@@ -1468,7 +1468,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: iBall
@@ -1486,7 +1486,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: "4"
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: iBall
@@ -1504,7 +1504,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Forstar
@@ -1522,7 +1522,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Hitech
@@ -1540,7 +1540,7 @@
     name: Chrome Webview
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Hitech
@@ -1558,7 +1558,7 @@
     name: Chrome Webview
     version: 50.0.2661.86
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Hitech
@@ -1576,7 +1576,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Hitech
@@ -1594,7 +1594,7 @@
     name: Chrome Webview
     version: 43.0.2357.121
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Hitech
@@ -1612,7 +1612,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Hitech
@@ -1630,7 +1630,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Hitech
@@ -1648,7 +1648,7 @@
     name: Chrome Webview
     version: 46.0.2490.76
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Hitech
@@ -1666,7 +1666,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Videocon
@@ -1684,7 +1684,7 @@
     name: Chrome Mobile
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Videocon
@@ -1702,7 +1702,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Videocon
@@ -1720,7 +1720,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Videocon
@@ -1738,7 +1738,7 @@
     name: Yandex Browser
     version: 20.122.1
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Samsung
@@ -1774,7 +1774,7 @@
     name: Yandex Browser
     version: 20.85.0
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: smartphone
     brand: Samsung
@@ -1792,7 +1792,7 @@
     name: Yandex Browser
     version: 21.2.3.335.00
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: smartphone
     brand: Samsung
@@ -1810,7 +1810,7 @@
     name: Yandex Browser
     version: 21.23.0
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: smartphone
     brand: Samsung
@@ -1846,7 +1846,7 @@
     name: Huawei Browser Mobile
     version: 11.0.5.306
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Huawei
@@ -1864,7 +1864,7 @@
     name: Opera Mobile
     version: 62.2.3146.57547
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Huawei
@@ -1882,7 +1882,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Blackview
@@ -1918,7 +1918,7 @@
     name: Opera Mobile
     version: 61.1.3076.56701
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: phablet
     brand: Xiaomi
@@ -1936,7 +1936,7 @@
     name: Yandex Browser
     version: 20.125.0
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: F150
@@ -1954,7 +1954,7 @@
     name: Yandex Browser
     version: 21.23.1
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: smartphone
     brand: Realme
@@ -1972,7 +1972,7 @@
     name: Yandex Browser
     version: 21.23.1
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: smartphone
     brand: CUBOT
@@ -1990,7 +1990,7 @@
     name: Opera Mobile
     version: 62.3.3146.57763
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Xiaomi
@@ -2008,7 +2008,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Xiaomi
@@ -2026,7 +2026,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: Xiaomi
@@ -2044,7 +2044,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: Xiaomi
@@ -2080,7 +2080,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: CUBOT
@@ -2116,7 +2116,7 @@
     name: Chrome Mobile
     version: 89.0.4389.72
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.72"
   device:
     type: smartphone
     brand: Realme
@@ -2134,7 +2134,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: phablet
     brand: Xiaomi
@@ -2152,7 +2152,7 @@
     name: Yandex Browser
     version: 20.122.1
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Blackview
@@ -2170,7 +2170,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Blackview
@@ -2188,7 +2188,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: POCO
@@ -2206,7 +2206,7 @@
     name: Chrome Mobile
     version: 89.0.4389.72
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.72"
   device:
     type: smartphone
     brand: Doogee
@@ -2224,7 +2224,7 @@
     name: Yandex Browser
     version: 21.23.1
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: smartphone
     brand: Doogee
@@ -2242,7 +2242,7 @@
     name: Chrome Mobile
     version: 89.0.4389.90
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.90"
   device:
     type: smartphone
     brand: Doogee
@@ -2260,7 +2260,7 @@
     name: Yandex Browser
     version: 21.23.1
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: smartphone
     brand: Doogee
@@ -2278,7 +2278,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: POCO
@@ -2296,7 +2296,7 @@
     name: Yandex Browser
     version: 20.124.1
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Blackview
@@ -2314,7 +2314,7 @@
     name: Yandex Browser
     version: 21.21.0
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: smartphone
     brand: OnePlus
@@ -2332,7 +2332,7 @@
     name: Yandex Browser
     version: 21.2.1.108.01
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: tablet
     brand: bq
@@ -2350,7 +2350,7 @@
     name: Yandex Browser
     version: 21.22.1
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: smartphone
     brand: bq
@@ -2368,7 +2368,7 @@
     name: Yandex Browser
     version: 19.12.1.121.00
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.97"
   device:
     type: smartphone
     brand: Vivo
@@ -2386,7 +2386,7 @@
     name: Yandex Browser
     version: 20.122.1
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Doogee
@@ -2404,7 +2404,7 @@
     name: Yandex Browser
     version: 21.23.0
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: smartphone
     brand: Alcatel
@@ -2422,7 +2422,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Archos
@@ -2476,7 +2476,7 @@
     name: Chrome Webview
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Xiaomi
@@ -2494,7 +2494,7 @@
     name: Opera Mobile
     version: 62.3.3146.57763
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: TCL
@@ -2512,7 +2512,7 @@
     name: Opera Mobile
     version: 62.3.3146.57763
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Alcatel
@@ -2530,7 +2530,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: Hisense
@@ -2548,7 +2548,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: phablet
     brand: Xiaomi
@@ -2566,7 +2566,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: TCL
@@ -2584,7 +2584,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Cricket
@@ -2602,7 +2602,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: 'AT&T'
@@ -2620,7 +2620,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: LG
@@ -2638,7 +2638,7 @@
     name: Opera Mobile
     version: 60.3.3004.55692
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: OnePlus
@@ -2656,7 +2656,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: OnePlus
@@ -2674,7 +2674,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: OnePlus
@@ -2692,7 +2692,7 @@
     name: Chrome Mobile
     version: 89.0.4389.86
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.86"
   device:
     type: smartphone
     brand: OnePlus
@@ -2710,7 +2710,7 @@
     name: Chrome Mobile
     version: 88.0.4324.141
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.141"
   device:
     type: smartphone
     brand: OnePlus
@@ -2728,7 +2728,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: OnePlus
@@ -2746,7 +2746,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Motorola
@@ -2780,7 +2780,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Motorola
@@ -2798,7 +2798,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: LG
@@ -2816,7 +2816,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Motorola
@@ -2834,7 +2834,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Motorola
@@ -2852,7 +2852,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Motorola
@@ -2870,7 +2870,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Verykool
@@ -2888,7 +2888,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: iPro
@@ -2906,7 +2906,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: Lanix
@@ -2924,7 +2924,7 @@
     name: Chrome Mobile
     version: 89.0.4389.86
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.86"
   device:
     type: smartphone
     brand: TCL
@@ -2942,7 +2942,7 @@
     name: Chrome Mobile
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Polaroid
@@ -2960,7 +2960,7 @@
     name: Chrome Mobile
     version: 89.0.4389.72
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.72"
   device:
     type: smartphone
     brand: Lanix
@@ -2978,7 +2978,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Lanix
@@ -3014,7 +3014,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Zuum
@@ -3032,7 +3032,7 @@
     name: Chrome Mobile
     version: 88.0.4324.141
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.141"
   device:
     type: smartphone
     brand: Hyundai
@@ -3278,7 +3278,7 @@
     name: Chrome Mobile
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: bq
@@ -3314,7 +3314,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Fly
@@ -3332,7 +3332,7 @@
     name: Chrome Mobile
     version: 47.0.2825.74
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2825.74"
   device:
     type: smartphone
     brand: Oukitel
@@ -3350,7 +3350,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Explay
@@ -3368,7 +3368,7 @@
     name: Yandex Browser
     version: 20.2.0.215.00
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.117"
   device:
     type: smartphone
     brand: Torex
@@ -3386,7 +3386,7 @@
     name: Yandex Browser
     version: 21.23.1
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: smartphone
     brand: Realme
@@ -3404,7 +3404,7 @@
     name: Chrome Webview
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Realme
@@ -3422,7 +3422,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Black Fox
@@ -3458,7 +3458,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Xiaomi
@@ -3476,7 +3476,7 @@
     name: Chrome Mobile
     version: 88.0.4324.152
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.152"
   device:
     type: smartphone
     brand: POCO
@@ -3494,7 +3494,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Logic
@@ -3512,7 +3512,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Huawei
@@ -3530,7 +3530,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: Ulefone
@@ -3548,7 +3548,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Doogee
@@ -3566,7 +3566,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: bq
@@ -3584,7 +3584,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: bq
@@ -3602,7 +3602,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: bq
@@ -3620,7 +3620,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: bq
@@ -3638,7 +3638,7 @@
     name: Yandex Browser
     version: "7.52"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Black Fox
@@ -3656,7 +3656,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: DEXP
@@ -3674,7 +3674,7 @@
     name: Yandex Browser Lite
     version: 19.6.0.179
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: DEXP
@@ -3692,7 +3692,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Allview
@@ -3710,7 +3710,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Advan
@@ -3728,7 +3728,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Advan
@@ -3746,7 +3746,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: iTel
@@ -3818,7 +3818,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: iTel
@@ -3836,7 +3836,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: iTel
@@ -3872,7 +3872,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: iTel
@@ -3890,7 +3890,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: iTel
@@ -3908,7 +3908,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: iTel
@@ -3962,7 +3962,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: iTel
@@ -3980,7 +3980,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: iTel
@@ -3998,7 +3998,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: iTel
@@ -4016,7 +4016,7 @@
     name: Chrome Mobile
     version: 89.0.4389.90
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.90"
   device:
     type: smartphone
     brand: iTel
@@ -4034,7 +4034,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: iTel
@@ -4052,7 +4052,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: iTel
@@ -4070,7 +4070,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: iTel
@@ -4088,7 +4088,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: iTel
@@ -4106,7 +4106,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: iTel
@@ -4124,7 +4124,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: iTel
@@ -4142,7 +4142,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Gionee
@@ -4160,7 +4160,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Gionee
@@ -4178,7 +4178,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Gionee
@@ -4196,7 +4196,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: POCO
@@ -4214,7 +4214,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4232,7 +4232,7 @@
     name: Chrome Mobile
     version: 89.0.4389.86
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.86"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4250,7 +4250,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: OnePlus
@@ -4268,7 +4268,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: OnePlus
@@ -4286,7 +4286,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: OnePlus
@@ -4304,7 +4304,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Asus
@@ -4322,7 +4322,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: POCO
@@ -4374,7 +4374,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Sony
@@ -4392,7 +4392,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Vivo
@@ -4410,7 +4410,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Vivo
@@ -4428,7 +4428,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: TCL
@@ -4446,7 +4446,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Realme
@@ -4464,7 +4464,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Realme
@@ -4482,7 +4482,7 @@
     name: Chrome Mobile
     version: 89.0.4389.86
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.86"
   device:
     type: smartphone
     brand: Realme
@@ -4518,7 +4518,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: POCO
@@ -4536,7 +4536,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: Vivo
@@ -4554,7 +4554,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Huawei
@@ -4572,7 +4572,7 @@
     name: Chrome Mobile
     version: 89.0.4389.72
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.72"
   device:
     type: smartphone
     brand: Artel
@@ -4590,7 +4590,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Blu
@@ -4608,7 +4608,7 @@
     name: Chrome Mobile
     version: 88.0.4324.152
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.152"
   device:
     type: smartphone
     brand: CUBOT
@@ -4626,7 +4626,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: POCO
@@ -4644,7 +4644,7 @@
     name: Chrome Mobile
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Blu
@@ -4680,7 +4680,7 @@
     name: Chrome Mobile
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: smartphone
     brand: LG
@@ -4698,7 +4698,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Realme
@@ -4716,7 +4716,7 @@
     name: Chrome Mobile
     version: 88.0.4324.29
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.29"
   device:
     type: smartphone
     brand: Realme
@@ -4734,7 +4734,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Realme
@@ -4752,7 +4752,7 @@
     name: Chrome Mobile
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: smartphone
     brand: Realme
@@ -4770,7 +4770,7 @@
     name: Chrome Mobile
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: smartphone
     brand: Realme
@@ -4806,7 +4806,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Ravoz
@@ -4824,7 +4824,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Ravoz
@@ -4842,7 +4842,7 @@
     name: Chrome Mobile
     version: 88.0.4324.16
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.16"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4860,7 +4860,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4878,7 +4878,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: POCO
@@ -4896,7 +4896,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: T-Mobile
@@ -4914,7 +4914,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: T-Mobile
@@ -4932,7 +4932,7 @@
     name: Chrome Webview
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: T-Mobile
@@ -4950,7 +4950,7 @@
     name: Chrome Mobile
     version: 88.0.4324.152
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.152"
   device:
     type: smartphone
     brand: T-Mobile
@@ -4968,7 +4968,7 @@
     name: Huawei Browser Mobile
     version: 11.0.4.302
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Huawei
@@ -4986,7 +4986,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Vivo
@@ -5004,7 +5004,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Karbonn
@@ -5022,7 +5022,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Greentel
@@ -5040,7 +5040,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Mito
@@ -5076,7 +5076,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Huawei
@@ -5094,7 +5094,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -5112,7 +5112,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Realme
@@ -5130,7 +5130,7 @@
     name: Chrome Mobile
     version: 88.0.4324.141
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.141"
   device:
     type: smartphone
     brand: Realme
@@ -5148,7 +5148,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: 'Yes'
@@ -5166,7 +5166,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Mobiistar
@@ -5184,7 +5184,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Mobiistar
@@ -5202,7 +5202,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Mobiistar
@@ -5220,7 +5220,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Mobiistar
@@ -5238,7 +5238,7 @@
     name: Chrome Webview
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: LG
@@ -5256,7 +5256,7 @@
     name: Chrome Webview
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: LG
@@ -5274,7 +5274,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: LG
@@ -5292,7 +5292,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: LG
@@ -5310,7 +5310,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: LG
@@ -5328,7 +5328,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: LG
@@ -5346,7 +5346,7 @@
     name: Chrome Webview
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: LG
@@ -5364,7 +5364,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: LG
@@ -5382,7 +5382,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: LG
@@ -5418,7 +5418,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: LG
@@ -5436,7 +5436,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: LG
@@ -5472,7 +5472,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: QMobile
@@ -5490,7 +5490,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Yezz
@@ -5508,7 +5508,7 @@
     name: Chrome Mobile
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Asus
@@ -5544,7 +5544,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Kyocera
@@ -5562,7 +5562,7 @@
     name: Chrome Webview
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Kyocera
@@ -5598,7 +5598,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: LT Mobile
@@ -5616,7 +5616,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Logic
@@ -5634,7 +5634,7 @@
     name: Opera Mobile
     version: 38.1.2254.136033
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: QMobile
@@ -5652,7 +5652,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Asus
@@ -5670,7 +5670,7 @@
     name: Chrome Mobile
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Asus
@@ -5688,7 +5688,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Asus
@@ -5706,7 +5706,7 @@
     name: Chrome Mobile
     version: 32.0.1700.99
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: Asus
@@ -5724,7 +5724,7 @@
     name: Chrome Mobile
     version: 49.0.2623.27
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.27"
   device:
     type: smartphone
     brand: Asus
@@ -5742,7 +5742,7 @@
     name: Chrome Mobile
     version: 33.0.1750.170
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.170"
   device:
     type: smartphone
     brand: Asus
@@ -5760,7 +5760,7 @@
     name: Opera Mobile
     version: 63.1.3216.58539
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Blu
@@ -5778,7 +5778,7 @@
     name: Opera Mobile
     version: 63.3.3216.58675
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: ZTE
@@ -5796,7 +5796,7 @@
     name: Opera Mobile
     version: 63.3.3216.58675
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5814,7 +5814,7 @@
     name: Opera Mobile
     version: 63.3.3216.58675
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5832,7 +5832,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: GFive
@@ -5850,7 +5850,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: GFive
@@ -5868,7 +5868,7 @@
     name: Chrome Mobile
     version: 88.0.4324.79
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.79"
   device:
     type: smartphone
     brand: Huawei
@@ -5886,7 +5886,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: QMobile
@@ -5904,7 +5904,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Essentielb
@@ -5922,7 +5922,7 @@
     name: Chrome Webview
     version: 51.0.2704.81
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Asus
@@ -5940,7 +5940,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Videocon
@@ -5958,7 +5958,7 @@
     name: Chrome Mobile
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: smartphone
     brand: Gionee
@@ -5976,7 +5976,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5994,7 +5994,7 @@
     name: Yandex Browser
     version: 21.22.0
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: smartphone
     brand: Meizu
@@ -6012,7 +6012,7 @@
     name: Yandex Browser
     version: 21.26.1
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: smartphone
     brand: Meizu
@@ -6030,7 +6030,7 @@
     name: Yandex Browser
     version: "10.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Meizu
@@ -6048,7 +6048,7 @@
     name: Chrome Mobile
     version: 89.0.4389.90
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.90"
   device:
     type: smartphone
     brand: Twoe
@@ -6066,7 +6066,7 @@
     name: Chrome Webview
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Konrow
@@ -6084,7 +6084,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: IKU Mobile
@@ -6102,7 +6102,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: KINGZONE
@@ -6120,7 +6120,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Venso
@@ -6138,7 +6138,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Venso
@@ -6156,7 +6156,7 @@
     name: Chrome Webview
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: DEXP
@@ -6174,7 +6174,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: IUNI
@@ -6192,7 +6192,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Keneksi
@@ -6210,7 +6210,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Iris
@@ -6228,7 +6228,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Konrow
@@ -6282,7 +6282,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Leagoo
@@ -6300,7 +6300,7 @@
     name: Chrome Mobile
     version: 89.0.4389.72
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.72"
   device:
     type: smartphone
     brand: Oukitel
@@ -6318,7 +6318,7 @@
     name: Chrome Mobile
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: smartphone
     brand: Oukitel
@@ -6336,7 +6336,7 @@
     name: Chrome Webview
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Oukitel
@@ -6354,7 +6354,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: Oysters
@@ -6372,7 +6372,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Ziox
@@ -6390,7 +6390,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: QMobile
@@ -6408,7 +6408,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Centric
@@ -6426,7 +6426,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Xolo
@@ -6444,7 +6444,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: InFocus
@@ -6462,7 +6462,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: InFocus
@@ -6480,7 +6480,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: InFocus
@@ -6498,7 +6498,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Fourel
@@ -6516,7 +6516,7 @@
     name: Chrome Webview
     version: 50.0.2661.86
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Fourel
@@ -6534,7 +6534,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: M-Tech
@@ -6552,7 +6552,7 @@
     name: Chrome Mobile
     version: 89.0.4389.90
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.90"
   device:
     type: smartphone
     brand: DEXP
@@ -6570,7 +6570,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Energy Sistem
@@ -6588,7 +6588,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Asus
@@ -6606,7 +6606,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Asus
@@ -6624,7 +6624,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6642,7 +6642,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6660,7 +6660,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Fantec
@@ -6678,7 +6678,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: MyPhone
@@ -6696,7 +6696,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Vivax
@@ -6714,7 +6714,7 @@
     name: Chrome Mobile
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6786,7 +6786,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: GOCLEVER
@@ -6804,7 +6804,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Qumo
@@ -6822,7 +6822,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Qumo
@@ -6840,7 +6840,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Qumo
@@ -6858,7 +6858,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: S-TELL
@@ -6876,7 +6876,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: S-TELL
@@ -6894,7 +6894,7 @@
     name: Yandex Browser
     version: 20.12.4.100.00
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: DEXP
@@ -6912,7 +6912,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Yu
@@ -6930,7 +6930,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Karbonn
@@ -6948,7 +6948,7 @@
     name: Yandex Browser
     version: 21.2.2.99.00
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: smartphone
     brand: Torex
@@ -6966,7 +6966,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: YUHO
@@ -6984,7 +6984,7 @@
     name: Chrome Mobile
     version: 85.0.4183.18
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.18"
   device:
     type: smartphone
     brand: YUHO
@@ -7002,7 +7002,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: YUHO
@@ -7020,7 +7020,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: YUHO
@@ -7038,7 +7038,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: YUHO
@@ -7056,7 +7056,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: YUHO
@@ -7074,7 +7074,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: YUHO
@@ -7092,7 +7092,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: YUHO
@@ -7110,7 +7110,7 @@
     name: Chrome Mobile
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: smartphone
     brand: YUHO
@@ -7128,7 +7128,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: YUHO
@@ -7146,7 +7146,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: YUHO
@@ -7164,7 +7164,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: YUHO
@@ -7182,7 +7182,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: YUHO
@@ -7200,7 +7200,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: YUHO
@@ -7218,7 +7218,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: F2 Mobile
@@ -7236,7 +7236,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: F2 Mobile
@@ -7254,7 +7254,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Vivo
@@ -7272,7 +7272,7 @@
     name: Chrome Webview
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Vivo
@@ -7290,7 +7290,7 @@
     name: Chrome Webview
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Vivo
@@ -7308,7 +7308,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Vivo
@@ -7326,7 +7326,7 @@
     name: Chrome Webview
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Vivo
@@ -7344,7 +7344,7 @@
     name: Chrome Webview
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Vivo
@@ -7362,7 +7362,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Huawei
@@ -7380,7 +7380,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Huawei
@@ -7398,7 +7398,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -7416,7 +7416,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -7434,7 +7434,7 @@
     name: Chrome Webview
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: OPPO
@@ -7452,7 +7452,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -7471,7 +7471,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -7489,7 +7489,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -7507,7 +7507,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -7525,7 +7525,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -7543,7 +7543,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -7561,7 +7561,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -7579,7 +7579,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -7597,7 +7597,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -7615,7 +7615,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Huawei
@@ -7633,7 +7633,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Realme
@@ -7651,7 +7651,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Realme
@@ -7669,7 +7669,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Realme
@@ -7687,7 +7687,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Realme
@@ -7705,7 +7705,7 @@
     name: Chrome Webview
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Realme
@@ -7723,7 +7723,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Vivo
@@ -7741,7 +7741,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Vivo
@@ -7759,7 +7759,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Vivo
@@ -7777,7 +7777,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Vivo
@@ -7795,7 +7795,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Vivo
@@ -7813,7 +7813,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Vivo
@@ -7831,7 +7831,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Vivo
@@ -7849,7 +7849,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Vivo
@@ -7867,7 +7867,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Vivo
@@ -7885,7 +7885,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Vivo
@@ -7903,7 +7903,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Vivo
@@ -7921,7 +7921,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Vivo
@@ -7939,7 +7939,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -7957,7 +7957,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -7975,7 +7975,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -7993,7 +7993,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -8011,7 +8011,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -8029,7 +8029,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -8047,7 +8047,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -8065,7 +8065,7 @@
     name: Huawei Browser Mobile
     version: 11.0.8.301
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Huawei
@@ -8083,7 +8083,7 @@
     name: Chrome Webview
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Smartisan
@@ -8101,7 +8101,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8119,7 +8119,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Vivo
@@ -8137,7 +8137,7 @@
     name: Chrome Webview
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Xiaolajiao
@@ -8155,7 +8155,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Xiaolajiao
@@ -8173,7 +8173,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: Realme
@@ -8191,7 +8191,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: OPPO
@@ -8209,7 +8209,7 @@
     name: Chrome Webview
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8227,7 +8227,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: 'AT&T'
@@ -8245,7 +8245,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: CUBOT
@@ -8263,7 +8263,7 @@
     name: Yandex Browser
     version: "8.70"
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: DEXP
@@ -8281,7 +8281,7 @@
     name: Opera Mobile
     version: 63.3.3216.58675
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: DEXP
@@ -8299,7 +8299,7 @@
     name: Yandex Browser
     version: 21.31.1
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.128"
   device:
     type: smartphone
     brand: DEXP
@@ -8317,7 +8317,7 @@
     name: Chrome Webview
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Oysters
@@ -8335,7 +8335,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: ZTE
@@ -8353,7 +8353,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: ZTE
@@ -8371,7 +8371,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: ZTE
@@ -8389,7 +8389,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Lava
@@ -8407,7 +8407,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: ZTE
@@ -8425,7 +8425,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: DEXP
@@ -8443,7 +8443,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: DEXP
@@ -8461,7 +8461,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: VGO TEL
@@ -8479,7 +8479,7 @@
     name: Chrome Mobile
     version: 80.0.3987.117
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: smartphone
     brand: Mobicel
@@ -8497,7 +8497,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Spectralink
@@ -8515,7 +8515,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Casper
@@ -8533,7 +8533,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Casper
@@ -8551,7 +8551,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Wiko
@@ -8569,7 +8569,7 @@
     name: Chrome Mobile
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Beeline
@@ -8605,7 +8605,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: smartphone
     brand: BIHEE
@@ -8623,7 +8623,7 @@
     name: Chrome Webview
     version: 58.0.3029.125
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.125"
   device:
     type: smartphone
     brand: BIHEE
@@ -8641,7 +8641,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Bleck
@@ -8659,7 +8659,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Bleck
@@ -8677,7 +8677,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Bleck
@@ -8695,7 +8695,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Bleck
@@ -8713,7 +8713,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Bleck
@@ -8731,7 +8731,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Bleck
@@ -8749,7 +8749,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Motorola
@@ -8767,7 +8767,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Motorola
@@ -8785,7 +8785,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Motorola
@@ -8803,7 +8803,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Motorola
@@ -8821,7 +8821,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8839,7 +8839,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Blu
@@ -8857,7 +8857,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Blackview
@@ -8875,7 +8875,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: OPPO
@@ -8893,7 +8893,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Realme
@@ -8911,7 +8911,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Realme
@@ -8929,7 +8929,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Realme
@@ -8947,7 +8947,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Vivo
@@ -8965,7 +8965,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Vernee
@@ -8983,7 +8983,7 @@
     name: Yandex Browser
     version: "11.41"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: DEXP
@@ -9001,7 +9001,7 @@
     name: Yandex Browser
     version: 20.6.0.182.00
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: DEXP
@@ -9019,7 +9019,7 @@
     name: Yandex Browser
     version: 20.12.2.68.00
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: DEXP
@@ -9037,7 +9037,7 @@
     name: Yandex Browser
     version: 19.12.0.250.00
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.97"
   device:
     type: smartphone
     brand: DEXP
@@ -9055,7 +9055,7 @@
     name: Yandex Browser
     version: 21.22.0
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: smartphone
     brand: MyPhone
@@ -9073,7 +9073,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: DEXP
@@ -9091,7 +9091,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: DEXP
@@ -9109,7 +9109,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Lava
@@ -9127,7 +9127,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Telenor
@@ -9145,7 +9145,7 @@
     name: Chrome Mobile
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: smartphone
     brand: Mito
@@ -9163,7 +9163,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: LT Mobile
@@ -9181,7 +9181,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: STG Telecom
@@ -9199,7 +9199,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: STG Telecom
@@ -9217,7 +9217,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: STG Telecom
@@ -9235,7 +9235,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: STG Telecom
@@ -9253,7 +9253,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: STG Telecom
@@ -9271,7 +9271,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: STG Telecom
@@ -9289,7 +9289,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: STG Telecom
@@ -9307,7 +9307,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: STG Telecom
@@ -9325,7 +9325,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: STG Telecom
@@ -9343,7 +9343,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: STG Telecom
@@ -9361,7 +9361,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: STG Telecom
@@ -9379,7 +9379,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Cloudfone
@@ -9397,7 +9397,7 @@
     name: Opera Mobile
     version: 52.2.2254.54723
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9415,7 +9415,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9433,7 +9433,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9451,7 +9451,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9469,7 +9469,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9487,7 +9487,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9505,7 +9505,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9523,7 +9523,7 @@
     name: Chrome Webview
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9541,7 +9541,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: LG
@@ -9559,7 +9559,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: LG
@@ -9577,7 +9577,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: LG
@@ -9595,7 +9595,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: LG
@@ -9613,7 +9613,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Huawei
@@ -9631,7 +9631,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Wiko
@@ -9649,7 +9649,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Wiko
@@ -9667,7 +9667,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Wiko
@@ -9685,7 +9685,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Wiko
@@ -9703,7 +9703,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Phicomm
@@ -9721,7 +9721,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Huawei
@@ -9739,7 +9739,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Celkon
@@ -9757,7 +9757,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Celkon
@@ -9775,7 +9775,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Celkon
@@ -9811,7 +9811,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Celkon
@@ -9829,7 +9829,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Astro
@@ -9847,7 +9847,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Astro
@@ -9865,7 +9865,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Maxwest
@@ -9883,7 +9883,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Maxwest
@@ -9901,7 +9901,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Woxter
@@ -9919,7 +9919,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Woxter
@@ -9937,7 +9937,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Woxter
@@ -9955,7 +9955,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Zuum
@@ -9973,7 +9973,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Celkon
@@ -10007,7 +10007,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: FMT
@@ -10025,7 +10025,7 @@
     name: Chrome Webview
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: FMT
@@ -10043,7 +10043,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: FMT
@@ -10061,7 +10061,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: FMT
@@ -10079,7 +10079,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: FMT
@@ -10097,7 +10097,7 @@
     name: Chrome Mobile
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: smartphone
     brand: FMT
@@ -10115,7 +10115,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -10133,7 +10133,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -10151,7 +10151,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -10169,7 +10169,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Hisense
@@ -10187,7 +10187,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: ZTE

--- a/Tests/fixtures/smartphone-23.yml
+++ b/Tests/fixtures/smartphone-23.yml
@@ -10,7 +10,7 @@
     name: Chrome Webview
     version: 33.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Xiaomi
@@ -28,7 +28,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Samsung
@@ -46,7 +46,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Samsung
@@ -64,7 +64,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Samsung
@@ -100,7 +100,7 @@
     name: Chrome
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Kyocera
@@ -118,7 +118,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Sharp
@@ -136,7 +136,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Sharp
@@ -154,7 +154,7 @@
     name: Chrome Webview
     version: 33.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Sharp
@@ -172,7 +172,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Sharp
@@ -190,7 +190,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Sony
@@ -208,7 +208,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Coolpad
@@ -280,7 +280,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Samsung
@@ -316,7 +316,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Sony
@@ -334,7 +334,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Xiaomi
@@ -352,7 +352,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Samsung
@@ -370,7 +370,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Sharp
@@ -406,7 +406,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Sharp
@@ -424,7 +424,7 @@
     name: Chrome Webview
     version: 33.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Kyocera
@@ -442,7 +442,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: BS Mobile
@@ -460,7 +460,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: BS Mobile
@@ -478,7 +478,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Runbo
@@ -496,7 +496,7 @@
     name: Chrome Mobile
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Runbo
@@ -514,7 +514,7 @@
     name: Chrome Mobile
     version: 85.0.4183.69
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.69"
   device:
     type: smartphone
     brand: RoyQueen
@@ -532,7 +532,7 @@
     name: Chrome Webview
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Invens
@@ -550,7 +550,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Invens
@@ -568,7 +568,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Invens
@@ -586,7 +586,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Invens
@@ -604,7 +604,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Invens
@@ -622,7 +622,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Invens
@@ -640,7 +640,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Invens
@@ -658,7 +658,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Invens
@@ -676,7 +676,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: EE
@@ -694,7 +694,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Revo
@@ -712,7 +712,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Revo
@@ -730,7 +730,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Revo
@@ -748,7 +748,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Ramos
@@ -766,7 +766,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Ramos
@@ -784,7 +784,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Ramos
@@ -802,7 +802,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Ramos
@@ -820,7 +820,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Karbonn
@@ -838,7 +838,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Karbonn
@@ -856,7 +856,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Karbonn
@@ -874,7 +874,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Q.Bell
@@ -892,7 +892,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Quantum
@@ -910,7 +910,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Quantum
@@ -928,7 +928,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Quantum
@@ -946,7 +946,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Quantum
@@ -964,7 +964,7 @@
     name: Chrome Webview
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Quantum
@@ -982,7 +982,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Quantum
@@ -1000,7 +1000,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Quantum
@@ -1018,7 +1018,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: GFive
@@ -1036,7 +1036,7 @@
     name: Chrome Mobile
     version: 80.0.3987.117
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: smartphone
     brand: Sky
@@ -1054,7 +1054,7 @@
     name: Chrome Mobile
     version: 75.0.3770.67
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: smartphone
     brand: Sky
@@ -1072,7 +1072,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Sky
@@ -1090,7 +1090,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Vivax
@@ -1108,7 +1108,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Oysters
@@ -1126,7 +1126,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Oysters
@@ -1144,7 +1144,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Oysters
@@ -1162,7 +1162,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: SWISSMOBILITY
@@ -1180,7 +1180,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: SWISSMOBILITY
@@ -1198,7 +1198,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Axioo
@@ -1216,7 +1216,7 @@
     name: Chrome Mobile
     version: 50.0.2661.89
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Axioo
@@ -1234,7 +1234,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Axioo
@@ -1252,7 +1252,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Axioo
@@ -1288,7 +1288,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Rivo
@@ -1306,7 +1306,7 @@
     name: Chrome Webview
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Rivo
@@ -1324,7 +1324,7 @@
     name: Chrome Webview
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Rivo
@@ -1342,7 +1342,7 @@
     name: Chrome Webview
     version: 43.0.2357.121
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Rivo
@@ -1360,7 +1360,7 @@
     name: Chrome Webview
     version: 43.0.2357.121
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Rivo
@@ -1378,7 +1378,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Rivo
@@ -1414,7 +1414,7 @@
     name: Chrome Webview
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Rivo
@@ -1432,7 +1432,7 @@
     name: Chrome Webview
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Rivo
@@ -1450,7 +1450,7 @@
     name: Chrome Webview
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Rivo
@@ -1468,7 +1468,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Rivo
@@ -1486,7 +1486,7 @@
     name: Chrome Mobile
     version: 40.0.2214.109
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Rivo
@@ -1540,7 +1540,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Rivo
@@ -1558,7 +1558,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Rivo
@@ -1576,7 +1576,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Rivo
@@ -1594,7 +1594,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Rivo
@@ -1612,7 +1612,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Rivo
@@ -1630,7 +1630,7 @@
     name: Chrome Webview
     version: 43.0.2357.121
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Rivo
@@ -1648,7 +1648,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Rivo
@@ -1666,7 +1666,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Rivo
@@ -1684,7 +1684,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Mito
@@ -1702,7 +1702,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Mito
@@ -1720,7 +1720,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Medion
@@ -1738,7 +1738,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Medion
@@ -1756,7 +1756,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Medion
@@ -1774,7 +1774,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Melrose
@@ -1792,7 +1792,7 @@
     name: Chrome Webview
     version: 50.0.2661.86
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Melrose
@@ -1810,7 +1810,7 @@
     name: Chrome Webview
     version: 50.0.2661.86
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Melrose
@@ -1828,7 +1828,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Multilaser
@@ -1846,7 +1846,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Multilaser
@@ -1864,7 +1864,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Manta Multimedia
@@ -1882,7 +1882,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Manta Multimedia
@@ -1900,7 +1900,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Manta Multimedia
@@ -1918,7 +1918,7 @@
     name: Chrome Mobile
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Manta Multimedia
@@ -1936,7 +1936,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Manta Multimedia
@@ -1954,7 +1954,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: M-Tech
@@ -1972,7 +1972,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Four Mobile
@@ -1990,7 +1990,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Four Mobile
@@ -2008,7 +2008,7 @@
     name: Chrome Webview
     version: 60.0.3112.50
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.50"
   device:
     type: smartphone
     brand: Four Mobile
@@ -2026,7 +2026,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Four Mobile
@@ -2044,7 +2044,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Four Mobile
@@ -2062,7 +2062,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Vsmart
@@ -2080,7 +2080,7 @@
     name: Chrome Mobile
     version: 89.0.4389.23
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.23"
   device:
     type: smartphone
     brand: Huawei
@@ -2098,7 +2098,7 @@
     name: Chrome Mobile
     version: 89.0.4389.72
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.72"
   device:
     type: smartphone
     brand: Vsmart
@@ -2116,7 +2116,7 @@
     name: Coc Coc
     version: 87.0.184
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.184"
   device:
     type: smartphone
     brand: Vsmart
@@ -2134,7 +2134,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Vsmart
@@ -2152,7 +2152,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Unihertz
@@ -2170,7 +2170,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Huawei
@@ -2188,7 +2188,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: UZ Mobile
@@ -2206,7 +2206,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: KREZ
@@ -2224,7 +2224,7 @@
     name: Opera Mobile
     version: 37.0.2192.105088
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.94"
   device:
     type: smartphone
     brand: Jinga
@@ -2242,7 +2242,7 @@
     name: Chrome Mobile
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Kurio
@@ -2260,7 +2260,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: DNS
@@ -2278,7 +2278,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Inco
@@ -2296,7 +2296,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Inco
@@ -2314,7 +2314,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Inco
@@ -2404,7 +2404,7 @@
     name: Chrome Mobile
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: UTime
@@ -2476,7 +2476,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: Highscreen
@@ -2494,7 +2494,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: MyPhone
@@ -2512,7 +2512,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Oukitel
@@ -2530,7 +2530,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: OnePlus
@@ -2548,7 +2548,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: phablet
     brand: Xiaomi
@@ -2566,7 +2566,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Alcatel
@@ -2584,7 +2584,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Zopo
@@ -2602,7 +2602,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Zopo
@@ -2620,7 +2620,7 @@
     name: Chrome Mobile
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Zopo
@@ -2638,7 +2638,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Zopo
@@ -2656,7 +2656,7 @@
     name: Chrome Webview
     version: 43.0.2357.121
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: L-Max
@@ -2674,7 +2674,7 @@
     name: Chrome Webview
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: L-Max
@@ -2692,7 +2692,7 @@
     name: Chrome Webview
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: L-Max
@@ -2710,7 +2710,7 @@
     name: Chrome Webview
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: L-Max
@@ -2728,7 +2728,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: L-Max
@@ -2746,7 +2746,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: mPhone
@@ -2764,7 +2764,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: mPhone
@@ -2782,7 +2782,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: mPhone
@@ -2800,7 +2800,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: mPhone
@@ -2818,7 +2818,7 @@
     name: Chrome Mobile
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Cobalt
@@ -2836,7 +2836,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Cobalt
@@ -2854,7 +2854,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Cobalt
@@ -2872,7 +2872,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Kodak
@@ -2890,7 +2890,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: OnePlus
@@ -2908,7 +2908,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Xtratech
@@ -2926,7 +2926,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Sky
@@ -2944,7 +2944,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Sky
@@ -2962,7 +2962,7 @@
     name: Opera Mobile
     version: 35.0.2254.127759
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Mobicel
@@ -2980,7 +2980,7 @@
     name: Chrome Mobile
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Maxwest
@@ -2998,7 +2998,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Maxwest
@@ -3016,7 +3016,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Maxwest
@@ -3052,7 +3052,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Maxwest
@@ -3070,7 +3070,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Maxwest
@@ -3088,7 +3088,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Maxwest
@@ -3106,7 +3106,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Maxwest
@@ -3124,7 +3124,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Maxwest
@@ -3142,7 +3142,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Tambo
@@ -3160,7 +3160,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Tambo
@@ -3178,7 +3178,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Tambo
@@ -3196,7 +3196,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Tambo
@@ -3214,7 +3214,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Tambo
@@ -3232,7 +3232,7 @@
     name: Chrome Mobile
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Tambo
@@ -3250,7 +3250,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Tambo
@@ -3268,7 +3268,7 @@
     name: Chrome Mobile
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: smartphone
     brand: Tambo
@@ -3286,7 +3286,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Tambo
@@ -3304,7 +3304,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Tambo
@@ -3322,7 +3322,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Tambo
@@ -3340,7 +3340,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Tambo
@@ -3358,7 +3358,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Huawei
@@ -3376,7 +3376,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Walton
@@ -3394,7 +3394,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: YUHO
@@ -3412,7 +3412,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: YUHO
@@ -3430,7 +3430,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: YUHO
@@ -3448,7 +3448,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Maxwest
@@ -3466,7 +3466,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: TechPad
@@ -3484,7 +3484,7 @@
     name: Chrome Webview
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Mobiistar
@@ -3502,7 +3502,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: CUBOT
@@ -3520,7 +3520,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Xiaomi
@@ -3538,7 +3538,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: OnePlus
@@ -3556,7 +3556,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Vivo
@@ -3574,7 +3574,7 @@
     name: Chrome Mobile
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: P-UP
@@ -3592,7 +3592,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Xiaomi
@@ -3610,7 +3610,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Xiaomi
@@ -3628,7 +3628,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Realme
@@ -3646,7 +3646,7 @@
     name: Chrome Webview
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Realme
@@ -3664,7 +3664,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Wiko
@@ -3682,7 +3682,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Vivo
@@ -3700,7 +3700,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Xiaomi
@@ -3718,7 +3718,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Vivo
@@ -3736,7 +3736,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Sharp
@@ -3754,7 +3754,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Gionee
@@ -3772,7 +3772,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: NUU Mobile
@@ -3790,7 +3790,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Sico
@@ -3808,7 +3808,7 @@
     name: Opera Mobile
     version: 52.2.2254.54723
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Panasonic
@@ -3844,7 +3844,7 @@
     name: Chrome Mobile
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: smartphone
     brand: Coolpad
@@ -3862,7 +3862,7 @@
     name: Chrome Webview
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Karbonn
@@ -3880,7 +3880,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Telenor
@@ -3898,7 +3898,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Telenor
@@ -3916,7 +3916,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Telenor
@@ -3934,7 +3934,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Telenor
@@ -3952,7 +3952,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Singtech
@@ -3970,7 +3970,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Singtech
@@ -3988,7 +3988,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Telenor
@@ -4006,7 +4006,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Timovi
@@ -4024,7 +4024,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Timovi
@@ -4042,7 +4042,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Timovi
@@ -4060,7 +4060,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Timovi
@@ -4078,7 +4078,7 @@
     name: Chrome Mobile
     version: 85.0.4183.120
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: smartphone
     brand: IKU Mobile
@@ -4096,7 +4096,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: IKU Mobile
@@ -4114,7 +4114,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: IKU Mobile
@@ -4132,7 +4132,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Explay
@@ -4150,7 +4150,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Explay
@@ -4168,7 +4168,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: ZTE
@@ -4186,7 +4186,7 @@
     name: Opera Mobile
     version: 52.4.2517.140781
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Doogee
@@ -4204,7 +4204,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Hotwav
@@ -4222,7 +4222,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Hotwav
@@ -4240,7 +4240,7 @@
     name: Chrome Webview
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Hotwav
@@ -4258,7 +4258,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Hotwav
@@ -4276,7 +4276,7 @@
     name: Chrome Webview
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Hotwav
@@ -4294,7 +4294,7 @@
     name: Chrome Mobile
     version: 83.0.4103.44
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.44"
   device:
     type: smartphone
     brand: Hotwav
@@ -4312,7 +4312,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Hotwav
@@ -4330,7 +4330,7 @@
     name: Chrome Webview
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Hotwav
@@ -4348,7 +4348,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Hotwav
@@ -4366,7 +4366,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Hotwav
@@ -4384,7 +4384,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Hotwav
@@ -4402,7 +4402,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Hotwav
@@ -4420,7 +4420,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Overmax
@@ -4438,7 +4438,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Verykool
@@ -4456,7 +4456,7 @@
     name: Chrome Mobile
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: smartphone
     brand: Verykool
@@ -4474,7 +4474,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Verykool
@@ -4492,7 +4492,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Verykool
@@ -4510,7 +4510,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Verykool
@@ -4528,7 +4528,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Verykool
@@ -4546,7 +4546,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Verykool
@@ -4564,7 +4564,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Verykool
@@ -4582,7 +4582,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Verykool
@@ -4600,7 +4600,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Verykool
@@ -4618,7 +4618,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Verykool
@@ -4636,7 +4636,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Verykool
@@ -4654,7 +4654,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Verykool
@@ -4672,7 +4672,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Verykool
@@ -4690,7 +4690,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Verykool
@@ -4708,7 +4708,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Verykool
@@ -4726,7 +4726,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Verykool
@@ -4744,7 +4744,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Verykool
@@ -4834,7 +4834,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Verykool
@@ -4852,7 +4852,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Verykool
@@ -4870,7 +4870,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Verykool
@@ -4888,7 +4888,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Verykool
@@ -4906,7 +4906,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Verykool
@@ -4924,7 +4924,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Verykool
@@ -4942,7 +4942,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Verykool
@@ -4960,7 +4960,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Verykool
@@ -4978,7 +4978,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Verykool
@@ -4996,7 +4996,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Verykool
@@ -5014,7 +5014,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Verykool
@@ -5032,7 +5032,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Verykool
@@ -5050,7 +5050,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Verykool
@@ -5068,7 +5068,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Verykool
@@ -5086,7 +5086,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Verykool
@@ -5104,7 +5104,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Verykool
@@ -5122,7 +5122,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Verykool
@@ -5140,7 +5140,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Verykool
@@ -5158,7 +5158,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Verykool
@@ -5176,7 +5176,7 @@
     name: Chrome Webview
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: VGO TEL
@@ -5194,7 +5194,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Verykool
@@ -5212,7 +5212,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Verykool
@@ -5230,7 +5230,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Verykool
@@ -5248,7 +5248,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Verykool
@@ -5266,7 +5266,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Verykool
@@ -5284,7 +5284,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Verykool
@@ -5302,7 +5302,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Verykool
@@ -5320,7 +5320,7 @@
     name: Chrome Mobile
     version: 71.0.3578.98
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.98"
   device:
     type: smartphone
     brand: Verykool
@@ -5356,7 +5356,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Vivax
@@ -5374,7 +5374,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Vivax
@@ -5392,7 +5392,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Elephone
@@ -5410,7 +5410,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Elephone
@@ -5428,7 +5428,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Iris
@@ -5446,7 +5446,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Iris
@@ -5464,7 +5464,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Land Rover
@@ -5482,7 +5482,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Land Rover
@@ -5500,7 +5500,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Quantum
@@ -5518,7 +5518,7 @@
     name: Opera Mobile
     version: 46.0.2254.145391
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Fly
@@ -5536,7 +5536,7 @@
     name: Opera Mobile
     version: 44.1.2254.143214
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Fly
@@ -5554,7 +5554,7 @@
     name: Opera Mobile
     version: 44.1.2254.143214
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Navon
@@ -5572,7 +5572,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: ZTE
@@ -5590,7 +5590,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Komu
@@ -5608,7 +5608,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Komu
@@ -5626,7 +5626,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Komu
@@ -5662,7 +5662,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -5776,7 +5776,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Ark
@@ -5794,7 +5794,7 @@
     name: Aloha Browser
     version: 2.10.0.2
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Leagoo
@@ -5828,7 +5828,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5846,7 +5846,7 @@
     name: Chrome Webview
     version: 66.0.3359.126
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: LG
@@ -6048,7 +6048,7 @@
     name: Chrome Webview
     version: 59.0.3071.125
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Prestigio
@@ -6066,7 +6066,7 @@
     name: Chrome Webview
     version: 54.0.2840.85
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Prestigio
@@ -6084,7 +6084,7 @@
     name: Chrome Webview
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Philips
@@ -6234,7 +6234,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: OPPO
@@ -6286,7 +6286,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Huawei
@@ -6304,7 +6304,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Blackview
@@ -6322,7 +6322,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: Tone
@@ -6374,7 +6374,7 @@
     name: Chrome Webview
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: SFR
@@ -6392,7 +6392,7 @@
     name: Chrome Webview
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: LG
@@ -6410,7 +6410,7 @@
     name: Chrome Webview
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: LG
@@ -6428,7 +6428,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Archos
@@ -6494,7 +6494,7 @@
     name: Chrome Webview
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Huawei
@@ -6512,7 +6512,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: LeEco
@@ -6530,7 +6530,7 @@
     name: Chrome Webview
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Huawei
@@ -6548,7 +6548,7 @@
     name: Yandex Browser
     version: "7.33"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Lenovo
@@ -6566,7 +6566,7 @@
     name: Chrome Mobile
     version: 43.0.2357.93
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Vivo
@@ -6584,7 +6584,7 @@
     name: Chrome Mobile
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Hisense
@@ -6602,7 +6602,7 @@
     name: Chrome Webview
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Archos
@@ -6620,7 +6620,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Xiaomi
@@ -6654,7 +6654,7 @@
     name: Yandex Browser
     version: 20.115.0
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Nubia
@@ -6672,7 +6672,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: LG
@@ -6690,7 +6690,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Vertex
@@ -6708,7 +6708,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: LG
@@ -6744,7 +6744,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Azumi Mobile
@@ -6762,7 +6762,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Blu
@@ -6780,7 +6780,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Vivo
@@ -6798,7 +6798,7 @@
     name: Chrome Mobile
     version: 87.0.4280.107
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.107"
   device:
     type: smartphone
     brand: Vivo
@@ -6816,7 +6816,7 @@
     name: Yandex Browser
     version: 20.92.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Vivo
@@ -6882,7 +6882,7 @@
     name: Chrome Webview
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Motorola
@@ -6900,7 +6900,7 @@
     name: Chrome Webview
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -6918,7 +6918,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Motorola
@@ -6936,7 +6936,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: LG
@@ -6990,7 +6990,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Vestel
@@ -7008,7 +7008,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Vestel
@@ -7026,7 +7026,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Hotwav
@@ -7044,7 +7044,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Hotwav
@@ -7062,7 +7062,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: ZTE
@@ -7080,7 +7080,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: ZTE
@@ -7098,7 +7098,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Vertex
@@ -7116,7 +7116,7 @@
     name: Aloha Browser
     version: 2.2.1.1
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Vertex
@@ -7134,7 +7134,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Motorola
@@ -7152,7 +7152,7 @@
     name: Aloha Browser
     version: 2.0.0.2
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Motorola
@@ -7170,7 +7170,7 @@
     name: Chrome Mobile
     version: 77.0.3865.73
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Intex
@@ -7188,7 +7188,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Intex
@@ -7206,7 +7206,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Intex
@@ -7224,7 +7224,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Intex
@@ -7242,7 +7242,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Intex
@@ -7260,7 +7260,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Intex
@@ -7278,7 +7278,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Intex
@@ -7296,7 +7296,7 @@
     name: Chrome Webview
     version: 59.0.3071.125
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Intex
@@ -7314,7 +7314,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Intex
@@ -7332,7 +7332,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Intex
@@ -7350,7 +7350,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Intex
@@ -7368,7 +7368,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Intex
@@ -7386,7 +7386,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Intex
@@ -7404,7 +7404,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Nomi
@@ -7422,7 +7422,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Nomi
@@ -7440,7 +7440,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Nomi
@@ -7458,7 +7458,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Nomi
@@ -7476,7 +7476,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Nomi
@@ -7494,7 +7494,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Nomi
@@ -7512,7 +7512,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Nomi
@@ -7530,7 +7530,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Nomi
@@ -7548,7 +7548,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: iMan
@@ -7566,7 +7566,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: iMan
@@ -7584,7 +7584,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: iPro
@@ -7602,7 +7602,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: VAVA
@@ -7620,7 +7620,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Samsung
@@ -7638,7 +7638,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: Samsung
@@ -7656,7 +7656,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -7674,7 +7674,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -7692,7 +7692,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: HTC
@@ -7710,7 +7710,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: HTC
@@ -7728,7 +7728,7 @@
     name: Chrome Mobile
     version: 42.0.2311.108
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.108"
   device:
     type: smartphone
     brand: HTC
@@ -7746,7 +7746,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: HTC
@@ -7764,7 +7764,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: HTC
@@ -7782,7 +7782,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: HTC
@@ -7800,7 +7800,7 @@
     name: Chrome Mobile
     version: 38.0.2125.102
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: smartphone
     brand: HTC
@@ -7818,7 +7818,7 @@
     name: Chrome Mobile
     version: 41.0.2272.96
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.96"
   device:
     type: smartphone
     brand: HTC
@@ -7836,7 +7836,7 @@
     name: Chrome Mobile
     version: 72.0.3626.81
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.81"
   device:
     type: smartphone
     brand: HTC
@@ -7854,7 +7854,7 @@
     name: Chrome Mobile
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: HTC
@@ -7872,7 +7872,7 @@
     name: Chrome Mobile
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: HTC
@@ -7890,7 +7890,7 @@
     name: Chrome Mobile
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: HTC
@@ -7908,7 +7908,7 @@
     name: Chrome Mobile
     version: 31.0.1650.59
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: HTC
@@ -7926,7 +7926,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: HTC
@@ -7944,7 +7944,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: DEXP
@@ -7962,7 +7962,7 @@
     name: Chrome Mobile
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: smartphone
     brand: DEXP
@@ -7980,7 +7980,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: DEXP
@@ -7998,7 +7998,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: DEXP
@@ -8016,7 +8016,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: HTC
@@ -8034,7 +8034,7 @@
     name: Chrome Webview
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Vodafone
@@ -8052,7 +8052,7 @@
     name: Chrome Webview
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Vodafone
@@ -8086,7 +8086,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Samsung
@@ -8104,7 +8104,7 @@
     name: Yandex Browser
     version: 18.3.1.651.00
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.186"
   device:
     type: smartphone
     brand: Neffos
@@ -8122,7 +8122,7 @@
     name: Chrome Mobile
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Asus
@@ -8156,7 +8156,7 @@
     name: Yandex Browser
     version: 20.120.0
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8174,7 +8174,7 @@
     name: Chrome Mobile
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Polaroid
@@ -8224,7 +8224,7 @@
     name: Chrome Webview
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Samsung
@@ -8274,7 +8274,7 @@
     name: Chrome Webview
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Samsung
@@ -8292,7 +8292,7 @@
     name: Chrome Webview
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Huawei
@@ -8310,7 +8310,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: HTC
@@ -8328,7 +8328,7 @@
     name: Opera Mobile
     version: 58.2.2878.53403
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: HTC
@@ -8346,7 +8346,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: HTC
@@ -8364,7 +8364,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: HTC
@@ -8382,7 +8382,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: HTC
@@ -8400,7 +8400,7 @@
     name: Chrome Mobile
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: HTC
@@ -8418,7 +8418,7 @@
     name: Yandex Browser
     version: 20.11.5.113.00
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Samsung
@@ -8436,7 +8436,7 @@
     name: Yandex Browser
     version: 20.11.4.121.00
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Samsung
@@ -8508,7 +8508,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Avvio
@@ -8526,7 +8526,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: ZTE
@@ -8544,7 +8544,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: ZTE
@@ -8562,7 +8562,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: ZTE
@@ -8580,7 +8580,7 @@
     name: Chrome Mobile
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: smartphone
     brand: Hisense
@@ -8598,7 +8598,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Hisense
@@ -8616,7 +8616,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Hisense
@@ -8634,7 +8634,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Highscreen
@@ -8652,7 +8652,7 @@
     name: Opera Touch
     version: "2.8"
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8670,7 +8670,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Videocon
@@ -8688,7 +8688,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8706,7 +8706,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8724,7 +8724,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8742,7 +8742,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8760,7 +8760,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8778,7 +8778,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8796,7 +8796,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8814,7 +8814,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8832,7 +8832,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: iVooMi
@@ -8850,7 +8850,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: ivvi
@@ -8868,7 +8868,7 @@
     name: Chrome Mobile
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: smartphone
     brand: ivvi
@@ -8886,7 +8886,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: ivvi
@@ -8904,7 +8904,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: ivvi
@@ -8922,7 +8922,7 @@
     name: Yandex Browser
     version: 19.7.4.97.00
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -8940,7 +8940,7 @@
     name: Chrome Mobile
     version: 80.0.3987.117
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: smartphone
     brand: Huawei
@@ -8958,7 +8958,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Huawei
@@ -8976,7 +8976,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Huawei
@@ -8994,7 +8994,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Huawei
@@ -9012,7 +9012,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Prestigio
@@ -9030,7 +9030,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Prestigio
@@ -9048,7 +9048,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: Prestigio
@@ -9066,7 +9066,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Prestigio
@@ -9084,7 +9084,7 @@
     name: Opera Mobile
     version: 44.1.2254.143214
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Prestigio
@@ -9102,7 +9102,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: Prestigio
@@ -9120,7 +9120,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Motorola
@@ -9138,7 +9138,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Motorola
@@ -9156,7 +9156,7 @@
     name: Chrome Mobile
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: smartphone
     brand: Motorola
@@ -9174,7 +9174,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Motorola
@@ -9192,7 +9192,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Motorola
@@ -9210,7 +9210,7 @@
     name: Chrome Mobile
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: smartphone
     brand: Motorola
@@ -9228,7 +9228,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Motorola
@@ -9246,7 +9246,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Hisense
@@ -9264,7 +9264,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Hisense
@@ -9282,7 +9282,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Kyocera
@@ -9300,7 +9300,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Hisense
@@ -9318,7 +9318,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Hisense
@@ -9336,7 +9336,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Hisense
@@ -9354,7 +9354,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Hisense
@@ -9372,7 +9372,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Hisense
@@ -9390,7 +9390,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Gionee
@@ -9426,7 +9426,7 @@
     name: Chrome Mobile
     version: 92.0.4515.70
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.70"
   device:
     type: smartphone
     brand: Samsung
@@ -9444,7 +9444,7 @@
     name: Chrome Webview
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Xiaomi

--- a/Tests/fixtures/smartphone-24.yml
+++ b/Tests/fixtures/smartphone-24.yml
@@ -10,7 +10,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Majestic
@@ -28,7 +28,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Majestic
@@ -46,7 +46,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Starmobile
@@ -64,7 +64,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Starmobile
@@ -82,7 +82,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Navon
@@ -100,7 +100,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Nokia
@@ -118,7 +118,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Nokia
@@ -136,7 +136,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: QMobile
@@ -154,7 +154,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: QMobile
@@ -172,7 +172,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: QMobile
@@ -190,7 +190,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: QMobile
@@ -208,7 +208,7 @@
     name: Chrome Mobile
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: smartphone
     brand: MicroMax
@@ -226,7 +226,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: MicroMax
@@ -244,7 +244,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: MicroMax
@@ -262,7 +262,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: MicroMax
@@ -280,7 +280,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: MicroMax
@@ -298,7 +298,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: MicroMax
@@ -316,7 +316,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: MicroMax
@@ -334,7 +334,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: MicroMax
@@ -388,7 +388,7 @@
     name: Chrome Mobile
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: GOCLEVER
@@ -406,7 +406,7 @@
     name: Chrome Mobile
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: GOCLEVER
@@ -424,7 +424,7 @@
     name: Yandex Browser
     version: "7.33"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: ZTE
@@ -442,7 +442,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: TCL
@@ -460,7 +460,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: LG
@@ -478,7 +478,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: HTC
@@ -496,7 +496,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: LG
@@ -514,7 +514,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Asus
@@ -532,7 +532,7 @@
     name: Yandex Browser
     version: "11.41"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Vertex
@@ -550,7 +550,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: LG
@@ -568,7 +568,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: LG
@@ -586,7 +586,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: LG
@@ -604,7 +604,7 @@
     name: Chrome
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Motorola
@@ -622,7 +622,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Realme
@@ -656,7 +656,7 @@
     name: Chrome Webview
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Samsung
@@ -674,7 +674,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Xiaomi
@@ -692,7 +692,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: HTC
@@ -710,7 +710,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Blackview
@@ -762,7 +762,7 @@
     name: Yandex Browser
     version: 20.7.1.60.00
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.116"
   device:
     type: smartphone
     brand: LG
@@ -780,7 +780,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Vivo
@@ -798,7 +798,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Vivo
@@ -816,7 +816,7 @@
     name: Chrome Webview
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Vodafone
@@ -834,7 +834,7 @@
     name: Chrome Webview
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Vodafone
@@ -852,7 +852,7 @@
     name: Chrome Webview
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Motorola
@@ -902,7 +902,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Cloudfone
@@ -920,7 +920,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Panasonic
@@ -938,7 +938,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Huawei
@@ -957,7 +957,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Lenovo
@@ -975,7 +975,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Lenovo
@@ -993,7 +993,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Lenovo
@@ -1011,7 +1011,7 @@
     name: Chrome Mobile
     version: 52.0.2743.98
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Lenovo
@@ -1029,7 +1029,7 @@
     name: Chrome Webview
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -1047,7 +1047,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -1065,7 +1065,7 @@
     name: Microsoft Edge
     version: 45.12.4.5137
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Huawei
@@ -1083,7 +1083,7 @@
     name: Chrome Webview
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: OPPO
@@ -1101,7 +1101,7 @@
     name: Chrome Webview
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -1183,7 +1183,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Hisense
@@ -1201,7 +1201,7 @@
     name: Chrome
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Samsung
@@ -1219,7 +1219,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Hisense
@@ -1237,7 +1237,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Safaricom
@@ -1255,7 +1255,7 @@
     name: Opera Mobile
     version: 52.2.2254.54723
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Xiaomi
@@ -1273,7 +1273,7 @@
     name: Yandex Browser
     version: 20.11.3.88.00
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Xiaomi
@@ -1291,7 +1291,7 @@
     name: Chrome Webview
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -1309,7 +1309,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Prestigio
@@ -1327,7 +1327,7 @@
     name: Yandex Browser
     version: 20.113.1
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Samsung
@@ -1345,7 +1345,7 @@
     name: Yandex Browser
     version: 20.114.0
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Samsung
@@ -1363,7 +1363,7 @@
     name: Yandex Browser
     version: 20.84.1
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: smartphone
     brand: Samsung
@@ -1381,7 +1381,7 @@
     name: Yandex Browser
     version: 20.114.0
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Samsung
@@ -1399,7 +1399,7 @@
     name: Chrome Webview
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: ZTE
@@ -1467,7 +1467,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Samsung
@@ -1485,7 +1485,7 @@
     name: Chrome Mobile
     version: 77.0.3865.73
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Prestigio
@@ -1503,7 +1503,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Prestigio
@@ -1521,7 +1521,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Prestigio
@@ -1539,7 +1539,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: LG
@@ -1589,7 +1589,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Panasonic
@@ -1677,7 +1677,7 @@
     name: Chrome Webview
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Wiko
@@ -1781,7 +1781,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Realme
@@ -1799,7 +1799,7 @@
     name: Chrome Mobile
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: smartphone
     brand: Pantech
@@ -1817,7 +1817,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Pantech
@@ -1835,7 +1835,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Pantech
@@ -1853,7 +1853,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Walton
@@ -1871,7 +1871,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Walton
@@ -1889,7 +1889,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Walton
@@ -1907,7 +1907,7 @@
     name: Chrome Mobile
     version: 80.0.3987.117
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: smartphone
     brand: Walton
@@ -1925,7 +1925,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Walton
@@ -1943,7 +1943,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Walton
@@ -1961,7 +1961,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Walton
@@ -1979,7 +1979,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Walton
@@ -1997,7 +1997,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Walton
@@ -2015,7 +2015,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Walton
@@ -2033,7 +2033,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Walton
@@ -2051,7 +2051,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Walton
@@ -2069,7 +2069,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: LG
@@ -2087,7 +2087,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: LG
@@ -2105,7 +2105,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: LG
@@ -2123,7 +2123,7 @@
     name: Chrome Mobile
     version: 30.0.1599.103
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.103"
   device:
     type: smartphone
     brand: LG
@@ -2141,7 +2141,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: LG
@@ -2159,7 +2159,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: Huawei
@@ -2225,7 +2225,7 @@
     name: Aloha Browser
     version: 2.23.0
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Samsung
@@ -2243,7 +2243,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Asus
@@ -2261,7 +2261,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: AGM
@@ -2279,7 +2279,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: AGM
@@ -2297,7 +2297,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: AGM
@@ -2315,7 +2315,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: AGM
@@ -2333,7 +2333,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: AGM
@@ -2351,7 +2351,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Aligator
@@ -2369,7 +2369,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Lumus
@@ -2387,7 +2387,7 @@
     name: Opera Mobile
     version: 56.0.2254.57357
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: ZTE
@@ -2423,7 +2423,7 @@
     name: Opera Mobile
     version: 56.1.2780.51589
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: LeEco
@@ -2441,7 +2441,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: LG
@@ -2459,7 +2459,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Hotwav
@@ -2477,7 +2477,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Hotwav
@@ -2495,7 +2495,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: Panasonic
@@ -2513,7 +2513,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -2531,7 +2531,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Bluboo
@@ -2549,7 +2549,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Meizu
@@ -2567,7 +2567,7 @@
     name: Opera Mobile
     version: 51.3.2461.138727
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Highscreen
@@ -2585,7 +2585,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Jinga
@@ -2603,7 +2603,7 @@
     name: Chrome Webview
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Gooweel
@@ -2621,7 +2621,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: AG Mobile
@@ -2639,7 +2639,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: AG Mobile
@@ -2657,7 +2657,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: AG Mobile
@@ -2675,7 +2675,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: BenQ
@@ -2709,7 +2709,7 @@
     name: Chrome Mobile
     version: 72.0.3626.76
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Explay
@@ -2727,7 +2727,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Highscreen
@@ -2761,7 +2761,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: LG
@@ -2859,7 +2859,7 @@
     name: Chrome Webview
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: LG
@@ -2927,7 +2927,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: LG
@@ -2961,7 +2961,7 @@
     name: Chrome Mobile
     version: 80.0.3987.117
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: smartphone
     brand: LG
@@ -2979,7 +2979,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: LG
@@ -2997,7 +2997,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: LG
@@ -3015,7 +3015,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: LG
@@ -3033,7 +3033,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: LG
@@ -3051,7 +3051,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: LG
@@ -3105,7 +3105,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: LG
@@ -3141,7 +3141,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: LG
@@ -3159,7 +3159,7 @@
     name: Chrome Mobile
     version: 85.0.4183.120
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: smartphone
     brand: LG
@@ -3177,7 +3177,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: LG
@@ -3195,7 +3195,7 @@
     name: Yandex Browser
     version: 19.12.4.87.00
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: LG
@@ -3245,7 +3245,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: LG
@@ -3297,7 +3297,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: LG
@@ -3315,7 +3315,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: LG
@@ -3333,7 +3333,7 @@
     name: Chrome Webview
     version: 74.0.3729.186
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.186"
   device:
     type: smartphone
     brand: LG
@@ -3351,7 +3351,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: LG
@@ -3369,7 +3369,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: LG
@@ -3387,7 +3387,7 @@
     name: Chrome Mobile
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: smartphone
     brand: LG
@@ -3405,7 +3405,7 @@
     name: Yandex Browser
     version: 20.113.0
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: LG
@@ -3441,7 +3441,7 @@
     name: Chrome Mobile
     version: 88.0.4304.4
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4304.4"
   device:
     type: smartphone
     brand: LG
@@ -3477,7 +3477,7 @@
     name: Opera Mobile
     version: 47.0.2254.146760
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: LG
@@ -3513,7 +3513,7 @@
     name: Yandex Browser
     version: 20.11.0.180.00
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: LG
@@ -3531,7 +3531,7 @@
     name: Chrome Mobile
     version: 47.0.2526.83
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: LG
@@ -3549,7 +3549,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: LG
@@ -3567,7 +3567,7 @@
     name: Chrome Mobile
     version: 43.0.2357.93
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: LG
@@ -3619,7 +3619,7 @@
     name: Yandex Browser
     version: 20.113.0
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: LG
@@ -3637,7 +3637,7 @@
     name: Yandex Browser
     version: 20.2.5.131.00
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: LG
@@ -3655,7 +3655,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: LG
@@ -3673,7 +3673,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: LG
@@ -3691,7 +3691,7 @@
     name: Chrome Mobile
     version: 86.0.4240.111
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.111"
   device:
     type: smartphone
     brand: LG
@@ -3709,7 +3709,7 @@
     name: Chrome Mobile
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: LG
@@ -3727,7 +3727,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: LG
@@ -3745,7 +3745,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: LG
@@ -3763,7 +3763,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: LG
@@ -3781,7 +3781,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: LG
@@ -3799,7 +3799,7 @@
     name: Yandex Browser
     version: 20.6.3.54.00
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: LG
@@ -3817,7 +3817,7 @@
     name: Yandex Browser
     version: 20.9.1.66.00
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: LG
@@ -3835,7 +3835,7 @@
     name: Yandex Browser
     version: 20.11.1.19.00
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: LG
@@ -3853,7 +3853,7 @@
     name: Yandex Browser
     version: 19.12.1.121.00
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.97"
   device:
     type: smartphone
     brand: LG
@@ -3871,7 +3871,7 @@
     name: Yandex Browser
     version: 20.9.3.85.00
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: LG
@@ -3889,7 +3889,7 @@
     name: Yandex Browser
     version: 20.113.0
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: LG
@@ -3907,7 +3907,7 @@
     name: Yandex Browser
     version: 20.8.5.97.00
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: smartphone
     brand: LG
@@ -3925,7 +3925,7 @@
     name: Yandex Browser
     version: 20.94.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: LG
@@ -3943,7 +3943,7 @@
     name: Yandex Browser
     version: 20.8.3.71.00
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: smartphone
     brand: LG
@@ -3979,7 +3979,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: LG
@@ -3997,7 +3997,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: LG
@@ -4033,7 +4033,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: LG
@@ -4101,7 +4101,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: LG
@@ -4119,7 +4119,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: LG
@@ -4137,7 +4137,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: LG
@@ -4155,7 +4155,7 @@
     name: Yandex Browser
     version: 19.10.4.187.00
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: smartphone
     brand: LG
@@ -4173,7 +4173,7 @@
     name: Chrome Mobile
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: LG
@@ -4191,7 +4191,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: LG
@@ -4209,7 +4209,7 @@
     name: Chrome Mobile
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: LG
@@ -4227,7 +4227,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: LG
@@ -4245,7 +4245,7 @@
     name: Chrome Mobile
     version: 85.0.4183.120
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: smartphone
     brand: LG
@@ -4263,7 +4263,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: LG
@@ -4297,7 +4297,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: LG
@@ -4315,7 +4315,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: LG
@@ -4333,7 +4333,7 @@
     name: Chrome Webview
     version: 30.0.1599.103
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.103"
   device:
     type: smartphone
     brand: LG
@@ -4441,7 +4441,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: LG
@@ -4459,7 +4459,7 @@
     name: Chrome Mobile
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: LG
@@ -4477,7 +4477,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: LG
@@ -4495,7 +4495,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: LG
@@ -4513,7 +4513,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: LG
@@ -4531,7 +4531,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: LG
@@ -4549,7 +4549,7 @@
     name: Chrome Mobile
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: smartphone
     brand: LG
@@ -4567,7 +4567,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: LG
@@ -4585,7 +4585,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: LG
@@ -4603,7 +4603,7 @@
     name: Yandex Browser
     version: 20.8.4.75.00
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: smartphone
     brand: LG
@@ -4621,7 +4621,7 @@
     name: Yandex Browser
     version: 20.4.3.90.00
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: LG
@@ -4639,7 +4639,7 @@
     name: Yandex Browser
     version: 20.2.0.215.00
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.117"
   device:
     type: smartphone
     brand: LG
@@ -4657,7 +4657,7 @@
     name: Yandex Browser
     version: 20.93.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: LG
@@ -4691,7 +4691,7 @@
     name: Yandex Browser
     version: 20.11.0.164.00
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: LG
@@ -4709,7 +4709,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: LG
@@ -4727,7 +4727,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: LG
@@ -4745,7 +4745,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: LG
@@ -4763,7 +4763,7 @@
     name: Yandex Browser
     version: 20.4.4.76.00
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: LG
@@ -4781,7 +4781,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: LG
@@ -4799,7 +4799,7 @@
     name: Chrome Webview
     version: 34.0.1847.118
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.118"
   device:
     type: smartphone
     brand: LG
@@ -4817,7 +4817,7 @@
     name: Chrome Webview
     version: 34.0.1847.118
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.118"
   device:
     type: smartphone
     brand: LG
@@ -4835,7 +4835,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: LG
@@ -4853,7 +4853,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: LG
@@ -4871,7 +4871,7 @@
     name: Chrome Mobile
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: LG
@@ -4889,7 +4889,7 @@
     name: Chrome Webview
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: LG
@@ -4907,7 +4907,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: LG
@@ -4925,7 +4925,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: LG
@@ -4943,7 +4943,7 @@
     name: Chrome Mobile
     version: 30.0.1599.103
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.103"
   device:
     type: smartphone
     brand: LG
@@ -4961,7 +4961,7 @@
     name: Chrome Webview
     version: 34.0.1847.118
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.118"
   device:
     type: smartphone
     brand: LG
@@ -4979,7 +4979,7 @@
     name: Chrome Webview
     version: 34.0.1847.118
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.118"
   device:
     type: smartphone
     brand: LG
@@ -5014,7 +5014,7 @@
     name: Opera Mobile
     version: 47.0.2254.146760
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.107"
   device:
     type: smartphone
     brand: LG
@@ -5068,7 +5068,7 @@
     name: Opera Mobile
     version: 43.2.2254.140293
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: LG
@@ -5104,7 +5104,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: LG
@@ -5138,7 +5138,7 @@
     name: Chrome Mobile
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: LG
@@ -5172,7 +5172,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: LG
@@ -5190,7 +5190,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: LG
@@ -5208,7 +5208,7 @@
     name: Chrome Mobile
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: LG
@@ -5226,7 +5226,7 @@
     name: Chrome Mobile
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: LG
@@ -5244,7 +5244,7 @@
     name: Chrome Mobile
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: LG
@@ -5278,7 +5278,7 @@
     name: Chrome Mobile
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: LG
@@ -5312,7 +5312,7 @@
     name: Chrome Mobile
     version: 53.0.2785.124
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: LG
@@ -5330,7 +5330,7 @@
     name: Chrome Mobile
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: LG
@@ -5348,7 +5348,7 @@
     name: Chrome Mobile
     version: 41.0.2272.96
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.96"
   device:
     type: smartphone
     brand: LG
@@ -5366,7 +5366,7 @@
     name: Chrome Mobile
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: LG
@@ -5384,7 +5384,7 @@
     name: Chrome Mobile
     version: 50.0.2661.89
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: LG
@@ -5402,7 +5402,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: LG
@@ -5420,7 +5420,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: LG
@@ -5438,7 +5438,7 @@
     name: Opera Mobile
     version: 51.0.2254.150807
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: LG
@@ -5456,7 +5456,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: LG
@@ -5474,7 +5474,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: LG
@@ -5492,7 +5492,7 @@
     name: Chrome Mobile
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: LG
@@ -5510,7 +5510,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: LG
@@ -5528,7 +5528,7 @@
     name: Chrome Mobile
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: LG
@@ -5546,7 +5546,7 @@
     name: Chrome Mobile
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: LG
@@ -5564,7 +5564,7 @@
     name: Chrome Mobile
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: LG
@@ -5672,7 +5672,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: LG
@@ -5708,7 +5708,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: LG
@@ -5758,7 +5758,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: LG
@@ -5776,7 +5776,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: S-TELL
@@ -5794,7 +5794,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Alcatel
@@ -5812,7 +5812,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Prestigio
@@ -5830,7 +5830,7 @@
     name: Opera Touch
     version: "2.6"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Prestigio
@@ -5848,7 +5848,7 @@
     name: Yandex Browser
     version: "11.20"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Prestigio
@@ -5866,7 +5866,7 @@
     name: Yandex Browser
     version: "10.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Haier
@@ -5884,7 +5884,7 @@
     name: Chrome Webview
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: HTC
@@ -5902,7 +5902,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Prestigio
@@ -5920,7 +5920,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: HTC
@@ -5938,7 +5938,7 @@
     name: Chrome Webview
     version: 52.0.2743.98
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: HTC
@@ -5956,7 +5956,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: HTC
@@ -5974,7 +5974,7 @@
     name: Chrome Mobile
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: HTC
@@ -5992,7 +5992,7 @@
     name: Yandex Browser
     version: "7.52"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Inoi
@@ -6010,7 +6010,7 @@
     name: Chrome Mobile
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: smartphone
     brand: HTC
@@ -6028,7 +6028,7 @@
     name: Chrome Webview
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Nomi
@@ -6046,7 +6046,7 @@
     name: Chrome Mobile
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: smartphone
     brand: Infinix
@@ -6064,7 +6064,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Infinix
@@ -6082,7 +6082,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Infinix
@@ -6100,7 +6100,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -6118,7 +6118,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Infinix
@@ -6136,7 +6136,7 @@
     name: Chrome Mobile
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: smartphone
     brand: Infinix
@@ -6154,7 +6154,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Haier
@@ -6172,7 +6172,7 @@
     name: Yandex Browser
     version: 20.3.0.276.00
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.122"
   device:
     type: smartphone
     brand: Inoi
@@ -6190,7 +6190,7 @@
     name: Chrome Mobile
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -6208,7 +6208,7 @@
     name: Yandex Browser
     version: "11.30"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -6244,7 +6244,7 @@
     name: Yandex Browser
     version: "11.30"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -6262,7 +6262,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: iOutdoor
@@ -6280,7 +6280,7 @@
     name: Opera Mobile
     version: 50.0.2254.149182
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Asus
@@ -6298,7 +6298,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Nomi
@@ -6316,7 +6316,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: ThL
@@ -6334,7 +6334,7 @@
     name: Opera Touch
     version: "2.5"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Inoi
@@ -6352,7 +6352,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -6370,7 +6370,7 @@
     name: Chrome Webview
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Huawei
@@ -6388,7 +6388,7 @@
     name: Chrome Mobile
     version: 53.0.2785.124
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: LG
@@ -6406,7 +6406,7 @@
     name: Chrome Mobile
     version: 59.0.3071.125
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: LG
@@ -6424,7 +6424,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Azumi Mobile
@@ -6442,7 +6442,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Prestigio
@@ -6460,7 +6460,7 @@
     name: Chrome Mobile
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -6478,7 +6478,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -6496,7 +6496,7 @@
     name: Chrome Webview
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -6514,7 +6514,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -6532,7 +6532,7 @@
     name: Chrome Mobile
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -6550,7 +6550,7 @@
     name: Yandex Browser Lite
     version: 19.3.0.137
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -6568,7 +6568,7 @@
     name: Chrome Mobile
     version: 83.0.4103.60
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.60"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -6586,7 +6586,7 @@
     name: Chrome Webview
     version: 66.0.3359.126
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Infinix
@@ -6604,7 +6604,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: FLYCAT
@@ -6622,7 +6622,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: FLYCAT
@@ -6640,7 +6640,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: FLYCAT
@@ -6658,7 +6658,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: FLYCAT
@@ -6676,7 +6676,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: FLYCAT
@@ -6694,7 +6694,7 @@
     name: Chrome Webview
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Leagoo
@@ -6712,7 +6712,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Leagoo
@@ -6746,7 +6746,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: VIWA
@@ -6764,7 +6764,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: VIWA
@@ -6782,7 +6782,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: 4Good
@@ -6800,7 +6800,7 @@
     name: Chrome Mobile
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Highscreen
@@ -6818,7 +6818,7 @@
     name: Chrome Mobile
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Cyrus
@@ -6884,7 +6884,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Leagoo
@@ -6902,7 +6902,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: QMobile
@@ -6936,7 +6936,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Doogee
@@ -6986,7 +6986,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Jinga
@@ -7168,7 +7168,7 @@
     name: Yandex Browser
     version: 18.11.2.730.00
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: smartphone
     brand: Gretel
@@ -7266,7 +7266,7 @@
     name: Chrome Webview
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: DEXP
@@ -7284,7 +7284,7 @@
     name: Yandex Browser
     version: 19.1.3.198.00
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Jinga
@@ -7302,7 +7302,7 @@
     name: Chrome Mobile
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Beeline
@@ -7320,7 +7320,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Doogee
@@ -7338,7 +7338,7 @@
     name: Chrome Mobile
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: DEXP
@@ -7356,7 +7356,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: DEXP
@@ -7374,7 +7374,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Doogee
@@ -7392,7 +7392,7 @@
     name: Yandex Browser
     version: 19.4.1.454.00
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.103"
   device:
     type: smartphone
     brand: Meizu
@@ -7410,7 +7410,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: M-Horse
@@ -7444,7 +7444,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: M-Horse
@@ -7494,7 +7494,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Oukitel
@@ -7512,7 +7512,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Samsung
@@ -7530,7 +7530,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Xiaomi
@@ -7548,7 +7548,7 @@
     name: Chrome Webview
     version: 88.0.4324.152
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.152"
   device:
     type: smartphone
     brand: Samsung
@@ -7566,7 +7566,7 @@
     name: Chrome Mobile
     version: 91.0.4472.134
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.134"
   device:
     type: smartphone
     brand: Asus
@@ -7584,7 +7584,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: ZTE
@@ -7602,7 +7602,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Vivo
@@ -7620,7 +7620,7 @@
     name: Chrome Mobile
     version: 89.0.4389.90
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.90"
   device:
     type: smartphone
     brand: Vivo
@@ -7638,7 +7638,7 @@
     name: Chrome Webview
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Samsung
@@ -7656,7 +7656,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Samsung
@@ -7674,7 +7674,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Vivo
@@ -7692,7 +7692,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Vivo
@@ -7710,7 +7710,7 @@
     name: Chrome Webview
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Vivo
@@ -7728,7 +7728,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Vivo
@@ -7746,7 +7746,7 @@
     name: Opera Mobile
     version: 62.3.3146.57763
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Vivo
@@ -7764,7 +7764,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Vivo
@@ -7782,7 +7782,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Huawei
@@ -7800,7 +7800,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Hyundai
@@ -7818,7 +7818,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: ZTE
@@ -7836,7 +7836,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Motorola
@@ -7854,7 +7854,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Motorola
@@ -7872,7 +7872,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Huawei
@@ -7890,7 +7890,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Nokia
@@ -7908,7 +7908,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Huawei
@@ -7926,7 +7926,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Huawei
@@ -7944,7 +7944,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Huawei
@@ -7962,7 +7962,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Huawei
@@ -7980,7 +7980,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Huawei
@@ -7998,7 +7998,7 @@
     name: Chrome Webview
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -8016,7 +8016,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: ZTE
@@ -8034,7 +8034,7 @@
     name: Yandex Browser
     version: 21.5.6.56.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Samsung
@@ -8052,7 +8052,7 @@
     name: Yandex Browser
     version: "20.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: smartphone
     brand: Realme
@@ -8070,7 +8070,7 @@
     name: Yandex Browser
     version: 21.54.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Realme
@@ -8088,7 +8088,7 @@
     name: Yandex Browser
     version: 21.54.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Sharp
@@ -8106,7 +8106,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: OPPO
@@ -8124,7 +8124,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: ZTE
@@ -8142,7 +8142,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Hyundai
@@ -8160,7 +8160,7 @@
     name: Chrome Mobile
     version: 89.0.4389.90
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.90"
   device:
     type: smartphone
     brand: LG
@@ -8178,7 +8178,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: LG
@@ -8196,7 +8196,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Nokia
@@ -8214,7 +8214,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Motorola
@@ -8250,7 +8250,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Motorola
@@ -8268,7 +8268,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Motorola
@@ -8286,7 +8286,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Motorola
@@ -8304,7 +8304,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Motorola
@@ -8322,7 +8322,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Huawei
@@ -8340,7 +8340,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Motorola
@@ -8358,7 +8358,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Lenovo
@@ -8376,7 +8376,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Lenovo
@@ -8394,7 +8394,7 @@
     name: Chrome Webview
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8412,7 +8412,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8430,7 +8430,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8448,7 +8448,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8466,7 +8466,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8502,7 +8502,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Philips
@@ -8520,7 +8520,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Philips
@@ -8538,7 +8538,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Philips
@@ -8556,7 +8556,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Huawei
@@ -8574,7 +8574,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Huawei
@@ -8592,7 +8592,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Blu
@@ -8610,7 +8610,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Blu
@@ -8628,7 +8628,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Blu
@@ -8646,7 +8646,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Phonemax
@@ -8664,7 +8664,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -8682,7 +8682,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Sigma
@@ -8700,7 +8700,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Sigma
@@ -8718,7 +8718,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Motorola
@@ -8736,7 +8736,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Motorola
@@ -8754,7 +8754,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Motorola
@@ -8772,7 +8772,7 @@
     name: Chrome Mobile
     version: 92.0.4515.80
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.80"
   device:
     type: smartphone
     brand: Motorola
@@ -8790,7 +8790,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Motorola
@@ -8808,7 +8808,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Ulefone
@@ -8826,7 +8826,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: ZTE
@@ -8844,7 +8844,7 @@
     name: Yandex Browser
     version: 21.51.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: ZTE
@@ -8862,7 +8862,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Ulefone
@@ -8880,7 +8880,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Ulefone
@@ -8898,7 +8898,7 @@
     name: Chrome Webview
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: F150
@@ -8916,7 +8916,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -8934,7 +8934,7 @@
     name: Chrome Mobile
     version: 92.0.4515.51
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.51"
   device:
     type: smartphone
     brand: OPPO
@@ -8952,7 +8952,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: OPPO
@@ -8970,7 +8970,7 @@
     name: Chrome Mobile
     version: 92.0.4515.80
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.80"
   device:
     type: smartphone
     brand: OPPO
@@ -8988,7 +8988,7 @@
     name: Chrome Mobile
     version: 93.0.4577.8
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.8"
   device:
     type: smartphone
     brand: OPPO
@@ -9006,7 +9006,7 @@
     name: Chrome Mobile
     version: 92.0.4515.70
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.70"
   device:
     type: smartphone
     brand: OPPO
@@ -9024,7 +9024,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -9060,7 +9060,7 @@
     name: Yandex Browser
     version: 21.54.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Archos
@@ -9078,7 +9078,7 @@
     name: Opera Mobile
     version: 57.0.2254.58007
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Samsung
@@ -9096,7 +9096,7 @@
     name: Opera Mobile
     version: 56.1.2254.57583
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9114,7 +9114,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: ZTE
@@ -9132,7 +9132,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: ZTE
@@ -9150,7 +9150,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: ZTE
@@ -9168,7 +9168,7 @@
     name: Yandex Browser
     version: 21.50.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: smartphone
     brand: Neffos
@@ -9186,7 +9186,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Nomi
@@ -9204,7 +9204,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: NOA
@@ -9222,7 +9222,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Inoi
@@ -9240,7 +9240,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Infinix
@@ -9258,7 +9258,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Nomu
@@ -9276,7 +9276,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Doogee
@@ -9294,7 +9294,7 @@
     name: Chrome
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Senseit
@@ -9312,7 +9312,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Samsung
@@ -9330,7 +9330,7 @@
     name: Opera Mobile
     version: 52.2.2254.54723
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9348,7 +9348,7 @@
     name: Opera Mobile
     version: 55.0.2254.56695
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: ZTE
@@ -9366,7 +9366,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: ZTE
@@ -9384,7 +9384,7 @@
     name: Chrome Webview
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: ZTE
@@ -9402,7 +9402,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Vivo
@@ -9420,7 +9420,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Huawei
@@ -9438,7 +9438,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: 'AT&T'
@@ -9456,7 +9456,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9474,7 +9474,7 @@
     name: Chrome Mobile
     version: 93.0.4572.0
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4572.0"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9492,7 +9492,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Mintt
@@ -9510,7 +9510,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Mobicel
@@ -9528,7 +9528,7 @@
     name: Opera Mobile
     version: 58.0.2254.58245
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: ZTE
@@ -9546,7 +9546,7 @@
     name: Chrome Webview
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: ZTE
@@ -9564,7 +9564,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: ZTE
@@ -9582,7 +9582,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: HTC
@@ -9600,7 +9600,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Prestigio
@@ -9618,7 +9618,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Prestigio
@@ -9636,7 +9636,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Prestigio
@@ -9654,7 +9654,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Prestigio
@@ -9672,7 +9672,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Doogee
@@ -9690,7 +9690,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -9708,7 +9708,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -9726,7 +9726,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Vertex
@@ -9744,7 +9744,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -9762,7 +9762,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -9780,7 +9780,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -9798,7 +9798,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Vertex
@@ -9816,7 +9816,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -9834,7 +9834,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Blu

--- a/Tests/fixtures/smartphone-25.yml
+++ b/Tests/fixtures/smartphone-25.yml
@@ -10,7 +10,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Bluboo
@@ -28,7 +28,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Motorola
@@ -46,7 +46,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Prestigio
@@ -64,7 +64,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Jinga
@@ -82,7 +82,7 @@
     name: Opera Mobile
     version: 59.1.2926.54067
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Hisense
@@ -100,7 +100,7 @@
     name: Yandex Browser
     version: "11.20"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: UNIWA
@@ -118,7 +118,7 @@
     name: Yandex Browser
     version: "11.30"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Vertex
@@ -136,7 +136,7 @@
     name: Yandex Browser
     version: "20.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: smartphone
     brand: Inoi
@@ -154,7 +154,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Hisense
@@ -172,7 +172,7 @@
     name: Yandex Browser
     version: "20.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Vertex
@@ -190,7 +190,7 @@
     name: Chrome Mobile
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Blackview
@@ -208,7 +208,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blackview
@@ -226,7 +226,7 @@
     name: Yandex Browser
     version: 19.9.6.88.00
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Samsung
@@ -244,7 +244,7 @@
     name: Yandex Browser
     version: "8.70"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Highscreen
@@ -262,7 +262,7 @@
     name: Yandex Browser
     version: 19.9.3.116.00
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Neffos
@@ -280,7 +280,7 @@
     name: Chrome Mobile
     version: 85.0.4165.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4165.0"
   device:
     type: smartphone
     brand: Asus
@@ -298,7 +298,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: OPPO
@@ -316,7 +316,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: OPPO
@@ -334,7 +334,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: OPPO
@@ -352,7 +352,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: OPPO
@@ -370,7 +370,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: OPPO
@@ -388,7 +388,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: OPPO
@@ -406,7 +406,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: OPPO
@@ -424,7 +424,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: OPPO
@@ -442,7 +442,7 @@
     name: Chrome Webview
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: OPPO
@@ -460,7 +460,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: OPPO
@@ -478,7 +478,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: OPPO
@@ -496,7 +496,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: OPPO
@@ -514,7 +514,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: OPPO
@@ -532,7 +532,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: OPPO
@@ -550,7 +550,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: OPPO
@@ -568,7 +568,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: OPPO
@@ -604,7 +604,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: OPPO
@@ -622,7 +622,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: OnePlus
@@ -640,7 +640,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: OnePlus
@@ -694,7 +694,7 @@
     name: Opera Mobile
     version: 64.1.3282.59829
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: smartphone
     brand: Xiaomi
@@ -712,7 +712,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: POCO
@@ -730,7 +730,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: POCO
@@ -748,7 +748,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: POCO
@@ -766,7 +766,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Meizu
@@ -784,7 +784,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Nokia
@@ -802,7 +802,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Nokia
@@ -820,7 +820,7 @@
     name: Chrome Mobile
     version: 93.0.4530.6
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4530.6"
   device:
     type: smartphone
     brand: Nokia
@@ -838,7 +838,7 @@
     name: Chrome Mobile
     version: 93.0.4534.0
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4534.0"
   device:
     type: smartphone
     brand: Nokia
@@ -856,7 +856,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Nokia
@@ -874,7 +874,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Nokia
@@ -892,7 +892,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Nokia
@@ -910,7 +910,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Nokia
@@ -928,7 +928,7 @@
     name: Chrome Mobile
     version: 92.0.4515.92
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.92"
   device:
     type: smartphone
     brand: Nokia
@@ -946,7 +946,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Nokia
@@ -1036,7 +1036,7 @@
     name: Opera Mobile
     version: 56.1.2254.57583
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Samsung
@@ -1054,7 +1054,7 @@
     name: Opera Mobile
     version: 55.1.2254.56965
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Samsung
@@ -1126,7 +1126,7 @@
     name: Opera Mobile
     version: 57.0.2254.58007
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Vivo
@@ -1144,7 +1144,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Asus
@@ -1162,7 +1162,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Asus
@@ -1180,7 +1180,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: Asus
@@ -1198,7 +1198,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Artel
@@ -1216,7 +1216,7 @@
     name: Chrome Webview
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: ZTE
@@ -1252,7 +1252,7 @@
     name: Yandex Browser
     version: 21.55.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Vivo
@@ -1270,7 +1270,7 @@
     name: Yandex Browser
     version: 21.5.1.107.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Vivo
@@ -1288,7 +1288,7 @@
     name: Yandex Browser
     version: 21.5.5.110.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Vivo
@@ -1306,7 +1306,7 @@
     name: Yandex Browser
     version: 20.9.0.203.00
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.121"
   device:
     type: smartphone
     brand: Vivo
@@ -1324,7 +1324,7 @@
     name: Yandex Browser
     version: 21.5.5.110.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Asus
@@ -1360,7 +1360,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Samsung
@@ -1378,7 +1378,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Samsung
@@ -1396,7 +1396,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: OnePlus
@@ -1414,7 +1414,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: OnePlus
@@ -1432,7 +1432,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: OnePlus
@@ -1450,7 +1450,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: OnePlus
@@ -1468,7 +1468,7 @@
     name: Opera Mobile
     version: 63.3.3216.58675
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Lenovo
@@ -1486,7 +1486,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: phablet
     brand: Samsung
@@ -1504,7 +1504,7 @@
     name: Chrome Mobile
     version: 92.0.4515.59
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.59"
   device:
     type: smartphone
     brand: OnePlus
@@ -1522,7 +1522,7 @@
     name: Yandex Browser
     version: 21.51.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: ZTE
@@ -1540,7 +1540,7 @@
     name: Yandex Browser
     version: "21.60"
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: smartphone
     brand: ZTE
@@ -1558,7 +1558,7 @@
     name: Yandex Browser
     version: 21.60.1
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: smartphone
     brand: ZTE
@@ -1576,7 +1576,7 @@
     name: Opera Mobile
     version: 56.1.2254.57583
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: ZTE
@@ -1594,7 +1594,7 @@
     name: Opera Mobile
     version: 55.1.2254.56965
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: ZTE
@@ -1612,7 +1612,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Asus
@@ -1630,7 +1630,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Asus
@@ -1648,7 +1648,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Asus
@@ -1666,7 +1666,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Asus
@@ -1684,7 +1684,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Asus
@@ -1702,7 +1702,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Asus
@@ -1720,7 +1720,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Samsung
@@ -1738,7 +1738,7 @@
     name: Chrome Webview
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Samsung
@@ -1756,7 +1756,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Samsung
@@ -1774,7 +1774,7 @@
     name: Chrome Mobile
     version: 92.0.4515.40
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.40"
   device:
     type: smartphone
     brand: Samsung
@@ -1792,7 +1792,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Senseit
@@ -1810,7 +1810,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Senseit
@@ -1846,7 +1846,7 @@
     name: Chrome Mobile
     version: 93.0.4525.0
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4525.0"
   device:
     type: smartphone
     brand: Xiaomi
@@ -1864,7 +1864,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -1882,7 +1882,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -1900,7 +1900,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -1918,7 +1918,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -1936,7 +1936,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -1954,7 +1954,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Vertex
@@ -1972,7 +1972,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Vertex
@@ -1990,7 +1990,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -2008,7 +2008,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -2026,7 +2026,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Vertex
@@ -2044,7 +2044,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Vertex
@@ -2062,7 +2062,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Vertex
@@ -2080,7 +2080,7 @@
     name: Chrome Mobile
     version: 93.0.4577.0
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.0"
   device:
     type: smartphone
     brand: Xiaomi
@@ -2098,7 +2098,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Xiaomi
@@ -2116,7 +2116,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Xiaomi
@@ -2134,7 +2134,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Xiaomi
@@ -2152,7 +2152,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -2170,7 +2170,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Vivo
@@ -2188,7 +2188,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Blu
@@ -2206,7 +2206,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Energizer
@@ -2224,7 +2224,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -2242,7 +2242,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -2260,7 +2260,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Vestel
@@ -2278,7 +2278,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Blu
@@ -2296,7 +2296,7 @@
     name: Yandex Browser
     version: 21.5.4.119.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Samsung
@@ -2314,7 +2314,7 @@
     name: Yandex Browser
     version: 21.5.4.119.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Nokia
@@ -2332,7 +2332,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: HTC
@@ -2350,7 +2350,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -2368,7 +2368,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: HTC
@@ -2386,7 +2386,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: HTC
@@ -2404,7 +2404,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: HTC
@@ -2422,7 +2422,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: HTC
@@ -2440,7 +2440,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -2458,7 +2458,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: HTC
@@ -2476,7 +2476,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -2494,7 +2494,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -2512,7 +2512,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: HTC
@@ -2530,7 +2530,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: HTC
@@ -2548,7 +2548,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: HTC
@@ -2566,7 +2566,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -2584,7 +2584,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: HTC
@@ -2602,7 +2602,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -2620,7 +2620,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -2638,7 +2638,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -2656,7 +2656,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: HTC
@@ -2674,7 +2674,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: HTC
@@ -2692,7 +2692,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: HTC
@@ -2710,7 +2710,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: HTC
@@ -2728,7 +2728,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -2746,7 +2746,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: HTC
@@ -2764,7 +2764,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -2782,7 +2782,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: HTC
@@ -2800,7 +2800,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: HTC
@@ -2818,7 +2818,7 @@
     name: Chrome Mobile
     version: 91.0.4472.8
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.8"
   device:
     type: smartphone
     brand: Vertex
@@ -2836,7 +2836,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Blackview
@@ -2854,7 +2854,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -2872,7 +2872,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: HTC
@@ -2908,7 +2908,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Iris
@@ -2926,7 +2926,7 @@
     name: Yandex Browser
     version: 21.5.4.119.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Vivo
@@ -2944,7 +2944,7 @@
     name: Yandex Browser
     version: 21.5.2.110.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Vivo
@@ -2962,7 +2962,7 @@
     name: Yandex Browser
     version: 21.5.5.110.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Vivo
@@ -2980,7 +2980,7 @@
     name: Yandex Browser
     version: 21.50.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: smartphone
     brand: Huawei
@@ -2998,7 +2998,7 @@
     name: Yandex Browser
     version: 21.5.6.56.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: ZTE
@@ -3016,7 +3016,7 @@
     name: Yandex Browser
     version: 21.51.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Blu
@@ -3034,7 +3034,7 @@
     name: Yandex Browser
     version: 21.5.0.350.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: smartphone
     brand: ZTE
@@ -3052,7 +3052,7 @@
     name: Yandex Browser
     version: 21.50.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: smartphone
     brand: Hisense
@@ -3070,7 +3070,7 @@
     name: Opera Mobile
     version: 56.0.2254.57357
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: MyPhone
@@ -3088,7 +3088,7 @@
     name: Opera Mobile
     version: 56.1.2254.57583
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Meizu
@@ -3106,7 +3106,7 @@
     name: Opera Mobile
     version: 27.0.2254.118423
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Meizu
@@ -3124,7 +3124,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Huawei
@@ -3142,7 +3142,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Huawei
@@ -3160,7 +3160,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Huawei
@@ -3178,7 +3178,7 @@
     name: Chrome Mobile
     version: 92.0.4515.40
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.40"
   device:
     type: smartphone
     brand: Huawei
@@ -3196,7 +3196,7 @@
     name: Chrome Mobile
     version: 93.0.4557.4
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4557.4"
   device:
     type: smartphone
     brand: Huawei
@@ -3214,7 +3214,7 @@
     name: Chrome Mobile
     version: 92.0.4515.70
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.70"
   device:
     type: smartphone
     brand: Inoi
@@ -3232,7 +3232,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Inoi
@@ -3250,7 +3250,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Inoi
@@ -3268,7 +3268,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Oukitel
@@ -3286,7 +3286,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Infinix
@@ -3304,7 +3304,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Infinix
@@ -3322,7 +3322,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Infinix
@@ -3340,7 +3340,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Infinix
@@ -3358,7 +3358,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Infinix
@@ -3376,7 +3376,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Infinix
@@ -3394,7 +3394,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Infinix
@@ -3412,7 +3412,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Infinix
@@ -3430,7 +3430,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Infinix
@@ -3448,7 +3448,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Infinix
@@ -3466,7 +3466,7 @@
     name: Opera Mobile
     version: 55.0.2254.56857
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Infinix
@@ -3484,7 +3484,7 @@
     name: Opera Mobile
     version: 55.0.2254.56695
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Infinix
@@ -3502,7 +3502,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Infinix
@@ -3520,7 +3520,7 @@
     name: Chrome Webview
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Infinix
@@ -3538,7 +3538,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Infinix
@@ -3556,7 +3556,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Infinix
@@ -3574,7 +3574,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Infinix
@@ -3592,7 +3592,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Infinix
@@ -3610,7 +3610,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Huawei
@@ -3628,7 +3628,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Infinix
@@ -3646,7 +3646,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Huawei
@@ -3664,7 +3664,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -3682,7 +3682,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: MyPhone
@@ -3700,7 +3700,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Huawei
@@ -3718,7 +3718,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Evolveo
@@ -3736,7 +3736,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -3754,7 +3754,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: HTC
@@ -3772,7 +3772,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: HTC
@@ -3790,7 +3790,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -3808,7 +3808,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -3826,7 +3826,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -3844,7 +3844,7 @@
     name: Chrome Mobile
     version: 50.0.2661.89
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -4060,7 +4060,7 @@
     name: Chrome Mobile
     version: 33.0.1750.136
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Samsung
@@ -4096,7 +4096,7 @@
     name: Chrome Mobile
     version: 33.0.1750.136
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Samsung
@@ -4114,7 +4114,7 @@
     name: Chrome Mobile
     version: 33.0.1750.136
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Samsung
@@ -4168,7 +4168,7 @@
     name: Chrome Mobile
     version: 33.0.1750.136
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Samsung
@@ -4204,7 +4204,7 @@
     name: Chrome Mobile
     version: 33.0.1750.136
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Samsung
@@ -4222,7 +4222,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -4240,7 +4240,7 @@
     name: Chrome Mobile
     version: 72.0.3626.76
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Huawei
@@ -4258,7 +4258,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -4276,7 +4276,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -4294,7 +4294,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -4312,7 +4312,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Blu
@@ -4330,7 +4330,7 @@
     name: Chrome Mobile
     version: 72.0.3626.76
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Blu
@@ -4348,7 +4348,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -4366,7 +4366,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -4384,7 +4384,7 @@
     name: Chrome Mobile
     version: 50.0.2661.89
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Huawei
@@ -4402,7 +4402,7 @@
     name: Chrome Mobile
     version: 72.0.3626.76
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Huawei
@@ -4420,7 +4420,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -4438,7 +4438,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -4456,7 +4456,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -4474,7 +4474,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -4492,7 +4492,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -4510,7 +4510,7 @@
     name: Chrome Mobile
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Huawei
@@ -4528,7 +4528,7 @@
     name: Chrome Mobile
     version: 72.0.3626.96
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Huawei
@@ -4546,7 +4546,7 @@
     name: Chrome Mobile
     version: 72.0.3626.96
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Huawei
@@ -4564,7 +4564,7 @@
     name: Chrome Mobile
     version: 72.0.3626.96
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Huawei
@@ -4582,7 +4582,7 @@
     name: Chrome Mobile
     version: 72.0.3626.96
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Huawei
@@ -4600,7 +4600,7 @@
     name: Chrome Mobile
     version: 72.0.3626.96
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Huawei
@@ -4618,7 +4618,7 @@
     name: Chrome Mobile
     version: 72.0.3626.96
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Alcatel
@@ -4636,7 +4636,7 @@
     name: Chrome Mobile
     version: 72.0.3626.96
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Alcatel
@@ -4654,7 +4654,7 @@
     name: Chrome Mobile
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Alcatel
@@ -4672,7 +4672,7 @@
     name: Chrome Mobile
     version: 72.0.3626.96
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Blu
@@ -4690,7 +4690,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Blu
@@ -4708,7 +4708,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -4726,7 +4726,7 @@
     name: Chrome Mobile
     version: 72.0.3626.96
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Huawei
@@ -4744,7 +4744,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -4762,7 +4762,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -4780,7 +4780,7 @@
     name: Chrome Mobile
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Hyundai
@@ -4798,7 +4798,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Hyundai
@@ -4816,7 +4816,7 @@
     name: Chrome Mobile
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Hyundai
@@ -4834,7 +4834,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Hyundai
@@ -4852,7 +4852,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Hyundai
@@ -4870,7 +4870,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Hyundai
@@ -4888,7 +4888,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Hyundai
@@ -4906,7 +4906,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Hyundai
@@ -4924,7 +4924,7 @@
     name: Chrome Mobile
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Bitel
@@ -4960,7 +4960,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Samsung
@@ -4978,7 +4978,7 @@
     name: Chrome Mobile
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Samsung
@@ -4996,7 +4996,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Samsung
@@ -5014,7 +5014,7 @@
     name: Chrome Mobile
     version: 74.0.3729.112
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: smartphone
     brand: Samsung
@@ -5032,7 +5032,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Samsung
@@ -5050,7 +5050,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Samsung
@@ -5086,7 +5086,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Samsung
@@ -5104,7 +5104,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Samsung
@@ -5122,7 +5122,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Huawei
@@ -5140,7 +5140,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Huawei
@@ -5158,7 +5158,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Huawei
@@ -5176,7 +5176,7 @@
     name: Chrome Mobile
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Huawei
@@ -5194,7 +5194,7 @@
     name: Chrome Mobile
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Huawei
@@ -5212,7 +5212,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Huawei
@@ -5230,7 +5230,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -5248,7 +5248,7 @@
     name: Chrome Mobile
     version: 74.0.3729.112
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: smartphone
     brand: Huawei
@@ -5266,7 +5266,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Huawei
@@ -5284,7 +5284,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Huawei
@@ -5302,7 +5302,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -5320,7 +5320,7 @@
     name: Chrome Mobile
     version: 43.0.2357.93
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: ZTE
@@ -5338,7 +5338,7 @@
     name: Chrome Mobile
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: ZTE
@@ -5356,7 +5356,7 @@
     name: Chrome Webview
     version: 74.0.3729.112
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: smartphone
     brand: ZTE
@@ -5374,7 +5374,7 @@
     name: Chrome Webview
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: ZTE
@@ -5392,7 +5392,7 @@
     name: Chrome Mobile
     version: 34.0.1847.114
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: ZTE
@@ -5410,7 +5410,7 @@
     name: Chrome Mobile
     version: 35.0.1916.141
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: smartphone
     brand: ZTE
@@ -5428,7 +5428,7 @@
     name: Chrome Mobile
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: ZTE
@@ -5446,7 +5446,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: ZTE
@@ -5482,7 +5482,7 @@
     name: Chrome Mobile
     version: 43.0.2357.93
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: ZTE
@@ -5500,7 +5500,7 @@
     name: Chrome Mobile
     version: 36.0.1985.135
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: ZTE
@@ -5518,7 +5518,7 @@
     name: Chrome Webview
     version: 74.0.3729.112
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: smartphone
     brand: ZTE
@@ -5536,7 +5536,7 @@
     name: Chrome Mobile
     version: 40.0.2214.109
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: ZTE
@@ -5554,7 +5554,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: ZTE
@@ -5572,7 +5572,7 @@
     name: Chrome Mobile
     version: 72.0.3626.76
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: ZTE
@@ -5590,7 +5590,7 @@
     name: Chrome Mobile
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: ZTE
@@ -5608,7 +5608,7 @@
     name: Chrome Mobile
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: ZTE
@@ -5626,7 +5626,7 @@
     name: Chrome Mobile
     version: 35.0.1916.141
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: smartphone
     brand: ZTE
@@ -5644,7 +5644,7 @@
     name: Chrome Mobile
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: ZTE
@@ -5678,7 +5678,7 @@
     name: Chrome Mobile
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: ZTE
@@ -5696,7 +5696,7 @@
     name: Chrome Webview
     version: 52.0.2743.98
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: ZTE
@@ -5714,7 +5714,7 @@
     name: Chrome Mobile
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: ZTE
@@ -5750,7 +5750,7 @@
     name: Chrome Webview
     version: 42.0.2311.137
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.137"
   device:
     type: smartphone
     brand: ZTE
@@ -5768,7 +5768,7 @@
     name: Chrome Webview
     version: 42.0.2311.137
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.137"
   device:
     type: smartphone
     brand: ZTE
@@ -5786,7 +5786,7 @@
     name: Chrome Webview
     version: 45.0.2454.95
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.95"
   device:
     type: smartphone
     brand: ZTE
@@ -5804,7 +5804,7 @@
     name: Chrome Webview
     version: 45.0.2454.95
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.95"
   device:
     type: smartphone
     brand: ZTE
@@ -5822,7 +5822,7 @@
     name: Chrome Mobile
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: ZTE
@@ -5840,7 +5840,7 @@
     name: Chrome Mobile
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: ZTE
@@ -5894,7 +5894,7 @@
     name: Chrome Mobile
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: ZTE
@@ -5912,7 +5912,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: ZTE
@@ -5948,7 +5948,7 @@
     name: Chrome Mobile
     version: 50.0.2661.89
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: ZTE
@@ -5966,7 +5966,7 @@
     name: Chrome Mobile
     version: 36.0.1985.135
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: ZTE
@@ -6002,7 +6002,7 @@
     name: Chrome Mobile
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: ZTE
@@ -6020,7 +6020,7 @@
     name: Chrome Mobile
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: ZTE
@@ -6056,7 +6056,7 @@
     name: Chrome Mobile
     version: 32.0.1700.99
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: ZTE
@@ -6110,7 +6110,7 @@
     name: Chrome Mobile
     version: 33.0.1750.166
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: smartphone
     brand: ZTE
@@ -6128,7 +6128,7 @@
     name: Chrome Mobile
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Nubia
@@ -6146,7 +6146,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Nubia
@@ -6164,7 +6164,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Nubia
@@ -6182,7 +6182,7 @@
     name: Chrome Mobile
     version: 71.0.3578.83
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: smartphone
     brand: Nubia
@@ -6200,7 +6200,7 @@
     name: Chrome Mobile
     version: 53.0.2785.124
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Nubia
@@ -6250,7 +6250,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Nubia
@@ -6286,7 +6286,7 @@
     name: Chrome Mobile
     version: 52.0.2743.98
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: ZTE
@@ -6320,7 +6320,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: ZTE
@@ -6338,7 +6338,7 @@
     name: Chrome Mobile
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: ZTE
@@ -6356,7 +6356,7 @@
     name: Chrome Mobile
     version: 46.0.2490.76
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: ZTE
@@ -6374,7 +6374,7 @@
     name: Chrome Mobile
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: ZTE
@@ -6636,7 +6636,7 @@
     name: Chrome Mobile
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: ZTE
@@ -6654,7 +6654,7 @@
     name: Chrome Mobile
     version: 53.0.2785.124
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: ZTE
@@ -6672,7 +6672,7 @@
     name: Chrome Mobile
     version: 53.0.2785.124
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: ZTE
@@ -6690,7 +6690,7 @@
     name: Chrome Mobile
     version: 59.0.3071.125
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: ZTE
@@ -6708,7 +6708,7 @@
     name: Chrome Mobile
     version: 49.0.2623.91
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: smartphone
     brand: ZTE
@@ -6726,7 +6726,7 @@
     name: Chrome Mobile
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: ZTE
@@ -6744,7 +6744,7 @@
     name: Chrome Mobile
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: ZTE
@@ -6762,7 +6762,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: ZTE
@@ -6780,7 +6780,7 @@
     name: Chrome Mobile
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: ZTE
@@ -6798,7 +6798,7 @@
     name: Chrome Webview
     version: 45.0.2454.95
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.95"
   device:
     type: smartphone
     brand: ZTE
@@ -6816,7 +6816,7 @@
     name: Chrome Mobile
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Zuum
@@ -6834,7 +6834,7 @@
     name: Chrome Webview
     version: 37.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: Zuum
@@ -6870,7 +6870,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Iris
@@ -6888,7 +6888,7 @@
     name: Yandex Browser
     version: 21.5.4.119.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Vivo
@@ -6906,7 +6906,7 @@
     name: Yandex Browser
     version: 21.5.2.110.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Vivo
@@ -6924,7 +6924,7 @@
     name: Yandex Browser
     version: 21.5.5.110.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Vivo
@@ -6942,7 +6942,7 @@
     name: Yandex Browser
     version: 21.50.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: smartphone
     brand: Huawei
@@ -6960,7 +6960,7 @@
     name: Yandex Browser
     version: 21.5.6.56.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: ZTE
@@ -6978,7 +6978,7 @@
     name: Yandex Browser
     version: 21.51.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Blu
@@ -6996,7 +6996,7 @@
     name: Yandex Browser
     version: 21.5.0.350.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: smartphone
     brand: ZTE
@@ -7014,7 +7014,7 @@
     name: Yandex Browser
     version: 21.50.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: smartphone
     brand: Hisense
@@ -7032,7 +7032,7 @@
     name: Opera Mobile
     version: 56.0.2254.57357
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: MyPhone
@@ -7050,7 +7050,7 @@
     name: Opera Mobile
     version: 56.1.2254.57583
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Meizu
@@ -7068,7 +7068,7 @@
     name: Opera Mobile
     version: 27.0.2254.118423
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Meizu
@@ -7086,7 +7086,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Huawei
@@ -7104,7 +7104,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Huawei
@@ -7122,7 +7122,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Huawei
@@ -7140,7 +7140,7 @@
     name: Chrome Mobile
     version: 92.0.4515.40
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.40"
   device:
     type: smartphone
     brand: Huawei
@@ -7158,7 +7158,7 @@
     name: Chrome Mobile
     version: 93.0.4557.4
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4557.4"
   device:
     type: smartphone
     brand: Huawei
@@ -7176,7 +7176,7 @@
     name: Chrome Mobile
     version: 92.0.4515.70
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.70"
   device:
     type: smartphone
     brand: Inoi
@@ -7194,7 +7194,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Inoi
@@ -7212,7 +7212,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Inoi
@@ -7230,7 +7230,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Oukitel
@@ -7248,7 +7248,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Infinix
@@ -7266,7 +7266,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Infinix
@@ -7284,7 +7284,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Infinix
@@ -7302,7 +7302,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Infinix
@@ -7320,7 +7320,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Infinix
@@ -7338,7 +7338,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Infinix
@@ -7356,7 +7356,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Infinix
@@ -7374,7 +7374,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Infinix
@@ -7392,7 +7392,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Infinix
@@ -7410,7 +7410,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Infinix
@@ -7428,7 +7428,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Infinix
@@ -7446,7 +7446,7 @@
     name: Opera Mobile
     version: 55.0.2254.56857
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Infinix
@@ -7464,7 +7464,7 @@
     name: Opera Mobile
     version: 55.0.2254.56695
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Infinix
@@ -7482,7 +7482,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Infinix
@@ -7500,7 +7500,7 @@
     name: Chrome Webview
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Infinix
@@ -7518,7 +7518,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Infinix
@@ -7536,7 +7536,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Infinix
@@ -7554,7 +7554,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Infinix
@@ -7572,7 +7572,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Infinix
@@ -7590,7 +7590,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Huawei
@@ -7608,7 +7608,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Infinix
@@ -7626,7 +7626,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Huawei
@@ -7644,7 +7644,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -7662,7 +7662,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: MyPhone
@@ -7680,7 +7680,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Huawei
@@ -7698,7 +7698,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Evolveo
@@ -7716,7 +7716,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -7734,7 +7734,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: HTC
@@ -7752,7 +7752,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: HTC
@@ -7770,7 +7770,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -7788,7 +7788,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -7806,7 +7806,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Lenovo
@@ -7824,7 +7824,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Lava
@@ -7842,7 +7842,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Lava
@@ -7860,7 +7860,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Lenovo
@@ -7878,7 +7878,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Lenovo
@@ -7896,7 +7896,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Lenovo
@@ -7914,7 +7914,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Lenovo
@@ -7932,7 +7932,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Lenovo
@@ -7950,7 +7950,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Lenovo
@@ -7968,7 +7968,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Lenovo
@@ -7986,7 +7986,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Lenovo
@@ -8004,7 +8004,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Lenovo
@@ -8022,7 +8022,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Huawei
@@ -8040,7 +8040,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Lenovo
@@ -8058,7 +8058,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Lenovo
@@ -8076,7 +8076,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Lenovo
@@ -8094,7 +8094,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Turbo-X
@@ -8112,7 +8112,7 @@
     name: Chrome Mobile
     version: 92.0.4515.80
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.80"
   device:
     type: smartphone
     brand: Nomi
@@ -8130,7 +8130,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Nomi
@@ -8148,7 +8148,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Nomi
@@ -8166,7 +8166,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Nomi
@@ -8184,7 +8184,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Majestic
@@ -8202,7 +8202,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Prestigio
@@ -8220,7 +8220,7 @@
     name: Chrome Mobile
     version: 92.0.4515.40
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.40"
   device:
     type: smartphone
     brand: Prestigio
@@ -8238,7 +8238,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Ulefone
@@ -8256,7 +8256,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Ulefone
@@ -8274,7 +8274,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Ulefone
@@ -8292,7 +8292,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Energizer
@@ -8310,7 +8310,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Prestigio
@@ -8328,7 +8328,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Prestigio
@@ -8346,7 +8346,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Prestigio
@@ -8364,7 +8364,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Prestigio
@@ -8382,7 +8382,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: NGM
@@ -8400,7 +8400,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Lenovo
@@ -8418,7 +8418,7 @@
     name: Chrome Mobile
     version: 91.0.4472.114
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: smartphone
     brand: Lenovo
@@ -8436,7 +8436,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Lenovo
@@ -8454,7 +8454,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Ulefone
@@ -8472,7 +8472,7 @@
     name: Yandex Browser
     version: 21.5.2.110.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Lenovo
@@ -8490,7 +8490,7 @@
     name: Yandex Browser
     version: 21.53.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Lenovo
@@ -8508,7 +8508,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Blu
@@ -8526,7 +8526,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Lenovo
@@ -8544,7 +8544,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: HTC
@@ -8562,7 +8562,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: HTC
@@ -8580,7 +8580,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Doro
@@ -8598,7 +8598,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Motorola
@@ -8616,7 +8616,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Motorola
@@ -8634,7 +8634,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Motorola
@@ -8652,7 +8652,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Motorola
@@ -8670,7 +8670,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: ZTE
@@ -8688,7 +8688,7 @@
     name: Chrome Mobile
     version: "69.0.3497.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.86"
   device:
     type: smartphone
     brand: ZTE
@@ -8706,7 +8706,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: ZTE
@@ -8724,7 +8724,7 @@
     name: Chrome Mobile
     version: 91.0.4472.114
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: smartphone
     brand: Santin
@@ -8742,7 +8742,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Ulefone
@@ -8760,7 +8760,7 @@
     name: Yandex Browser
     version: 21.52.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Asus
@@ -8778,7 +8778,7 @@
     name: Chrome Mobile
     version: 94.0.4578.0
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4578.0"
   device:
     type: smartphone
     brand: Neffos
@@ -8796,7 +8796,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Neffos
@@ -8814,7 +8814,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Neffos
@@ -8832,7 +8832,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Nobby
@@ -8850,7 +8850,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8868,7 +8868,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8886,7 +8886,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8904,7 +8904,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8922,7 +8922,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8940,7 +8940,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: ZTE
@@ -8958,7 +8958,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8976,7 +8976,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8994,7 +8994,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: MyPhone
@@ -9012,7 +9012,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: MyPhone
@@ -9030,7 +9030,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: MyPhone
@@ -9048,7 +9048,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: OPPO
@@ -9066,7 +9066,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Wiko
@@ -9084,7 +9084,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -9102,7 +9102,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -9120,7 +9120,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: LT Mobile
@@ -9138,7 +9138,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: MLS
@@ -9156,7 +9156,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Lava
@@ -9174,7 +9174,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -9192,7 +9192,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Jinga
@@ -9210,7 +9210,7 @@
     name: Chrome Mobile
     version: 92.0.4515.70
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.70"
   device:
     type: smartphone
     brand: Xiaomi
@@ -9228,7 +9228,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Xiaomi
@@ -9246,7 +9246,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Palm
@@ -9264,7 +9264,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Palm
@@ -9282,7 +9282,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Archos
@@ -9300,7 +9300,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Archos
@@ -9334,7 +9334,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Bravis
@@ -9352,7 +9352,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Elephone
@@ -9370,7 +9370,7 @@
     name: Opera Mobile
     version: 56.1.2254.57583
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: MyPhone
@@ -9388,7 +9388,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Nomi
@@ -9406,7 +9406,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: OPPO
@@ -9424,7 +9424,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: OPPO
@@ -9442,7 +9442,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: OPPO
@@ -9460,7 +9460,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: A1
@@ -9478,7 +9478,7 @@
     name: Chrome Mobile
     version: 92.0.4515.80
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.80"
   device:
     type: smartphone
     brand: Huawei
@@ -9496,7 +9496,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Huawei
@@ -9514,7 +9514,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Crosscall
@@ -9532,7 +9532,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Realme
@@ -9550,7 +9550,7 @@
     name: Opera Mobile
     version: 64.1.3282.59829
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: smartphone
     brand: Realme
@@ -9568,7 +9568,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Realme
@@ -9586,7 +9586,7 @@
     name: Opera GX
     version: "1.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Samsung
@@ -9604,7 +9604,7 @@
     name: Opera Mobile
     version: 57.0.2254.58007
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9622,7 +9622,7 @@
     name: Yandex Browser
     version: 21.54.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: ZTE
@@ -9640,7 +9640,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Lenovo
@@ -9658,7 +9658,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Lenovo
@@ -9676,7 +9676,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Lenovo
@@ -9694,7 +9694,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Tigers
@@ -9712,7 +9712,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Positivo
@@ -9730,7 +9730,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9748,7 +9748,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Samsung
@@ -9766,7 +9766,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Samsung

--- a/Tests/fixtures/smartphone-26.yml
+++ b/Tests/fixtures/smartphone-26.yml
@@ -10,7 +10,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Reeder
@@ -28,7 +28,7 @@
     name: Chrome Mobile
     version: 46.0.2490.76
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Leagoo
@@ -46,7 +46,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Sony
@@ -64,7 +64,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: Sony
@@ -82,7 +82,7 @@
     name: Chrome Webview
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Sony
@@ -100,7 +100,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: OPPO
@@ -118,7 +118,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: OPPO
@@ -136,7 +136,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Asus
@@ -154,7 +154,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Xiaomi
@@ -172,7 +172,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: OPPO
@@ -190,7 +190,7 @@
     name: Chrome Webview
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Huawei
@@ -208,7 +208,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: OPPO
@@ -226,7 +226,7 @@
     name: Chrome Webview
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Sharp
@@ -244,7 +244,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Samsung
@@ -262,7 +262,7 @@
     name: Chrome Webview
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Fujitsu
@@ -280,7 +280,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Fujitsu
@@ -298,7 +298,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Sharp
@@ -316,7 +316,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Motorola
@@ -352,7 +352,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Sony
@@ -370,7 +370,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: Sharp
@@ -388,7 +388,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Samsung
@@ -406,7 +406,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Sony
@@ -424,7 +424,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Samsung
@@ -442,7 +442,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Motorola
@@ -460,7 +460,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Motorola
@@ -478,7 +478,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Sony
@@ -496,7 +496,7 @@
     name: Chrome Webview
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: OPPO
@@ -514,7 +514,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Sharp
@@ -532,7 +532,7 @@
     name: Chrome Webview
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Sony
@@ -550,7 +550,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Samsung
@@ -586,7 +586,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Fujitsu
@@ -604,7 +604,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Fujitsu
@@ -622,7 +622,7 @@
     name: Chrome Mobile
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Sharp
@@ -640,7 +640,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Samsung
@@ -658,7 +658,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Samsung
@@ -676,7 +676,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Sony
@@ -694,7 +694,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Huawei
@@ -712,7 +712,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Motorola
@@ -730,7 +730,7 @@
     name: Chrome Webview
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Fujitsu
@@ -748,7 +748,7 @@
     name: Chrome Mobile
     version: 86.0.4240.75
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.75"
   device:
     type: smartphone
     brand: Fujitsu
@@ -766,7 +766,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Huawei
@@ -784,7 +784,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Sony
@@ -802,7 +802,7 @@
     name: Chrome Mobile
     version: 91.0.4472.35
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.35"
   device:
     type: smartphone
     brand: Xiaomi
@@ -820,7 +820,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Xiaomi
@@ -838,7 +838,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Xiaomi
@@ -856,7 +856,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Xiaomi
@@ -874,7 +874,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Motorola
@@ -892,7 +892,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Motorola
@@ -910,7 +910,7 @@
     name: Yandex Browser
     version: 21.5.0.350.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: smartphone
     brand: Philips
@@ -928,7 +928,7 @@
     name: Yandex Browser
     version: 21.56.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Motorola
@@ -946,7 +946,7 @@
     name: Chrome Webview
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Samsung
@@ -964,7 +964,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Asus
@@ -982,7 +982,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Asus
@@ -1000,7 +1000,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Karbonn
@@ -1018,7 +1018,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Intex
@@ -1036,7 +1036,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Vivo
@@ -1054,7 +1054,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Lava
@@ -1072,7 +1072,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Xiaomi
@@ -1090,7 +1090,7 @@
     name: Chrome Mobile
     version: 92.0.4515.40
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.40"
   device:
     type: smartphone
     brand: Xiaomi
@@ -1108,7 +1108,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Xiaomi
@@ -1126,7 +1126,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Xiaomi
@@ -1144,7 +1144,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Xiaomi
@@ -1162,7 +1162,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Meizu
@@ -1180,7 +1180,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Meizu
@@ -1198,7 +1198,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Xiaomi
@@ -1216,7 +1216,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Xiaomi
@@ -1234,7 +1234,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Realme
@@ -1252,7 +1252,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Realme
@@ -1270,7 +1270,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Xiaomi
@@ -1288,7 +1288,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Xiaomi
@@ -1306,7 +1306,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Xiaomi
@@ -1324,7 +1324,7 @@
     name: Chrome Mobile
     version: 93.0.4572.0
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4572.0"
   device:
     type: smartphone
     brand: Samsung
@@ -1342,7 +1342,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vertex
@@ -1360,7 +1360,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Inoi
@@ -1378,7 +1378,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: MTC
@@ -1396,7 +1396,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: OnePlus
@@ -1414,7 +1414,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Nomi
@@ -1432,7 +1432,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Hisense
@@ -1450,7 +1450,7 @@
     name: Yandex Browser
     version: 21.65.1
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -1468,7 +1468,7 @@
     name: Yandex Browser
     version: 21.51.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Samsung
@@ -1504,7 +1504,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Samsung
@@ -1522,7 +1522,7 @@
     name: Opera Mobile
     version: 64.2.3282.60128
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: smartphone
     brand: Vivo
@@ -1540,7 +1540,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Realme
@@ -1558,7 +1558,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Vivo
@@ -1576,7 +1576,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Nokia
@@ -1594,7 +1594,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Nokia
@@ -1612,7 +1612,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Nokia
@@ -1630,7 +1630,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Nokia
@@ -1648,7 +1648,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Nokia
@@ -1666,7 +1666,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Nokia
@@ -1684,7 +1684,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Nokia
@@ -1720,7 +1720,7 @@
     name: Yandex Browser
     version: 21.6.4.119.00
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Nokia
@@ -1738,7 +1738,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Blackview
@@ -1756,7 +1756,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: LG
@@ -1774,7 +1774,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Motorola
@@ -1792,7 +1792,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Motorola
@@ -1810,7 +1810,7 @@
     name: Chrome Webview
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Motorola
@@ -1828,7 +1828,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Lenovo
@@ -1846,7 +1846,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Motorola
@@ -1880,7 +1880,7 @@
     name: Opera Mobile
     version: 64.2.3282.60128
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -1898,7 +1898,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Inoi
@@ -1916,7 +1916,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Motorola
@@ -1934,7 +1934,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: MyPhone
@@ -1952,7 +1952,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Motorola
@@ -1986,7 +1986,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Meizu
@@ -2004,7 +2004,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Blackview
@@ -2022,7 +2022,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Alcatel
@@ -2040,7 +2040,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Blackview
@@ -2058,7 +2058,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Blackview
@@ -2076,7 +2076,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Huawei
@@ -2094,7 +2094,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Fairphone
@@ -2112,7 +2112,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Hisense
@@ -2130,7 +2130,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: HTC
@@ -2148,7 +2148,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -2166,7 +2166,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Homtom
@@ -2184,7 +2184,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Homtom
@@ -2202,7 +2202,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: HTC
@@ -2220,7 +2220,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: HTC
@@ -2238,7 +2238,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: HTC
@@ -2256,7 +2256,7 @@
     name: Chrome Webview
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Meizu
@@ -2328,7 +2328,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Prestigio
@@ -2346,7 +2346,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Prestigio
@@ -2364,7 +2364,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Prestigio
@@ -2382,7 +2382,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Hoffmann
@@ -2400,7 +2400,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Hoffmann
@@ -2418,7 +2418,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Hoffmann
@@ -2436,7 +2436,7 @@
     name: Chrome Mobile
     version: 92.0.4515.40
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.40"
   device:
     type: smartphone
     brand: Hoffmann
@@ -2454,7 +2454,7 @@
     name: Yandex Browser
     version: 21.5.4.119.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Philips
@@ -2472,7 +2472,7 @@
     name: Yandex Browser
     version: 21.5.6.56.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Samsung
@@ -2490,7 +2490,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Coolpad
@@ -2508,7 +2508,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Digma
@@ -2526,7 +2526,7 @@
     name: Chrome Webview
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Digma
@@ -2544,7 +2544,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Digma
@@ -2562,7 +2562,7 @@
     name: Opera Mobile
     version: 64.1.3282.59829
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: smartphone
     brand: Digma
@@ -2580,7 +2580,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Digma
@@ -2598,7 +2598,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Reeder
@@ -2616,7 +2616,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: OPPO
@@ -2634,7 +2634,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Xiaomi
@@ -2652,7 +2652,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Oukitel
@@ -2670,7 +2670,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Oukitel
@@ -2688,7 +2688,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Oukitel
@@ -2706,7 +2706,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Oukitel
@@ -2724,7 +2724,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Oukitel
@@ -2742,7 +2742,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Oale
@@ -2760,7 +2760,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -2778,7 +2778,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -2796,7 +2796,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -2814,7 +2814,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -2832,7 +2832,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -2850,7 +2850,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -2868,7 +2868,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Blackview
@@ -2886,7 +2886,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Blackview
@@ -2904,7 +2904,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Blackview
@@ -2922,7 +2922,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: CGV
@@ -2940,7 +2940,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Realme
@@ -2958,7 +2958,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Oukitel
@@ -2976,7 +2976,7 @@
     name: Yandex Browser
     version: 21.5.2.10.00 alpha
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Coolpad
@@ -2994,7 +2994,7 @@
     name: Yandex Browser
     version: 21.53.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Hisense
@@ -3012,7 +3012,7 @@
     name: Yandex Browser
     version: 21.50.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: smartphone
     brand: Huawei
@@ -3030,7 +3030,7 @@
     name: Yandex Browser
     version: 21.5.4.119.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Asus
@@ -3048,7 +3048,7 @@
     name: Yandex Browser
     version: 21.55.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Asus
@@ -3066,7 +3066,7 @@
     name: Yandex Browser
     version: 21.51.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Xiaomi
@@ -3084,7 +3084,7 @@
     name: Yandex Browser
     version: 21.51.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Lenovo
@@ -3102,7 +3102,7 @@
     name: Yandex Browser
     version: 21.53.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Lenovo
@@ -3120,7 +3120,7 @@
     name: Yandex Browser
     version: 21.54.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Asus
@@ -3137,7 +3137,7 @@
     name: Yandex Browser
     version: 21.51.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Homtom
@@ -3155,7 +3155,7 @@
     name: Yandex Browser
     version: 21.50.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: smartphone
     brand: Meizu
@@ -3173,7 +3173,7 @@
     name: Yandex Browser
     version: 21.51.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Xiaomi
@@ -3191,7 +3191,7 @@
     name: Yandex Browser
     version: 21.5.3.120.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Prestigio
@@ -3209,7 +3209,7 @@
     name: Yandex Browser
     version: 21.50.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: smartphone
     brand: Blackview
@@ -3227,7 +3227,7 @@
     name: Yandex Browser
     version: "21.52"
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: LG
@@ -3245,7 +3245,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: OPPO
@@ -3263,7 +3263,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -3281,7 +3281,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -3299,7 +3299,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -3317,7 +3317,7 @@
     name: Chrome Mobile
     version: 91.0.4472.114
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: smartphone
     brand: Blu
@@ -3335,7 +3335,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Blu
@@ -3353,7 +3353,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Blu
@@ -3371,7 +3371,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Blu
@@ -3389,7 +3389,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Leagoo
@@ -3407,7 +3407,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Leagoo
@@ -3425,7 +3425,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Motorola
@@ -3443,7 +3443,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Motorola
@@ -3479,7 +3479,7 @@
     name: Chrome
     version: 89.0.4389.86
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.86"
   device:
     type: smartphone
     brand: Google
@@ -3497,7 +3497,7 @@
     name: Opera Mobile
     version: 61.0.3068.10
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Google
@@ -3515,7 +3515,7 @@
     name: Chrome Webview
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Google
@@ -3533,7 +3533,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: OPPO
@@ -3569,7 +3569,7 @@
     name: Chrome Mobile
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Xgody
@@ -3623,7 +3623,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: CUBOT
@@ -3641,7 +3641,7 @@
     name: Chrome Mobile
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: EE
@@ -3659,7 +3659,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -3761,7 +3761,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: DEXP
@@ -3779,7 +3779,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Archos
@@ -3813,7 +3813,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: QMobile
@@ -3831,7 +3831,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: F2 Mobile
@@ -3849,7 +3849,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: F2 Mobile
@@ -3867,7 +3867,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: KINGZONE
@@ -3885,7 +3885,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: KINGZONE
@@ -3903,7 +3903,7 @@
     name: Chrome Mobile
     version: 72.0.3626.96
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Vodafone
@@ -3921,7 +3921,7 @@
     name: Yandex Browser
     version: "11.42"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Oukitel
@@ -3939,7 +3939,7 @@
     name: Yandex Browser
     version: "11.41"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Oukitel
@@ -3957,7 +3957,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Alcatel
@@ -3975,7 +3975,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Alcatel
@@ -3993,7 +3993,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: HTC
@@ -4011,7 +4011,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Bmobile
@@ -4029,7 +4029,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -4047,7 +4047,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Gome
@@ -4065,7 +4065,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Realme
@@ -4083,7 +4083,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Doogee
@@ -4101,7 +4101,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Kiowa
@@ -4119,7 +4119,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Kiowa
@@ -4137,7 +4137,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Kiowa
@@ -4155,7 +4155,7 @@
     name: Chrome Webview
     version: 51.0.2704.91
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.91"
   device:
     type: smartphone
     brand: Bundy
@@ -4173,7 +4173,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Bundy
@@ -4190,7 +4190,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Bundy
@@ -4208,7 +4208,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: 7 Mobile
@@ -4226,7 +4226,7 @@
     name: Chrome Mobile
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: 7 Mobile
@@ -4244,7 +4244,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Qubo
@@ -4262,7 +4262,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -4280,7 +4280,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Covia
@@ -4298,7 +4298,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Covia
@@ -4316,7 +4316,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Covia
@@ -4334,7 +4334,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Smart
@@ -4352,7 +4352,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: GOCLEVER
@@ -4370,7 +4370,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: GOCLEVER
@@ -4388,7 +4388,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: GOCLEVER
@@ -4406,7 +4406,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: GOCLEVER
@@ -4424,7 +4424,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: GOCLEVER
@@ -4442,7 +4442,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: GOCLEVER
@@ -4460,7 +4460,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: GOCLEVER
@@ -4478,7 +4478,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -4496,7 +4496,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Stylo
@@ -4514,7 +4514,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Stylo
@@ -4532,7 +4532,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Stylo
@@ -4550,7 +4550,7 @@
     name: Chrome Mobile
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Stylo
@@ -4568,7 +4568,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Stylo
@@ -4586,7 +4586,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Stylo
@@ -4604,7 +4604,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Hurricane
@@ -4622,7 +4622,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Mobicel
@@ -4640,7 +4640,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Gresso
@@ -4658,7 +4658,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Riviera
@@ -4676,7 +4676,7 @@
     name: Chrome Mobile
     version: 81.0.4044.34
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.34"
   device:
     type: smartphone
     brand: Haier
@@ -4694,7 +4694,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Haier
@@ -4712,7 +4712,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Haier
@@ -4730,7 +4730,7 @@
     name: Chrome Mobile
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Haier
@@ -4748,7 +4748,7 @@
     name: Chrome Mobile
     version: 86.0.4240.16
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.16"
   device:
     type: smartphone
     brand: Alcatel
@@ -4766,7 +4766,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Alcatel
@@ -4784,7 +4784,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Alcatel
@@ -4802,7 +4802,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Alcatel
@@ -4820,7 +4820,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -4838,7 +4838,7 @@
     name: Chrome Mobile
     version: 85.0.4183.120
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: smartphone
     brand: Alcatel
@@ -4856,7 +4856,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -4874,7 +4874,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Alcatel
@@ -4892,7 +4892,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Leader Phone
@@ -4910,7 +4910,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Leader Phone
@@ -4928,7 +4928,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Karbonn
@@ -4946,7 +4946,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Karbonn
@@ -4964,7 +4964,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Karbonn
@@ -4982,7 +4982,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Highscreen
@@ -5000,7 +5000,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Starmobile
@@ -5018,7 +5018,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Blu
@@ -5036,7 +5036,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Blu
@@ -5054,7 +5054,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Lava
@@ -5072,7 +5072,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Gome
@@ -5090,7 +5090,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Hyundai
@@ -5108,7 +5108,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Accent
@@ -5126,7 +5126,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: F2 Mobile
@@ -5144,7 +5144,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Sony
@@ -5162,7 +5162,7 @@
     name: Chrome Mobile
     version: 90.0.4430.106
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.106"
   device:
     type: smartphone
     brand: Sony
@@ -5180,7 +5180,7 @@
     name: Opera Mobile
     version: 64.2.3282.60128
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: smartphone
     brand: Asus
@@ -5198,7 +5198,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Kyocera
@@ -5216,7 +5216,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Sony
@@ -5234,7 +5234,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Benzo
@@ -5252,7 +5252,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Exmart
@@ -5270,7 +5270,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Inco
@@ -5288,7 +5288,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: iMars
@@ -5306,7 +5306,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Qubo
@@ -5324,7 +5324,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Mito
@@ -5342,7 +5342,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Mito
@@ -5360,7 +5360,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Qubo
@@ -5378,7 +5378,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Mito
@@ -5396,7 +5396,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Mito
@@ -5414,7 +5414,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: DNS
@@ -5432,7 +5432,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: HiMax
@@ -5450,7 +5450,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: HiMax
@@ -5468,7 +5468,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: HiMax
@@ -5486,7 +5486,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: HiMax
@@ -5504,7 +5504,7 @@
     name: Chrome Mobile
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Hyundai
@@ -5522,7 +5522,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Masstel
@@ -5540,7 +5540,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Masstel
@@ -5558,7 +5558,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Masstel
@@ -5576,7 +5576,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Elephone
@@ -5594,7 +5594,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Elephone
@@ -5612,7 +5612,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Telefunken
@@ -5630,7 +5630,7 @@
     name: Chrome Mobile
     version: 84.0.4147.44
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.44"
   device:
     type: smartphone
     brand: Leader Phone
@@ -5648,7 +5648,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Leader Phone
@@ -5666,7 +5666,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: MyPhone
@@ -5684,7 +5684,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Luna
@@ -5702,7 +5702,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Telefunken
@@ -5720,7 +5720,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Lava
@@ -5738,7 +5738,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Qnet Mobile
@@ -5756,7 +5756,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Qnet Mobile
@@ -5774,7 +5774,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Qnet Mobile
@@ -5792,7 +5792,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Qnet Mobile
@@ -5810,7 +5810,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Qnet Mobile
@@ -5828,7 +5828,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Qnet Mobile
@@ -5846,7 +5846,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Qnet Mobile
@@ -5864,7 +5864,7 @@
     name: Chrome Webview
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Qnet Mobile
@@ -5882,7 +5882,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Qnet Mobile
@@ -5900,7 +5900,7 @@
     name: Chrome Mobile
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Qnet Mobile
@@ -5918,7 +5918,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Qnet Mobile
@@ -5936,7 +5936,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Qnet Mobile
@@ -5954,7 +5954,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Qnet Mobile
@@ -5972,7 +5972,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Qnet Mobile
@@ -5990,7 +5990,7 @@
     name: Chrome Webview
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Qnet Mobile
@@ -6008,7 +6008,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Samsung
@@ -6026,7 +6026,7 @@
     name: Chrome Webview
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Xiaomi
@@ -6044,7 +6044,7 @@
     name: Opera Mobile
     version: 64.3.3282.60839
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: smartphone
     brand: Realme
@@ -6062,7 +6062,7 @@
     name: Chrome Webview
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -6080,7 +6080,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Xiaomi
@@ -6098,7 +6098,7 @@
     name: Microsoft Edge
     version: 46.06.4.5161
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Nokia
@@ -6116,7 +6116,7 @@
     name: Chrome Webview
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Xiaomi
@@ -6134,7 +6134,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -6152,7 +6152,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Realme
@@ -6170,7 +6170,7 @@
     name: Yandex Browser
     version: 21.81.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Samsung
@@ -6188,7 +6188,7 @@
     name: Opera Mobile
     version: 59.0.2254.59208
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Samsung
@@ -6206,7 +6206,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Motorola
@@ -6224,7 +6224,7 @@
     name: Yandex Browser
     version: 21.81.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: ZTE
@@ -6242,7 +6242,7 @@
     name: Yandex Browser
     version: 21.80.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: ZTE
@@ -6260,7 +6260,7 @@
     name: Yandex Browser
     version: 21.6.6.55.00
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: ZTE
@@ -6278,7 +6278,7 @@
     name: Yandex Browser
     version: 21.80.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: ZTE
@@ -6296,7 +6296,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Mobicel
@@ -6314,7 +6314,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Vivo
@@ -6332,7 +6332,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: ZTE
@@ -6350,7 +6350,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Realme
@@ -6368,7 +6368,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Realme
@@ -6404,7 +6404,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Oukitel
@@ -6422,7 +6422,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: CUBOT
@@ -6440,7 +6440,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Ulefone
@@ -6458,7 +6458,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Ulefone
@@ -6476,7 +6476,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: OnePlus
@@ -6494,7 +6494,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: OnePlus
@@ -6512,7 +6512,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -6530,7 +6530,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: OnePlus
@@ -6548,7 +6548,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Vivo
@@ -6566,7 +6566,7 @@
     name: Yandex Browser
     version: 21.6.6.55.00
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Xiaomi
@@ -6584,7 +6584,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: TCL
@@ -6602,7 +6602,7 @@
     name: Chrome Mobile
     version: 94.0.4606.50
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.50"
   device:
     type: smartphone
     brand: Samsung
@@ -6620,7 +6620,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Xiaomi
@@ -6638,7 +6638,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Doogee
@@ -6656,7 +6656,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: OnePlus
@@ -6674,7 +6674,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: OnePlus
@@ -6692,7 +6692,7 @@
     name: Chrome Mobile
     version: 94.0.4606.50
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.50"
   device:
     type: smartphone
     brand: TCL
@@ -6710,7 +6710,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: TCL
@@ -6728,7 +6728,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: ZTE
@@ -6746,7 +6746,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: ZTE
@@ -6764,7 +6764,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: ZTE
@@ -6800,7 +6800,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: phablet
     brand: Tecno Mobile
@@ -6818,7 +6818,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -6836,7 +6836,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Hisense
@@ -6870,7 +6870,7 @@
     name: Opera Mobile
     version: 64.2.3282.60128
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: smartphone
     brand: Hisense
@@ -6888,7 +6888,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Hisense
@@ -6906,7 +6906,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6924,7 +6924,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6942,7 +6942,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Doogee
@@ -6960,7 +6960,7 @@
     name: Yandex Browser
     version: 21.66.1
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Doogee
@@ -6978,7 +6978,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Wiko
@@ -6996,7 +6996,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Wiko
@@ -7014,7 +7014,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Vivo
@@ -7050,7 +7050,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Motorola
@@ -7068,7 +7068,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Infinix
@@ -7086,7 +7086,7 @@
     name: Chrome Webview
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Infinix
@@ -7104,7 +7104,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Infinix
@@ -7122,7 +7122,7 @@
     name: Chrome Webview
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Infinix
@@ -7140,7 +7140,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Xiaomi
@@ -7158,7 +7158,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Xiaomi
@@ -7176,7 +7176,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Xiaomi
@@ -7194,7 +7194,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Xiaomi
@@ -7212,7 +7212,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Motorola
@@ -7230,7 +7230,7 @@
     name: Microsoft Edge
     version: 93.0.961.38
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.63"
   device:
     type: smartphone
     brand: Motorola
@@ -7248,7 +7248,7 @@
     name: Yandex Browser
     version: 21.81.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Samsung
@@ -7266,7 +7266,7 @@
     name: Yandex Browser
     version: 20.11.2.69.00
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Samsung
@@ -7284,7 +7284,7 @@
     name: Yandex Browser
     version: 21.80.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: Samsung
@@ -7302,7 +7302,7 @@
     name: Yandex Browser
     version: 21.80.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: Samsung
@@ -7320,7 +7320,7 @@
     name: Yandex Browser
     version: 21.81.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Samsung
@@ -7338,7 +7338,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: DEXP
@@ -7356,7 +7356,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Samsung
@@ -7374,7 +7374,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Samsung
@@ -7392,7 +7392,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Samsung
@@ -7410,7 +7410,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Samsung
@@ -7428,7 +7428,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Samsung
@@ -7446,7 +7446,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Xiaomi
@@ -7500,7 +7500,7 @@
     name: Aloha Browser
     version: 3.8.2
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Nokia
@@ -7518,7 +7518,7 @@
     name: Chrome Webview
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: bq
@@ -7536,7 +7536,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Samsung
@@ -7554,7 +7554,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Samsung
@@ -7572,7 +7572,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Samsung
@@ -7590,7 +7590,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Samsung
@@ -7608,7 +7608,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Samsung
@@ -7626,7 +7626,7 @@
     name: Chrome Mobile
     version: 94.0.4606.50
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.50"
   device:
     type: smartphone
     brand: Samsung
@@ -7644,7 +7644,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Nubia
@@ -7662,7 +7662,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -7680,7 +7680,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -7698,7 +7698,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -7716,7 +7716,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Logicom
@@ -7734,7 +7734,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -7752,7 +7752,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Stylo
@@ -7770,7 +7770,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Nubia
@@ -7788,7 +7788,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: QMobile
@@ -7806,7 +7806,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Stylo
@@ -7824,7 +7824,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Mobicel
@@ -7842,7 +7842,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Stylo
@@ -7860,7 +7860,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: DIXON
@@ -7878,7 +7878,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Vodacom
@@ -7896,7 +7896,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Xiaomi
@@ -7914,7 +7914,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Zuum
@@ -7932,7 +7932,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -7950,7 +7950,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -7968,7 +7968,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -7986,7 +7986,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Oukitel
@@ -8004,7 +8004,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Oukitel
@@ -8022,7 +8022,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Motorola
@@ -8040,7 +8040,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Asus
@@ -8058,7 +8058,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Asus
@@ -8076,7 +8076,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: OnePlus
@@ -8094,7 +8094,7 @@
     name: Chrome Webview
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: OnePlus
@@ -8112,7 +8112,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Vivo
@@ -8130,7 +8130,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: iTel
@@ -8148,7 +8148,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Mobicel
@@ -8166,7 +8166,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Doogee
@@ -8184,7 +8184,7 @@
     name: Chrome Webview
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Doogee
@@ -8202,7 +8202,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Cat
@@ -8220,7 +8220,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Stylo
@@ -8238,7 +8238,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: iHunt
@@ -8256,7 +8256,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: iHunt
@@ -8274,7 +8274,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Vivo
@@ -8292,7 +8292,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Motorola
@@ -8310,7 +8310,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Homtom
@@ -8328,7 +8328,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Homtom
@@ -8346,7 +8346,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Sony
@@ -8364,7 +8364,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: CUBOT
@@ -8382,7 +8382,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: CUBOT
@@ -8400,7 +8400,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: MLS
@@ -8418,7 +8418,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Oukitel
@@ -8436,7 +8436,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Oukitel
@@ -8454,7 +8454,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Oukitel
@@ -8472,7 +8472,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8490,7 +8490,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Stylo
@@ -8508,7 +8508,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Vestel
@@ -8526,7 +8526,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Unonu
@@ -8544,7 +8544,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Bluebird
@@ -8562,7 +8562,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Casper
@@ -8580,7 +8580,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Mobicel
@@ -8598,7 +8598,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Blu
@@ -8616,7 +8616,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Vivo
@@ -8634,7 +8634,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Nokia
@@ -8652,7 +8652,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -8670,7 +8670,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Mara
@@ -8688,7 +8688,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Mara
@@ -8706,7 +8706,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Mara
@@ -8724,7 +8724,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Mara
@@ -8742,7 +8742,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Motorola
@@ -8760,7 +8760,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Nokia
@@ -8778,7 +8778,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Nokia
@@ -8796,7 +8796,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Nokia
@@ -8814,7 +8814,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Nokia
@@ -8832,7 +8832,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Nokia
@@ -8850,7 +8850,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: MyPhone
@@ -8868,7 +8868,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: MyPhone
@@ -8886,7 +8886,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Nokia
@@ -8904,7 +8904,7 @@
     name: Chrome Webview
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Asus
@@ -8922,7 +8922,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Lenovo
@@ -8940,7 +8940,7 @@
     name: Chrome Webview
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Coolpad
@@ -8958,7 +8958,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Coolpad
@@ -8976,7 +8976,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Blu
@@ -8994,7 +8994,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Sony
@@ -9012,7 +9012,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Nubia
@@ -9030,7 +9030,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: OPPO
@@ -9048,7 +9048,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9066,7 +9066,7 @@
     name: Chrome Mobile
     version: 94.0.4606.50
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.50"
   device:
     type: smartphone
     brand: Hisense
@@ -9084,7 +9084,7 @@
     name: Yandex Browser
     version: 21.63.1
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -9120,7 +9120,7 @@
     name: Chrome Webview
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Nubia
@@ -9154,7 +9154,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9172,7 +9172,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Lenovo
@@ -9190,7 +9190,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Samsung
@@ -9208,7 +9208,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Samsung
@@ -9226,7 +9226,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Samsung
@@ -9262,7 +9262,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: ZTE
@@ -9280,7 +9280,7 @@
     name: Huawei Browser Mobile
     version: 11.1.0.304
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Huawei
@@ -9298,7 +9298,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: LG
@@ -9316,7 +9316,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Samsung
@@ -9334,7 +9334,7 @@
     name: Chrome Mobile
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -9352,7 +9352,7 @@
     name: Chrome Webview
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Xiaomi
@@ -9370,7 +9370,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Samsung
@@ -9388,7 +9388,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -9406,7 +9406,7 @@
     name: Chrome Mobile
     version: 96.0.4650.2
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4650.2"
   device:
     type: smartphone
     brand: Samsung
@@ -9424,7 +9424,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Zuum
@@ -9458,7 +9458,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Mobicel
@@ -9476,7 +9476,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: OPPO
@@ -9494,7 +9494,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Nomi
@@ -9512,7 +9512,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Nomi
@@ -9530,7 +9530,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: LG
@@ -9548,7 +9548,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: LG
@@ -9566,7 +9566,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: LG
@@ -9584,7 +9584,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: LG
@@ -9602,7 +9602,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: LG
@@ -9620,7 +9620,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: LG
@@ -9638,7 +9638,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: LG
@@ -9656,7 +9656,7 @@
     name: Chrome Webview
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Sony
@@ -9674,7 +9674,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Archos
@@ -9692,7 +9692,7 @@
     name: Opera Mobile
     version: 64.3.3282.60839
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: smartphone
     brand: Blackview
@@ -9710,7 +9710,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Samsung
@@ -9728,7 +9728,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: NUU Mobile
@@ -9746,7 +9746,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Samsung
@@ -9764,7 +9764,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Sony
@@ -9782,7 +9782,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Samsung
@@ -9800,7 +9800,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Samsung
@@ -9818,7 +9818,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Samsung
@@ -9836,7 +9836,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Oukitel
@@ -9854,7 +9854,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Coolpad
@@ -9872,7 +9872,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: LG
@@ -9890,7 +9890,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: LG
@@ -9908,7 +9908,7 @@
     name: Chrome Webview
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: ZTE
@@ -9926,7 +9926,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Huawei
@@ -9944,7 +9944,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Rakuten
@@ -9962,7 +9962,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Rakuten
@@ -9980,7 +9980,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Rakuten
@@ -9998,7 +9998,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Sony

--- a/Tests/fixtures/smartphone-27.yml
+++ b/Tests/fixtures/smartphone-27.yml
@@ -10,7 +10,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Coolpad
@@ -28,7 +28,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: TCL
@@ -46,7 +46,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: ZTE
@@ -64,7 +64,7 @@
     name: Yandex Browser
     version: 21.82.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Coolpad
@@ -82,7 +82,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Digma
@@ -100,7 +100,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Mobicel
@@ -118,7 +118,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: phablet
     brand: ZTE
@@ -136,7 +136,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Oukitel
@@ -154,7 +154,7 @@
     name: Yandex Browser
     version: 21.2.1.117.00
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: smartphone
     brand: Huawei
@@ -172,7 +172,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: DEXP
@@ -190,7 +190,7 @@
     name: Chrome Webview
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Intex
@@ -208,7 +208,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Santin
@@ -226,7 +226,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Santin
@@ -244,7 +244,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Santin
@@ -262,7 +262,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: ZTE
@@ -280,7 +280,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Huawei
@@ -298,7 +298,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: S-TELL
@@ -316,7 +316,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Sigma
@@ -334,7 +334,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Sigma
@@ -352,7 +352,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Blackview
@@ -370,7 +370,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Sigma
@@ -388,7 +388,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Vivo
@@ -424,7 +424,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: iTel
@@ -442,7 +442,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: ZTE
@@ -460,7 +460,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: ZTE
@@ -478,7 +478,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Sharp
@@ -496,7 +496,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Prestigio
@@ -514,7 +514,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: HTC
@@ -532,7 +532,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: OnePlus
@@ -550,7 +550,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Wiko
@@ -568,7 +568,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Sony
@@ -676,7 +676,7 @@
     name: Opera Mobile
     version: 60.0.2254.59405
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Lenovo
@@ -694,7 +694,7 @@
     name: Opera Mobile
     version: 33.0.2254.125673
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Samsung
@@ -712,7 +712,7 @@
     name: Yandex Browser
     version: 21.6.4.119.00
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: LG
@@ -730,7 +730,7 @@
     name: Yandex Browser
     version: 21.6.1.137.00
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Huawei
@@ -802,7 +802,7 @@
     name: Chrome Webview
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -820,7 +820,7 @@
     name: Chrome Webview
     version: 75.0.3770.156
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.156"
   device:
     type: smartphone
     brand: ZTE
@@ -838,7 +838,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Smartisan
@@ -856,7 +856,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: ZTE
@@ -892,7 +892,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -928,7 +928,7 @@
     name: Chrome Webview
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Vivo
@@ -946,7 +946,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: OPPO
@@ -1018,7 +1018,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: HTC
@@ -1036,7 +1036,7 @@
     name: Chrome Webview
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Xiaolajiao
@@ -1072,7 +1072,7 @@
     name: Chrome Webview
     version: 44.0.2403.119
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Konka
@@ -1106,7 +1106,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: OPPO
@@ -1142,7 +1142,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: POCO
@@ -1178,7 +1178,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -1196,7 +1196,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Huawei
@@ -1214,7 +1214,7 @@
     name: Huawei Browser Mobile
     version: 11.1.4.301
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -1232,7 +1232,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -1250,7 +1250,7 @@
     name: Huawei Browser Mobile
     version: 11.1.1.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -1268,7 +1268,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Meizu
@@ -1286,7 +1286,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Meizu
@@ -1412,7 +1412,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Blu
@@ -1448,7 +1448,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -1466,7 +1466,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -1502,7 +1502,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -1520,7 +1520,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Vivo
@@ -1538,7 +1538,7 @@
     name: Chrome Webview
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: Vivo
@@ -1646,7 +1646,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Vivo
@@ -1664,7 +1664,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Vivo
@@ -1700,7 +1700,7 @@
     name: Microsoft Edge
     version: 45.09.4.5079
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Vivo
@@ -1754,7 +1754,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -1772,7 +1772,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Vivo
@@ -1808,7 +1808,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Vivo
@@ -1826,7 +1826,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: HTC
@@ -1844,7 +1844,7 @@
     name: Chrome Mobile
     version: 89.0.4389.90
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.90"
   device:
     type: smartphone
     brand: HTC
@@ -1862,7 +1862,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Hisense
@@ -1880,7 +1880,7 @@
     name: Chrome Webview
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Hisense
@@ -1898,7 +1898,7 @@
     name: Chrome Webview
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Hisense
@@ -1916,7 +1916,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Gionee
@@ -1934,7 +1934,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Realme
@@ -1952,7 +1952,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Realme
@@ -1970,7 +1970,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -2006,7 +2006,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Vivo
@@ -2024,7 +2024,7 @@
     name: Chrome Mobile
     version: 89.0.4389.72
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.72"
   device:
     type: smartphone
     brand: Vivo
@@ -2042,7 +2042,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: Vivo
@@ -2060,7 +2060,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Vivo
@@ -2078,7 +2078,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Vivo
@@ -2096,7 +2096,7 @@
     name: Chrome Mobile
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -2114,7 +2114,7 @@
     name: Chrome Mobile
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -2132,7 +2132,7 @@
     name: Chrome Mobile
     version: 88.0.4324.152
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.152"
   device:
     type: smartphone
     brand: Vivo
@@ -2150,7 +2150,7 @@
     name: Chrome Webview
     version: 38.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.0.0"
   device:
     type: smartphone
     brand: Vivo
@@ -2168,7 +2168,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Vivo
@@ -2186,7 +2186,7 @@
     name: Opera Mobile
     version: 59.1.2926.54067
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Vivo
@@ -2222,7 +2222,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Vivo
@@ -2240,7 +2240,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Vivo
@@ -2258,7 +2258,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Vivo
@@ -2276,7 +2276,7 @@
     name: Opera Mobile
     version: 64.2.3282.60128
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: smartphone
     brand: Vivo
@@ -2294,7 +2294,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Vivo
@@ -2312,7 +2312,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Vivo
@@ -2330,7 +2330,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Vivo
@@ -2366,7 +2366,7 @@
     name: Yandex Browser
     version: 20.125.1
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Vivo
@@ -2384,7 +2384,7 @@
     name: Yandex Browser
     version: 19.9.2.117.00
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Vivo
@@ -2402,7 +2402,7 @@
     name: Yandex Browser
     version: 20.113.1
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Vivo
@@ -2420,7 +2420,7 @@
     name: Yandex Browser
     version: 19.9.6.88.00
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Vivo
@@ -2438,7 +2438,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Vivo
@@ -2474,7 +2474,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Vivo
@@ -2510,7 +2510,7 @@
     name: Chrome Mobile
     version: 73.0.3683.75
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.75"
   device:
     type: smartphone
     brand: Vivo
@@ -2528,7 +2528,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Vivo
@@ -2546,7 +2546,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Vivo
@@ -2564,7 +2564,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Vivo
@@ -2582,7 +2582,7 @@
     name: Aloha Browser
     version: 1.4.0.1
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Blu
@@ -2600,7 +2600,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Vivo
@@ -2636,7 +2636,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Vivo
@@ -2654,7 +2654,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Vivo
@@ -2672,7 +2672,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: NOA
@@ -2816,7 +2816,7 @@
     name: Chrome Webview
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -2834,7 +2834,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Vivo
@@ -2852,7 +2852,7 @@
     name: Chrome Mobile
     version: 75.0.3770.67
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: smartphone
     brand: Vivo
@@ -2870,7 +2870,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Vivo
@@ -2888,7 +2888,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Vivo
@@ -2906,7 +2906,7 @@
     name: Chrome Mobile
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -2924,7 +2924,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Vivo
@@ -2942,7 +2942,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Blu
@@ -2960,7 +2960,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Vivo
@@ -2996,7 +2996,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Vivo
@@ -3014,7 +3014,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Vivo
@@ -3032,7 +3032,7 @@
     name: Chrome Mobile
     version: 70.0.3538.64
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: Vivo
@@ -3050,7 +3050,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Vivo
@@ -3068,7 +3068,7 @@
     name: Chrome Mobile
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Vivo
@@ -3086,7 +3086,7 @@
     name: Yandex Browser
     version: "11.41"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Vivo
@@ -3158,7 +3158,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Vivo
@@ -3176,7 +3176,7 @@
     name: Chrome Mobile
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Vivo
@@ -3194,7 +3194,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Vivo
@@ -3212,7 +3212,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Zopo
@@ -3230,7 +3230,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Zopo
@@ -3248,7 +3248,7 @@
     name: Chrome Mobile
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: F2 Mobile
@@ -3266,7 +3266,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -3284,7 +3284,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Hotwav
@@ -3302,7 +3302,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Hotwav
@@ -3320,7 +3320,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Hotwav
@@ -3338,7 +3338,7 @@
     name: Chrome Mobile
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Hotwav
@@ -3356,7 +3356,7 @@
     name: Chrome Webview
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Hotwav
@@ -3374,7 +3374,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: DING DING
@@ -3392,7 +3392,7 @@
     name: Chrome Webview
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: DING DING
@@ -3410,7 +3410,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Orange
@@ -3428,7 +3428,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Orange
@@ -3500,7 +3500,7 @@
     name: Opera Mobile
     version: 60.0.2254.59405
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -3518,7 +3518,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: M4tel
@@ -3536,7 +3536,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: 'Kempler & Strauss'
@@ -3554,7 +3554,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: Rokit
@@ -3572,7 +3572,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Rokit
@@ -3590,7 +3590,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Neffos
@@ -3624,7 +3624,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Stylo
@@ -3658,7 +3658,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Stylo
@@ -3676,7 +3676,7 @@
     name: Chrome Mobile
     version: 94.0.4606.50
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.50"
   device:
     type: smartphone
     brand: Alcatel
@@ -3694,7 +3694,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Santin
@@ -3712,7 +3712,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Mobicel
@@ -3730,7 +3730,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Prestigio
@@ -3748,7 +3748,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Prestigio
@@ -3766,7 +3766,7 @@
     name: Chrome Mobile
     version: 94.0.4606.80
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.80"
   device:
     type: smartphone
     brand: Prestigio
@@ -3784,7 +3784,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Prestigio
@@ -3802,7 +3802,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Prestigio
@@ -3820,7 +3820,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Prestigio
@@ -3838,7 +3838,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Prestigio
@@ -3856,7 +3856,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Prestigio
@@ -3892,7 +3892,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: X-TIGI
@@ -3910,7 +3910,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: MicroMax
@@ -3928,7 +3928,7 @@
     name: Chrome Webview
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: MicroMax
@@ -3946,7 +3946,7 @@
     name: CoolBrowser
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: MicroMax
@@ -3964,7 +3964,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: MicroMax
@@ -3982,7 +3982,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: MicroMax
@@ -4000,7 +4000,7 @@
     name: Chrome Webview
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: MicroMax
@@ -4018,7 +4018,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Oukitel
@@ -4036,7 +4036,7 @@
     name: Chrome Webview
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Hurricane
@@ -4054,7 +4054,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Highscreen
@@ -4072,7 +4072,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Alcatel
@@ -4090,7 +4090,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: LG
@@ -4108,7 +4108,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: LG
@@ -4126,7 +4126,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: LG
@@ -4144,7 +4144,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: M4tel
@@ -4162,7 +4162,7 @@
     name: Chrome Mobile
     version: 95.0.4638.40
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.40"
   device:
     type: smartphone
     brand: S-TELL
@@ -4180,7 +4180,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: S-TELL
@@ -4198,7 +4198,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Blackview
@@ -4216,7 +4216,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Coolpad
@@ -4234,7 +4234,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Coolpad
@@ -4252,7 +4252,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: HTC
@@ -4270,7 +4270,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: HTC
@@ -4288,7 +4288,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: HTC
@@ -4306,7 +4306,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Coolpad
@@ -4324,7 +4324,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Coolpad
@@ -4342,7 +4342,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Coolpad
@@ -4360,7 +4360,7 @@
     name: Chrome Mobile
     version: 94.0.4606.80
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.80"
   device:
     type: smartphone
     brand: MicroMax
@@ -4378,7 +4378,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: MicroMax
@@ -4396,7 +4396,7 @@
     name: Yandex Browser
     version: 16.7.1.2912.00
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.106"
   device:
     type: smartphone
     brand: MicroMax
@@ -4414,7 +4414,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: LG
@@ -4432,7 +4432,7 @@
     name: Chrome Mobile
     version: 60.0.3090.0
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3090.0"
   device:
     type: smartphone
     brand: LG
@@ -4450,7 +4450,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: LG
@@ -4468,7 +4468,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: LG
@@ -4486,7 +4486,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: LG
@@ -4504,7 +4504,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Huawei
@@ -4522,7 +4522,7 @@
     name: Huawei Browser Mobile
     version: 11.1.4.301
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -4540,7 +4540,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Walton
@@ -4558,7 +4558,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Reeder
@@ -4576,7 +4576,7 @@
     name: Chrome Webview
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: Orange
@@ -4594,7 +4594,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Mobicel
@@ -4612,7 +4612,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Realme
@@ -4630,7 +4630,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: NUU Mobile
@@ -4648,7 +4648,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: MyPhone
@@ -4666,7 +4666,7 @@
     name: Opera Mobile
     version: 65.0.3310.60026
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4684,7 +4684,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Huawei
@@ -4702,7 +4702,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Huawei
@@ -4720,7 +4720,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Huawei
@@ -4738,7 +4738,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Hisense
@@ -4756,7 +4756,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Hisense
@@ -4774,7 +4774,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Hisense
@@ -4792,7 +4792,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Hisense
@@ -4810,7 +4810,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Hisense
@@ -4828,7 +4828,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Hisense
@@ -4846,7 +4846,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Zuum
@@ -4864,7 +4864,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -4882,7 +4882,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Motorola
@@ -4900,7 +4900,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Motorola
@@ -4918,7 +4918,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Motorola
@@ -4936,7 +4936,7 @@
     name: Chrome Webview
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: TCL
@@ -4990,7 +4990,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Packard Bell
@@ -5008,7 +5008,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5026,7 +5026,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5044,7 +5044,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5062,7 +5062,7 @@
     name: Chrome Mobile
     version: 94.0.4606.30
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.30"
   device:
     type: smartphone
     brand: OPPO
@@ -5080,7 +5080,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: OPPO
@@ -5098,7 +5098,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: OPPO
@@ -5116,7 +5116,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: OnePlus
@@ -5134,7 +5134,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: iHunt
@@ -5152,7 +5152,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Proline
@@ -5170,7 +5170,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Hurricane
@@ -5188,7 +5188,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Hurricane
@@ -5206,7 +5206,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Reeder
@@ -5224,7 +5224,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Stylo
@@ -5242,7 +5242,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Mobicel
@@ -5260,7 +5260,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Azumi Mobile
@@ -5278,7 +5278,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Azumi Mobile
@@ -5296,7 +5296,7 @@
     name: Opera Mobile
     version: 65.2.3381.61420
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: K-Touch
@@ -5314,7 +5314,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: 4Good
@@ -5332,7 +5332,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Prestigio
@@ -5350,7 +5350,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Vivo
@@ -5368,7 +5368,7 @@
     name: Chrome Webview
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Vivo
@@ -5386,7 +5386,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Oukitel
@@ -5404,7 +5404,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -5422,7 +5422,7 @@
     name: Chrome Webview
     version: 94.0.4606.80
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.80"
   device:
     type: smartphone
     brand: Vivo
@@ -5440,7 +5440,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Google
@@ -5458,7 +5458,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Google
@@ -5476,7 +5476,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Realme
@@ -5494,7 +5494,7 @@
     name: Chrome Webview
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Ravoz
@@ -5512,7 +5512,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: T-Mobile
@@ -5530,7 +5530,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: F150
@@ -5548,7 +5548,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Nubia
@@ -5566,7 +5566,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Huawei
@@ -5584,7 +5584,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: DIXON
@@ -5602,7 +5602,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Motorola
@@ -5620,7 +5620,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Asus
@@ -5638,7 +5638,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Nokia
@@ -5656,7 +5656,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -5674,7 +5674,7 @@
     name: Chrome Webview
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Vivo
@@ -5692,7 +5692,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Vivo
@@ -5710,7 +5710,7 @@
     name: Chrome Webview
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Vivo
@@ -5728,7 +5728,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Samsung
@@ -5746,7 +5746,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: ZTE
@@ -5764,7 +5764,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Motorola
@@ -5782,7 +5782,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5800,7 +5800,7 @@
     name: Yandex Browser
     version: 21.25.1
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: smartphone
     brand: Santin
@@ -5818,7 +5818,7 @@
     name: Yandex Browser
     version: 20.93.1
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Realme
@@ -5836,7 +5836,7 @@
     name: Yandex Browser
     version: 21.90.1
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Samsung
@@ -5854,7 +5854,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Meizu
@@ -5872,7 +5872,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Meizu
@@ -5890,7 +5890,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Alcatel
@@ -5908,7 +5908,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Alcatel
@@ -5926,7 +5926,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Alcatel
@@ -5944,7 +5944,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Alcatel
@@ -5962,7 +5962,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Alcatel
@@ -5980,7 +5980,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Alcatel
@@ -5998,7 +5998,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Trident
@@ -6016,7 +6016,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -6034,7 +6034,7 @@
     name: Yandex Browser
     version: 18.7.1.575.00
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.103"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -6052,7 +6052,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: DEXP
@@ -6070,7 +6070,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -6087,7 +6087,7 @@
     name: Chrome Webview
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Premio
@@ -6105,7 +6105,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Oukitel
@@ -6123,7 +6123,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Oukitel
@@ -6141,7 +6141,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Coolpad
@@ -6159,7 +6159,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Sky
@@ -6177,7 +6177,7 @@
     name: Huawei Browser Mobile
     version: 11.1.4.302
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -6195,7 +6195,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Stylo
@@ -6213,7 +6213,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Sky
@@ -6231,7 +6231,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Mobicel
@@ -6249,7 +6249,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Casper
@@ -6267,7 +6267,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Mobicel
@@ -6285,7 +6285,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Infinix
@@ -6303,7 +6303,7 @@
     name: Chrome Webview
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Infinix
@@ -6321,7 +6321,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -6339,7 +6339,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: TCL
@@ -6357,7 +6357,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: TCL
@@ -6375,7 +6375,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Alcatel
@@ -6393,7 +6393,7 @@
     name: Yandex Browser
     version: 21.90.1
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: DEXP
@@ -6411,7 +6411,7 @@
     name: Yandex Browser
     version: 21.84.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Vertex
@@ -6429,7 +6429,7 @@
     name: Yandex Browser
     version: 21.85.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Meizu
@@ -6447,7 +6447,7 @@
     name: Yandex Browser
     version: 21.85.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Taiga System
@@ -6465,7 +6465,7 @@
     name: Yandex Browser
     version: 21.90.1
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Sony
@@ -6483,7 +6483,7 @@
     name: Yandex Browser
     version: 21.9.0.359.00
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Sony
@@ -6501,7 +6501,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Cavion
@@ -6519,7 +6519,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Stylo
@@ -6537,7 +6537,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Mobicel
@@ -6555,7 +6555,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Ark
@@ -6573,7 +6573,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Hurricane
@@ -6591,7 +6591,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Mobicel
@@ -6609,7 +6609,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Mobicel
@@ -6627,7 +6627,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Glofiish
@@ -6645,7 +6645,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Mobicel
@@ -6663,7 +6663,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Hurricane
@@ -6681,7 +6681,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: bq
@@ -6699,7 +6699,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Hisense
@@ -6717,7 +6717,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -6735,7 +6735,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -6753,7 +6753,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Hurricane
@@ -6771,7 +6771,7 @@
     name: Chrome Webview
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: smartphone
     brand: NOA
@@ -6789,7 +6789,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Philips
@@ -6807,7 +6807,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Philips
@@ -6825,7 +6825,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Philips
@@ -6843,7 +6843,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: GOCLEVER
@@ -6861,7 +6861,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: GOCLEVER
@@ -6879,7 +6879,7 @@
     name: Chrome Mobile
     version: 52.0.2743.98
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Beeline
@@ -6897,7 +6897,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Archos
@@ -6915,7 +6915,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Archos
@@ -6933,7 +6933,7 @@
     name: Yandex Browser
     version: "8.05"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Archos
@@ -6951,7 +6951,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Blackview
@@ -6969,7 +6969,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Blackview
@@ -6987,7 +6987,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Blu
@@ -7005,7 +7005,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Gigaset
@@ -7023,7 +7023,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: LG
@@ -7041,7 +7041,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Senwa
@@ -7059,7 +7059,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Huawei
@@ -7077,7 +7077,7 @@
     name: Chrome Webview
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: LG
@@ -7095,7 +7095,7 @@
     name: Chrome Mobile
     version: 94.0.4606.50
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.50"
   device:
     type: smartphone
     brand: Lenovo
@@ -7113,7 +7113,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: LG
@@ -7131,7 +7131,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Lanix
@@ -7181,7 +7181,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: MyPhone
@@ -7199,7 +7199,7 @@
     name: Chrome Webview
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Blu
@@ -7217,7 +7217,7 @@
     name: Chrome Webview
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: POCO
@@ -7235,7 +7235,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Xiaomi
@@ -7253,7 +7253,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Samsung
@@ -7271,7 +7271,7 @@
     name: Chrome Webview
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Samsung
@@ -7289,7 +7289,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Samsung
@@ -7307,7 +7307,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -7361,7 +7361,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Elephone
@@ -7397,7 +7397,7 @@
     name: Microsoft Edge
     version: 45.09.4.5079
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Huawei
@@ -7415,7 +7415,7 @@
     name: Huawei Browser Mobile
     version: 11.1.3.300
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -7433,7 +7433,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -7451,7 +7451,7 @@
     name: Chrome Webview
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: OPPO
@@ -7469,7 +7469,7 @@
     name: Huawei Browser Mobile
     version: 10.1.2.320
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -7487,7 +7487,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: HTC
@@ -7505,7 +7505,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: ZTE
@@ -7523,7 +7523,7 @@
     name: Chrome Mobile
     version: 60.0.3112.107
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.107"
   device:
     type: smartphone
     brand: Samsung
@@ -7541,7 +7541,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Samsung
@@ -7559,7 +7559,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: TCL
@@ -7577,7 +7577,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: TCL
@@ -7595,7 +7595,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Samsung
@@ -7613,7 +7613,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Samsung
@@ -7631,7 +7631,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Samsung
@@ -7649,7 +7649,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Samsung
@@ -7685,7 +7685,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Samsung
@@ -7703,7 +7703,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Samsung
@@ -7721,7 +7721,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Samsung
@@ -7739,7 +7739,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Samsung
@@ -7757,7 +7757,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Samsung
@@ -7775,7 +7775,7 @@
     name: Chrome Webview
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: DIXON
@@ -7793,7 +7793,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Soyes
@@ -7811,7 +7811,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: ZTE
@@ -7829,7 +7829,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: OPPO
@@ -7847,7 +7847,7 @@
     name: Chrome Webview
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -7865,7 +7865,7 @@
     name: Yandex Browser
     version: "10.30"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.4"
   device:
     type: smartphone
     brand: Prestigio
@@ -7883,7 +7883,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Hisense
@@ -7901,7 +7901,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Hisense
@@ -7919,7 +7919,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Sony
@@ -7937,7 +7937,7 @@
     name: Chrome Mobile
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Hisense
@@ -7955,7 +7955,7 @@
     name: Chrome Mobile
     version: 94.0.4606.50
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.50"
   device:
     type: smartphone
     brand: Hisense
@@ -7973,7 +7973,7 @@
     name: Chrome Webview
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Hisense
@@ -7991,7 +7991,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: MyPhone
@@ -8009,7 +8009,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: 'AT&T'
@@ -8027,7 +8027,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -8045,7 +8045,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -8063,7 +8063,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -8081,7 +8081,7 @@
     name: Huawei Browser Mobile
     version: 11.1.4.301
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -8099,7 +8099,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: HTC
@@ -8117,7 +8117,7 @@
     name: Chrome Webview
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Hisense
@@ -8135,7 +8135,7 @@
     name: Huawei Browser Mobile
     version: 11.0.7.302
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Huawei
@@ -8153,7 +8153,7 @@
     name: Huawei Browser Mobile
     version: 11.1.2.301
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -8171,7 +8171,7 @@
     name: Huawei Browser Mobile
     version: 11.1.1.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -8189,7 +8189,7 @@
     name: Huawei Browser Mobile
     version: 11.1.1.302
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -8207,7 +8207,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -8225,7 +8225,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Vertex
@@ -8243,7 +8243,7 @@
     name: Yandex Browser
     version: 21.110.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Samsung
@@ -8261,7 +8261,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Blackview
@@ -8279,7 +8279,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Vertex
@@ -8297,7 +8297,7 @@
     name: Chrome Webview
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Blackview
@@ -8315,7 +8315,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Sharp
@@ -8333,7 +8333,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Xiaomi
@@ -8351,7 +8351,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Sharp
@@ -8369,7 +8369,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Sharp
@@ -8387,7 +8387,7 @@
     name: Huawei Browser Mobile
     version: 11.0.8.305
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Huawei
@@ -8405,7 +8405,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Sony
@@ -8441,7 +8441,7 @@
     name: Chrome Mobile
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Sharp
@@ -8459,7 +8459,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Fujitsu
@@ -8477,7 +8477,7 @@
     name: Opera Mobile
     version: 65.2.3381.61420
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Sony
@@ -8495,7 +8495,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Huawei
@@ -8513,7 +8513,7 @@
     name: Chrome Webview
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Samsung
@@ -8531,7 +8531,7 @@
     name: Chrome Webview
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: ZTE
@@ -8549,7 +8549,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -8585,7 +8585,7 @@
     name: Yandex Browser
     version: 21.110.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Vertex
@@ -8619,7 +8619,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: ZTE
@@ -8637,7 +8637,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Stylo
@@ -8655,7 +8655,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Blu
@@ -8673,7 +8673,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Q-Touch
@@ -8709,7 +8709,7 @@
     name: Opera Mobile
     version: 60.0.2254.59405
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -8727,7 +8727,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -8745,7 +8745,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Mitsui
@@ -8763,7 +8763,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: LG
@@ -8781,7 +8781,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: DIXON
@@ -8799,7 +8799,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Blu
@@ -8817,7 +8817,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: T-Mobile
@@ -8835,7 +8835,7 @@
     name: Yandex Browser
     version: 21.110.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Oukitel
@@ -8853,7 +8853,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Stylo
@@ -8871,7 +8871,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Stylo
@@ -8889,7 +8889,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Haier
@@ -8907,7 +8907,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Artel
@@ -8925,7 +8925,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Aiwa
@@ -8943,7 +8943,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Bmobile
@@ -8961,7 +8961,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Bmobile
@@ -8979,7 +8979,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Bmobile
@@ -8997,7 +8997,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: RIM
@@ -9015,7 +9015,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Blackview
@@ -9033,7 +9033,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Blackview
@@ -9051,7 +9051,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Blackview
@@ -9069,7 +9069,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Zuum
@@ -9087,7 +9087,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Ghia
@@ -9105,7 +9105,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: LG
@@ -9123,7 +9123,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Q-Touch
@@ -9141,7 +9141,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Mobicel
@@ -9159,7 +9159,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Zuum
@@ -9177,7 +9177,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Hyundai
@@ -9195,7 +9195,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Alcatel
@@ -9213,7 +9213,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Alcatel
@@ -9231,7 +9231,7 @@
     name: Chrome Webview
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Digma
@@ -9249,7 +9249,7 @@
     name: Chrome Webview
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Digma
@@ -9267,7 +9267,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Digma
@@ -9285,7 +9285,7 @@
     name: Chrome Webview
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Digma
@@ -9303,7 +9303,7 @@
     name: Opera Mobile
     version: 60.0.2254.59405
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Lenovo
@@ -9321,7 +9321,7 @@
     name: Opera Mobile
     version: 50.6.2426.201126
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Keneksi
@@ -9339,7 +9339,7 @@
     name: Chrome Webview
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Huawei
@@ -9393,7 +9393,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Sugar
@@ -9411,7 +9411,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Sugar
@@ -9429,7 +9429,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Sony
@@ -9447,7 +9447,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Wiko
@@ -9465,7 +9465,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Walton

--- a/Tests/fixtures/smartphone-28.yml
+++ b/Tests/fixtures/smartphone-28.yml
@@ -10,7 +10,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Prestigio
@@ -28,7 +28,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Prestigio
@@ -46,7 +46,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Prestigio
@@ -64,7 +64,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Prestigio
@@ -82,7 +82,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Prestigio
@@ -100,7 +100,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Zuum
@@ -118,7 +118,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: LG
@@ -136,7 +136,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: LG
@@ -154,7 +154,7 @@
     name: Yandex Browser
     version: 21.110.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: LG
@@ -172,7 +172,7 @@
     name: Yandex Browser
     version: 21.11.0.251.00
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Lenovo
@@ -190,7 +190,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: LG
@@ -208,7 +208,7 @@
     name: Chrome Mobile
     version: 95.0.4638.0
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.0"
   device:
     type: smartphone
     brand: LG
@@ -226,7 +226,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: LG
@@ -244,7 +244,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: LG
@@ -262,7 +262,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -280,7 +280,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -298,7 +298,7 @@
     name: Chrome Webview
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Vivo
@@ -316,7 +316,7 @@
     name: Chrome Webview
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Vivo
@@ -334,7 +334,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Vivo
@@ -352,7 +352,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Vivo
@@ -370,7 +370,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Vivo
@@ -388,7 +388,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Vivo
@@ -406,7 +406,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Wiko
@@ -424,7 +424,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: POCO
@@ -442,7 +442,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Motorola
@@ -460,7 +460,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Zebra
@@ -478,7 +478,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Inoi
@@ -496,7 +496,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Samsung
@@ -514,7 +514,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Samsung
@@ -532,7 +532,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Samsung
@@ -550,7 +550,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Samsung
@@ -568,7 +568,7 @@
     name: Chrome Webview
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: NUU Mobile
@@ -586,7 +586,7 @@
     name: Chrome Webview
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Lava
@@ -604,7 +604,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: TechPad
@@ -622,7 +622,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Homtom
@@ -640,7 +640,7 @@
     name: Chrome Mobile
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: smartphone
     brand: Bmobile
@@ -658,7 +658,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Sigma
@@ -676,7 +676,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Sigma
@@ -694,7 +694,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: HTC
@@ -712,7 +712,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: HTC
@@ -730,7 +730,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: HTC
@@ -748,7 +748,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Wiko
@@ -766,7 +766,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Wiko
@@ -784,7 +784,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: iGet
@@ -802,7 +802,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Motorola
@@ -820,7 +820,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Wiko
@@ -838,7 +838,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Realme
@@ -856,7 +856,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Realme
@@ -874,7 +874,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: OnePlus
@@ -892,7 +892,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -910,7 +910,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: LG
@@ -928,7 +928,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Digma
@@ -946,7 +946,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: HTC
@@ -964,7 +964,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Huawei
@@ -982,7 +982,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: General Mobile
@@ -1000,7 +1000,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: General Mobile
@@ -1018,7 +1018,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: General Mobile
@@ -1036,7 +1036,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -1054,7 +1054,7 @@
     name: Chrome Mobile
     version: 54.0.2840.68
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.68"
   device:
     type: smartphone
     brand: Huawei
@@ -1072,7 +1072,7 @@
     name: Chrome Mobile
     version: 54.0.2840.68
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.68"
   device:
     type: smartphone
     brand: Huawei
@@ -1090,7 +1090,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: General Mobile
@@ -1108,7 +1108,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: General Mobile
@@ -1126,7 +1126,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Meizu
@@ -1144,7 +1144,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Huawei
@@ -1162,7 +1162,7 @@
     name: Chrome Webview
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Centric
@@ -1180,7 +1180,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Cloudfone
@@ -1198,7 +1198,7 @@
     name: Chrome Webview
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Cloudfone
@@ -1216,7 +1216,7 @@
     name: Chrome Mobile
     version: 59.0.3071.125
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Cloudfone
@@ -1234,7 +1234,7 @@
     name: Chrome Mobile
     version: 66.0.3359.126
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Cloudfone
@@ -1252,7 +1252,7 @@
     name: Chrome Mobile
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Cloudfone
@@ -1270,7 +1270,7 @@
     name: Chrome Mobile
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Cloudfone
@@ -1288,7 +1288,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: ZTE
@@ -1306,7 +1306,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: ZTE
@@ -1324,7 +1324,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Samsung
@@ -1342,7 +1342,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Samsung
@@ -1360,7 +1360,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Samsung
@@ -1378,7 +1378,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Samsung
@@ -1396,7 +1396,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Samsung
@@ -1414,7 +1414,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Maze
@@ -1432,7 +1432,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Maze
@@ -1450,7 +1450,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Motorola
@@ -1468,7 +1468,7 @@
     name: Chrome Webview
     version: 94.0.4606.80
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.80"
   device:
     type: smartphone
     brand: Motorola
@@ -1486,7 +1486,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Motorola
@@ -1504,7 +1504,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: LG
@@ -1522,7 +1522,7 @@
     name: Huawei Browser Mobile
     version: 12.0.0.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -1540,7 +1540,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.311
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -1558,7 +1558,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Motorola
@@ -1576,7 +1576,7 @@
     name: Chrome Mobile
     version: 97.0.4692.10
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.10"
   device:
     type: smartphone
     brand: Xiaomi
@@ -1594,7 +1594,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Reeder
@@ -1612,7 +1612,7 @@
     name: Chrome Webview
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Motorola
@@ -1630,7 +1630,7 @@
     name: Yandex Browser
     version: "7.52"
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: DEXP
@@ -1648,7 +1648,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: DEXP
@@ -1684,7 +1684,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Vivo
@@ -1702,7 +1702,7 @@
     name: Chrome Webview
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Vivo
@@ -1720,7 +1720,7 @@
     name: Opera Mobile
     version: 66.0.3425.61578
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Vivo
@@ -1738,7 +1738,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Vivo
@@ -1756,7 +1756,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Wiko
@@ -1774,7 +1774,7 @@
     name: Yandex Browser
     version: "7.52"
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: bq
@@ -1792,7 +1792,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: OPPO
@@ -1810,7 +1810,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -1990,7 +1990,7 @@
     name: Chrome Webview
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Kalley
@@ -2026,7 +2026,7 @@
     name: Chrome Webview
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Hyundai
@@ -2044,7 +2044,7 @@
     name: Yandex Browser
     version: 21.112.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: ZTE
@@ -2062,7 +2062,7 @@
     name: Yandex Browser
     version: 21.85.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Ulefone
@@ -2080,7 +2080,7 @@
     name: Yandex Browser
     version: 21.90.1
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Oukitel
@@ -2098,7 +2098,7 @@
     name: Yandex Browser
     version: 21.60.1
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: smartphone
     brand: ZTE
@@ -2116,7 +2116,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: HTC
@@ -2134,7 +2134,7 @@
     name: Yandex Browser
     version: "21.113"
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Leagoo
@@ -2152,7 +2152,7 @@
     name: Yandex Browser
     version: 21.11.0.251.00
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Doogee
@@ -2170,7 +2170,7 @@
     name: Yandex Browser
     version: 21.111.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: ZTE
@@ -2188,7 +2188,7 @@
     name: Yandex Browser
     version: 21.112.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: ZTE
@@ -2206,7 +2206,7 @@
     name: Yandex Browser
     version: 21.110.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: ZTE
@@ -2224,7 +2224,7 @@
     name: Yandex Browser
     version: 21.113.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: ZTE
@@ -2242,7 +2242,7 @@
     name: Yandex Browser
     version: 20.85.1
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: smartphone
     brand: TCL
@@ -2260,7 +2260,7 @@
     name: Yandex Browser
     version: 20.85.1
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: smartphone
     brand: TCL
@@ -2278,7 +2278,7 @@
     name: Yandex Browser
     version: 20.85.1
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: smartphone
     brand: Alcatel
@@ -2296,7 +2296,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Hoozo
@@ -2314,7 +2314,7 @@
     name: Yandex Browser
     version: 21.84.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Parrot Mobile
@@ -2332,7 +2332,7 @@
     name: Yandex Browser
     version: 21.8.4.112.00
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: STK
@@ -2350,7 +2350,7 @@
     name: Yandex Browser
     version: 21.113.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: iTel
@@ -2368,7 +2368,7 @@
     name: Yandex Browser
     version: 21.112.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: iTel
@@ -2386,7 +2386,7 @@
     name: Chrome Webview
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: iTel
@@ -2404,7 +2404,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Seuic
@@ -2422,7 +2422,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Lenovo
@@ -2458,7 +2458,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Huawei
@@ -2476,7 +2476,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Nubia
@@ -2494,7 +2494,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: ComTrade Tesla
@@ -2512,7 +2512,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Zebra
@@ -2546,7 +2546,7 @@
     name: Chrome Webview
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Condor
@@ -2564,7 +2564,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Philips
@@ -2582,7 +2582,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Philips
@@ -2600,7 +2600,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Philips
@@ -2618,7 +2618,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Philips
@@ -2636,7 +2636,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Philips
@@ -2654,7 +2654,7 @@
     name: Opera Mobile
     version: 35.0.2254.127759
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Mobicel
@@ -2672,7 +2672,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Cloud
@@ -2690,7 +2690,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Stylo
@@ -2708,7 +2708,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Cloud
@@ -2726,7 +2726,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: OPPO
@@ -2744,7 +2744,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: Kodak
@@ -2762,7 +2762,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Bmobile
@@ -2780,7 +2780,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Doogee
@@ -2798,7 +2798,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Stylo
@@ -2816,7 +2816,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Mobiistar
@@ -2834,7 +2834,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Vodafone
@@ -2852,7 +2852,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Vodafone
@@ -2870,7 +2870,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Vernee
@@ -2888,7 +2888,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Oukitel
@@ -2906,7 +2906,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Oukitel
@@ -2924,7 +2924,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Artel
@@ -2942,7 +2942,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Artel
@@ -2978,7 +2978,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -2996,7 +2996,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -3014,7 +3014,7 @@
     name: Chrome Webview
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -3032,7 +3032,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -3050,7 +3050,7 @@
     name: Chrome Webview
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -3068,7 +3068,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Oukitel
@@ -3086,7 +3086,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Oukitel
@@ -3104,7 +3104,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Oukitel
@@ -3122,7 +3122,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Stylo
@@ -3140,7 +3140,7 @@
     name: Opera Touch
     version: "2.9"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: ThL
@@ -3158,7 +3158,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Huawei
@@ -3176,7 +3176,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Epik One
@@ -3194,7 +3194,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Sky
@@ -3212,7 +3212,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Motorola
@@ -3230,7 +3230,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Motorola
@@ -3248,7 +3248,7 @@
     name: Opera Mobile
     version: 58.0.2254.58441
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: iTel
@@ -3284,7 +3284,7 @@
     name: Opera Mobile
     version: 61.0.2254.59937
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Neffos
@@ -3302,7 +3302,7 @@
     name: Opera Mobile
     version: 60.0.2254.59405
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Neffos
@@ -3338,7 +3338,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Mobicel
@@ -3356,7 +3356,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Konka
@@ -3374,7 +3374,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: M4tel
@@ -3392,7 +3392,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Mobicel
@@ -3410,7 +3410,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Hurricane
@@ -3428,7 +3428,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Samsung
@@ -3446,7 +3446,7 @@
     name: Chrome
     version: 78.0.3882.0
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3882.0"
   device:
     type: smartphone
     brand: Samsung
@@ -3464,7 +3464,7 @@
     name: Opera Touch
     version: "2.9"
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Samsung
@@ -3482,7 +3482,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Samsung
@@ -3500,7 +3500,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Xiaomi
@@ -3518,7 +3518,7 @@
     name: Chrome Mobile
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Xiaomi
@@ -3536,7 +3536,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -3554,7 +3554,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Zuum
@@ -3572,7 +3572,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Soho Style
@@ -3590,7 +3590,7 @@
     name: Yandex Browser
     version: "21.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Samsung
@@ -3608,7 +3608,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: ZTE
@@ -3626,7 +3626,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: ZTE
@@ -3644,7 +3644,7 @@
     name: Chrome Webview
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Wiko
@@ -3662,7 +3662,7 @@
     name: Chrome Webview
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: ZTE
@@ -3680,7 +3680,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: ZTE
@@ -3698,7 +3698,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Blu
@@ -3732,7 +3732,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Leagoo
@@ -3750,7 +3750,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Leagoo
@@ -3768,7 +3768,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Elephone
@@ -3786,7 +3786,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Samsung
@@ -3804,7 +3804,7 @@
     name: Opera Mobile
     version: 65.2.3381.61420
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Samsung
@@ -3822,7 +3822,7 @@
     name: Chrome Webview
     version: 89.0.4389.116
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.116"
   device:
     type: smartphone
     brand: Samsung
@@ -3840,7 +3840,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Samsung
@@ -3858,7 +3858,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Samsung
@@ -3876,7 +3876,7 @@
     name: Chrome Webview
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Fly
@@ -3894,7 +3894,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: General Mobile
@@ -3912,7 +3912,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: ZTE
@@ -3930,7 +3930,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: ZTE
@@ -3948,7 +3948,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: Senseit
@@ -3966,7 +3966,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Senseit
@@ -3984,7 +3984,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Senseit
@@ -4002,7 +4002,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Senseit
@@ -4020,7 +4020,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Senseit
@@ -4038,7 +4038,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Senseit
@@ -4056,7 +4056,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Senseit
@@ -4074,7 +4074,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Realme
@@ -4092,7 +4092,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -4110,7 +4110,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -4128,7 +4128,7 @@
     name: Chrome Webview
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -4146,7 +4146,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -4164,7 +4164,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: ZTE
@@ -4182,7 +4182,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: ZTE
@@ -4200,7 +4200,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: ZTE
@@ -4218,7 +4218,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Vivo
@@ -4236,7 +4236,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Mobicel
@@ -4254,7 +4254,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Vivo
@@ -4272,7 +4272,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Fujitsu
@@ -4290,7 +4290,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: OPPO
@@ -4308,7 +4308,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: ZTE
@@ -4344,7 +4344,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Sharp
@@ -4362,7 +4362,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: OPPO
@@ -4380,7 +4380,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Fujitsu
@@ -4398,7 +4398,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Sony
@@ -4416,7 +4416,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: iHunt
@@ -4434,7 +4434,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Realme
@@ -4468,7 +4468,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4486,7 +4486,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Xiaomi
@@ -4504,7 +4504,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: OPPO
@@ -4522,7 +4522,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: OPPO
@@ -4540,7 +4540,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: OPPO
@@ -4558,7 +4558,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: OPPO
@@ -4576,7 +4576,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Meizu
@@ -4594,7 +4594,7 @@
     name: Yandex Browser
     version: 21.115.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -4612,7 +4612,7 @@
     name: Yandex Browser
     version: 21.11.5.121.00
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Samsung
@@ -4630,7 +4630,7 @@
     name: Yandex Browser
     version: 21.53.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Smartisan
@@ -4648,7 +4648,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: MicroMax
@@ -4666,7 +4666,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: OnePlus
@@ -4684,7 +4684,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -4702,7 +4702,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -4720,7 +4720,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Vivo
@@ -4738,7 +4738,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Vivo
@@ -4756,7 +4756,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: Wiko
@@ -4774,7 +4774,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: ZTE
@@ -4792,7 +4792,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: iTel
@@ -4810,7 +4810,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: iTel
@@ -4828,7 +4828,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: iTel
@@ -4846,7 +4846,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: iTel
@@ -4864,7 +4864,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: iTel
@@ -4882,7 +4882,7 @@
     name: Chrome Webview
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Motorola
@@ -4900,7 +4900,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Motorola
@@ -4918,7 +4918,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Ulefone
@@ -4936,7 +4936,7 @@
     name: Opera Mobile
     version: 66.2.3445.62346
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Realme
@@ -4954,7 +4954,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Realme
@@ -4972,7 +4972,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Realme
@@ -4990,7 +4990,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Realme
@@ -5008,7 +5008,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Walton
@@ -5026,7 +5026,7 @@
     name: Chrome Webview
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Realme
@@ -5044,7 +5044,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: Ulefone
@@ -5062,7 +5062,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Motorola
@@ -5080,7 +5080,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Motorola
@@ -5098,7 +5098,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Motorola
@@ -5116,7 +5116,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Symphony
@@ -5134,7 +5134,7 @@
     name: Chrome Webview
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Zuum
@@ -5152,7 +5152,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Viumee
@@ -5170,7 +5170,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Hi
@@ -5188,7 +5188,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: NYX Mobile
@@ -5206,7 +5206,7 @@
     name: Chrome Mobile
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Hotwav
@@ -5224,7 +5224,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: QTECH
@@ -5260,7 +5260,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: NavRoad
@@ -5278,7 +5278,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: NavRoad
@@ -5296,7 +5296,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Xolo
@@ -5314,7 +5314,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: POCO
@@ -5332,7 +5332,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: Lava
@@ -5350,7 +5350,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: TechPad
@@ -5368,7 +5368,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Huawei
@@ -5386,7 +5386,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: MyPhone
@@ -5404,7 +5404,7 @@
     name: Chrome Webview
     version: 55.0.2883.77
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.77"
   device:
     type: smartphone
     brand: ZTE
@@ -5422,7 +5422,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Motorola
@@ -5440,7 +5440,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Sharp
@@ -5458,7 +5458,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: phablet
     brand: Samsung
@@ -5494,7 +5494,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Alcatel
@@ -5512,7 +5512,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: TCL
@@ -5530,7 +5530,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Alcatel
@@ -5548,7 +5548,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: DIXON
@@ -5566,7 +5566,7 @@
     name: Opera Mobile
     version: 65.1.3381.61266
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Huawei
@@ -5584,7 +5584,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Hurricane
@@ -5602,7 +5602,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: LeEco
@@ -5620,7 +5620,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Samsung
@@ -5638,7 +5638,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: HTC
@@ -5656,7 +5656,7 @@
     name: Chrome Mobile
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Santin
@@ -5674,7 +5674,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Santin
@@ -5692,7 +5692,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Walton
@@ -5710,7 +5710,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: M-Horse
@@ -5728,7 +5728,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: QMobile
@@ -5746,7 +5746,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: ZTE
@@ -5764,7 +5764,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: OPPO
@@ -5782,7 +5782,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: FiGO
@@ -5800,7 +5800,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Symphony
@@ -5818,7 +5818,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: BDQ
@@ -5836,7 +5836,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: RT Project
@@ -5854,7 +5854,7 @@
     name: Chrome Webview
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: TuCEL
@@ -5872,7 +5872,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: TuCEL
@@ -5890,7 +5890,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Sky
@@ -5908,7 +5908,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Polaroid
@@ -5926,7 +5926,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Prestigio
@@ -5944,7 +5944,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Prestigio
@@ -5980,7 +5980,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Matrix
@@ -5998,7 +5998,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Zuum
@@ -6016,7 +6016,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Zuum
@@ -6034,7 +6034,7 @@
     name: Chrome Webview
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Ziox
@@ -6052,7 +6052,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Ziox
@@ -6070,7 +6070,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Ziox
@@ -6088,7 +6088,7 @@
     name: Chrome Webview
     version: 50.0.2661.86
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Ziox
@@ -6124,7 +6124,7 @@
     name: Chrome Webview
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Ziox
@@ -6142,7 +6142,7 @@
     name: Opera Mobile
     version: 44.0.2254.140702
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Ziox
@@ -6160,7 +6160,7 @@
     name: Chrome Webview
     version: 59.0.3071.125
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Ziox
@@ -6178,7 +6178,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Ziox
@@ -6196,7 +6196,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Ziox
@@ -6214,7 +6214,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Ziox
@@ -6232,7 +6232,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Zen
@@ -6250,7 +6250,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Xtouch
@@ -6268,7 +6268,7 @@
     name: Chrome Mobile
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Xtouch
@@ -6286,7 +6286,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Xtouch
@@ -6304,7 +6304,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Xtouch
@@ -6322,7 +6322,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Bmobile
@@ -6340,7 +6340,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Mobicel
@@ -6358,7 +6358,7 @@
     name: Chrome Webview
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -6376,7 +6376,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: OPPO
@@ -6430,7 +6430,7 @@
     name: Chrome Mobile
     version: 46.0.2490.76
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Kyocera
@@ -6484,7 +6484,7 @@
     name: Chrome Webview
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: MicroMax
@@ -6502,7 +6502,7 @@
     name: Chrome Webview
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: MicroMax
@@ -6520,7 +6520,7 @@
     name: Yandex Browser
     version: 18.1.0.527.00
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.132"
   device:
     type: smartphone
     brand: MicroMax
@@ -6538,7 +6538,7 @@
     name: Chrome Webview
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: MicroMax
@@ -6556,7 +6556,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: MicroMax
@@ -6574,7 +6574,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: MicroMax
@@ -6592,7 +6592,7 @@
     name: Chrome Webview
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: MicroMax
@@ -6610,7 +6610,7 @@
     name: Opera Mobile
     version: 66.2.3445.62346
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: MicroMax
@@ -6628,7 +6628,7 @@
     name: Chrome Webview
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: ZTE
@@ -6754,7 +6754,7 @@
     name: Chrome Webview
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Sky
@@ -6772,7 +6772,7 @@
     name: Chrome Mobile
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Sony
@@ -6826,7 +6826,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Fujitsu
@@ -6844,7 +6844,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Kzen
@@ -6862,7 +6862,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: Smooth Mobile
@@ -6880,7 +6880,7 @@
     name: Chrome Webview
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: 4Good
@@ -6898,7 +6898,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Selfix
@@ -6916,7 +6916,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: AGM
@@ -6934,7 +6934,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: AGM
@@ -6952,7 +6952,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Lava
@@ -6986,7 +6986,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: AGM
@@ -7004,7 +7004,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: AGM
@@ -7038,7 +7038,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Azumi Mobile
@@ -7056,7 +7056,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: FiGO
@@ -7128,7 +7128,7 @@
     name: Chrome Mobile
     version: 33.0.1750.166
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: smartphone
     brand: Sharp
@@ -7146,7 +7146,7 @@
     name: Chrome Webview
     version: 67.0.3396.127
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.127"
   device:
     type: smartphone
     brand: Sharp
@@ -7164,7 +7164,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: AMGOO
@@ -7182,7 +7182,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Bush
@@ -7200,7 +7200,7 @@
     name: Chrome Webview
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: 'True'
@@ -7218,7 +7218,7 @@
     name: Chrome Webview
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: QMobile
@@ -7236,7 +7236,7 @@
     name: Chrome Mobile
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: QMobile
@@ -7254,7 +7254,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: QMobile
@@ -7272,7 +7272,7 @@
     name: Chrome Mobile
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: QMobile
@@ -7290,7 +7290,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: QMobile
@@ -7308,7 +7308,7 @@
     name: Chrome Webview
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Karbonn
@@ -7326,7 +7326,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Zen
@@ -7344,7 +7344,7 @@
     name: Chrome Webview
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Samsung
@@ -7362,7 +7362,7 @@
     name: Chrome Webview
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -7380,7 +7380,7 @@
     name: Chrome Webview
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -7398,7 +7398,7 @@
     name: Chrome Mobile
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Lava
@@ -7416,7 +7416,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Lava
@@ -7434,7 +7434,7 @@
     name: Chrome Webview
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Lava
@@ -7452,7 +7452,7 @@
     name: Chrome Webview
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Meitu
@@ -7470,7 +7470,7 @@
     name: Chrome Webview
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Walton
@@ -7488,7 +7488,7 @@
     name: Chrome Webview
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Walton
@@ -7506,7 +7506,7 @@
     name: Opera Mobile
     version: 59.1.2926.54067
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Walton
@@ -7524,7 +7524,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Walton
@@ -7542,7 +7542,7 @@
     name: Chrome Webview
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Walton
@@ -7560,7 +7560,7 @@
     name: Opera Mobile
     version: 51.0.2254.150807
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Maximus
@@ -7596,7 +7596,7 @@
     name: Chrome Webview
     version: 43.0.2357.121
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: M-Tech
@@ -7614,7 +7614,7 @@
     name: Chrome Webview
     version: 46.0.2490.76
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: M-Tech
@@ -7650,7 +7650,7 @@
     name: Chrome Webview
     version: 49.0.2623.105
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: smartphone
     brand: Spice
@@ -7668,7 +7668,7 @@
     name: Chrome Webview
     version: 50.0.2661.86
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Spice
@@ -7686,7 +7686,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Spice
@@ -7812,7 +7812,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Spice
@@ -7830,7 +7830,7 @@
     name: Chrome Webview
     version: 43.0.2357.121
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Spice
@@ -7848,7 +7848,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Intex
@@ -7866,7 +7866,7 @@
     name: Chrome Webview
     version: 43.0.2357.121
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Polaroid
@@ -7884,7 +7884,7 @@
     name: Chrome Mobile
     version: 95.0.3140.99
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.3140.99"
   device:
     type: smartphone
     brand: Huawei
@@ -7902,7 +7902,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Realme
@@ -7920,7 +7920,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Siragon
@@ -7938,7 +7938,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Realme
@@ -7956,7 +7956,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Blu
@@ -7974,7 +7974,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Saiet
@@ -7992,7 +7992,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: STG Telecom
@@ -8010,7 +8010,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Sharp
@@ -8028,7 +8028,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: OPPO
@@ -8046,7 +8046,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -8064,7 +8064,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -8082,7 +8082,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: OPPO
@@ -8100,7 +8100,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Realme
@@ -8118,7 +8118,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Realme
@@ -8136,7 +8136,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: POCO
@@ -8154,7 +8154,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: LG
@@ -8172,7 +8172,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: LG
@@ -8190,7 +8190,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Reeder
@@ -8208,7 +8208,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Reeder
@@ -8226,7 +8226,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Philco
@@ -8244,7 +8244,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Onda
@@ -8262,7 +8262,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: SPC
@@ -8280,7 +8280,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: SPC
@@ -8298,7 +8298,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: SPC
@@ -8334,7 +8334,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: SPC
@@ -8352,7 +8352,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: SPC
@@ -8370,7 +8370,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: SPC
@@ -8388,7 +8388,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Alcatel
@@ -8406,7 +8406,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Alcatel
@@ -8424,7 +8424,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Vsmart
@@ -8442,7 +8442,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: ZTE
@@ -8460,7 +8460,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: ZTE
@@ -8478,7 +8478,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Obabox
@@ -8514,7 +8514,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: QMobile
@@ -8532,7 +8532,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Advance
@@ -8550,7 +8550,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Gionee
@@ -8568,7 +8568,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8586,7 +8586,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8604,7 +8604,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -8622,7 +8622,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: iHunt
@@ -8640,7 +8640,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Samsung
@@ -8658,7 +8658,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Samsung
@@ -8676,7 +8676,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Samsung
@@ -8694,7 +8694,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: IMO Mobile
@@ -8712,7 +8712,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Hot Pepper
@@ -8730,7 +8730,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Hot Pepper
@@ -8748,7 +8748,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Ruio
@@ -8766,7 +8766,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: LG
@@ -8784,7 +8784,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: LG
@@ -8802,7 +8802,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: LG
@@ -8820,7 +8820,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: LG
@@ -8838,7 +8838,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: LG
@@ -8856,7 +8856,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Lava
@@ -8874,7 +8874,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Danew
@@ -8892,7 +8892,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Lava
@@ -8910,7 +8910,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Gigaset
@@ -8928,7 +8928,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Gplus
@@ -8964,7 +8964,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Gplus
@@ -8982,7 +8982,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Kyocera
@@ -9000,7 +9000,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Positivo
@@ -9018,7 +9018,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Walton
@@ -9036,7 +9036,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Walton
@@ -9054,7 +9054,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Sharp
@@ -9072,7 +9072,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Sharp
@@ -9126,7 +9126,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Samsung
@@ -9144,7 +9144,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Black Fox
@@ -9162,7 +9162,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Black Fox
@@ -9180,7 +9180,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Xiaomi
@@ -9198,7 +9198,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Ulefone
@@ -9216,7 +9216,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Ulefone
@@ -9234,7 +9234,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Benco
@@ -9252,7 +9252,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Benco
@@ -9270,7 +9270,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Black Fox
@@ -9288,7 +9288,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Black Fox
@@ -9306,7 +9306,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: OPPO
@@ -9324,7 +9324,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: OnePlus
@@ -9342,7 +9342,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: LG
@@ -9360,7 +9360,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -9378,7 +9378,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: iHunt
@@ -9396,7 +9396,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Coolpad
@@ -9414,7 +9414,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Huawei
@@ -9432,7 +9432,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -9450,7 +9450,7 @@
     name: Chrome Mobile
     version: 97.0.4692.70
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.70"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -9468,7 +9468,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: F150
@@ -9486,7 +9486,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Lava
@@ -9504,7 +9504,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Motorola
@@ -9522,7 +9522,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Lenovo
@@ -9540,7 +9540,7 @@
     name: Chrome Mobile
     version: 95.0.4638.114
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.114"
   device:
     type: smartphone
     brand: OPPO
@@ -9576,7 +9576,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Xiaomi
@@ -9594,7 +9594,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Xiaomi
@@ -9612,7 +9612,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Samsung
@@ -9630,7 +9630,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Samsung
@@ -9648,7 +9648,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Samsung
@@ -9666,7 +9666,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Samsung
@@ -9684,7 +9684,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Evolveo
@@ -9702,7 +9702,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Mobicel
@@ -9720,7 +9720,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Gplus
@@ -9738,7 +9738,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: TCL
@@ -9756,7 +9756,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Alcatel
@@ -9774,7 +9774,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Alcatel
@@ -9792,7 +9792,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: bq
@@ -9810,7 +9810,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9828,7 +9828,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9846,7 +9846,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9864,7 +9864,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Wiko
@@ -9882,7 +9882,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Sony
@@ -9900,7 +9900,7 @@
     name: Chrome Mobile
     version: 97.0.4692.70
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.70"
   device:
     type: smartphone
     brand: Sony
@@ -9918,7 +9918,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Asus
@@ -9936,7 +9936,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: ZTE
@@ -9954,7 +9954,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Lenovo
@@ -9972,7 +9972,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: OnePlus
@@ -9990,7 +9990,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Samsung

--- a/Tests/fixtures/smartphone-29.yml
+++ b/Tests/fixtures/smartphone-29.yml
@@ -10,7 +10,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: phablet
     brand: Samsung
@@ -64,7 +64,7 @@
     name: Microsoft Edge
     version: 96.0.1054.62
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.110"
   device:
     type: smartphone
     brand: Motorola
@@ -82,7 +82,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: TCL
@@ -100,7 +100,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Samsung
@@ -118,7 +118,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Samsung
@@ -136,7 +136,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Samsung
@@ -154,7 +154,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: phablet
     brand: Samsung
@@ -172,7 +172,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: iTel
@@ -190,7 +190,7 @@
     name: Chrome Webview
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Fly
@@ -208,7 +208,7 @@
     name: Yandex Browser
     version: 22.1.0.365.00
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.116"
   device:
     type: smartphone
     brand: Infinix
@@ -226,7 +226,7 @@
     name: Yandex Browser
     version: 22.11.1
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.116"
   device:
     type: smartphone
     brand: HTC
@@ -244,7 +244,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Infinix
@@ -262,7 +262,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Infinix
@@ -280,7 +280,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Infinix
@@ -298,7 +298,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Infinix
@@ -316,7 +316,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: iSafe Mobile
@@ -334,7 +334,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Casper
@@ -352,7 +352,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Casper
@@ -370,7 +370,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: ZTE
@@ -388,7 +388,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: ZTE
@@ -406,7 +406,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: ZTE
@@ -424,7 +424,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: TCL
@@ -442,7 +442,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: MicroMax
@@ -460,7 +460,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Logicom
@@ -478,7 +478,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Philco
@@ -496,7 +496,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: POCO
@@ -514,7 +514,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: LG
@@ -532,7 +532,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -550,7 +550,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: OnePlus
@@ -568,7 +568,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Blu
@@ -586,7 +586,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: TCL
@@ -604,7 +604,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: TCL
@@ -622,7 +622,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: TCL
@@ -640,7 +640,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: TCL
@@ -658,7 +658,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: TCL
@@ -676,7 +676,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: TCL
@@ -694,7 +694,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: TCL
@@ -712,7 +712,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Vivo
@@ -730,7 +730,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Vivo
@@ -748,7 +748,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Realme
@@ -766,7 +766,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Vivo
@@ -784,7 +784,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Allview
@@ -802,7 +802,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Vivo
@@ -820,7 +820,7 @@
     name: Yandex Browser
     version: 20.85.1
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: smartphone
     brand: Infinix
@@ -838,7 +838,7 @@
     name: Yandex Browser
     version: "21.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Infinix
@@ -856,7 +856,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Gome
@@ -874,7 +874,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: iHunt
@@ -892,7 +892,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Vivax
@@ -910,7 +910,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: iHunt
@@ -928,7 +928,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Ulefone
@@ -946,7 +946,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Casper
@@ -964,7 +964,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Wiko
@@ -982,7 +982,7 @@
     name: Opera Mobile
     version: 62.1.2254.60552
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: iTel
@@ -1000,7 +1000,7 @@
     name: Yandex Browser
     version: 22.11.1
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.116"
   device:
     type: smartphone
     brand: iTel
@@ -1018,7 +1018,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: iTel
@@ -1036,7 +1036,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: phablet
     brand: Xiaomi
@@ -1054,7 +1054,7 @@
     name: Yandex Browser
     version: 22.12.1
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.116"
   device:
     type: smartphone
     brand: Elephone
@@ -1072,7 +1072,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: iTel
@@ -1090,7 +1090,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Vestel
@@ -1108,7 +1108,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Doogee
@@ -1126,7 +1126,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: Lava
@@ -1144,7 +1144,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: MicroMax
@@ -1162,7 +1162,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Telefunken
@@ -1180,7 +1180,7 @@
     name: Chrome Webview
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Reach
@@ -1198,7 +1198,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Ookee
@@ -1216,7 +1216,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Doogee
@@ -1234,7 +1234,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Doogee
@@ -1252,7 +1252,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Doogee
@@ -1288,7 +1288,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Blu
@@ -1306,7 +1306,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: b2m
@@ -1324,7 +1324,7 @@
     name: Opera Mobile
     version: 58.4.2878.56737
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Telefunken
@@ -1342,7 +1342,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Telefunken
@@ -1360,7 +1360,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Karbonn
@@ -1378,7 +1378,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Massgo
@@ -1396,7 +1396,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Massgo
@@ -1414,7 +1414,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Massgo
@@ -1432,7 +1432,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Massgo
@@ -1450,7 +1450,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Massgo
@@ -1468,7 +1468,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -1486,7 +1486,7 @@
     name: Chrome Webview
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Starlight
@@ -1504,7 +1504,7 @@
     name: Opera Mobile
     version: 62.1.2254.60552
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Gionee
@@ -1522,7 +1522,7 @@
     name: Opera Mobile
     version: 62.1.2254.60552
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Hisense
@@ -1540,7 +1540,7 @@
     name: Opera Mobile
     version: 61.0.2254.59937
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Hisense
@@ -1558,7 +1558,7 @@
     name: Opera Mobile
     version: 62.1.2254.60551
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Hisense
@@ -1576,7 +1576,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Hisense
@@ -1594,7 +1594,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Hisense
@@ -1612,7 +1612,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Hisense
@@ -1630,7 +1630,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Hisense
@@ -1648,7 +1648,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Hisense
@@ -1666,7 +1666,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Hisense
@@ -1684,7 +1684,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Hisense
@@ -1702,7 +1702,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Realme
@@ -1720,7 +1720,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: OMIX
@@ -1738,7 +1738,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -1756,7 +1756,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: Bluebird
@@ -1774,7 +1774,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Asus
@@ -1792,7 +1792,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Wexler
@@ -1810,7 +1810,7 @@
     name: Opera Mobile
     version: 50.6.2426.201126
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: iPEGTOP
@@ -1828,7 +1828,7 @@
     name: Chrome Mobile
     version: 38.0.2125.102
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: smartphone
     brand: Gigabyte
@@ -1846,7 +1846,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Nexa
@@ -1864,7 +1864,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: SWISSMOBILITY
@@ -1898,7 +1898,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Huawei
@@ -1934,7 +1934,7 @@
     name: Huawei Browser Mobile
     version: 11.1.2.332
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Hi Nova
@@ -1952,7 +1952,7 @@
     name: Chrome Webview
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Samsung
@@ -1970,7 +1970,7 @@
     name: Chrome Webview
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Realme
@@ -2042,7 +2042,7 @@
     name: Huawei Browser Mobile
     version: 12.0.3.310
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -2060,7 +2060,7 @@
     name: Chrome Webview
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: ZTE
@@ -2078,7 +2078,7 @@
     name: Chrome Webview
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: ZTE
@@ -2096,7 +2096,7 @@
     name: Microsoft Edge
     version: 97.0.1072.78
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.99"
   device:
     type: smartphone
     brand: OPPO
@@ -2114,7 +2114,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Realme
@@ -2132,7 +2132,7 @@
     name: Chrome Webview
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Realme
@@ -2150,7 +2150,7 @@
     name: Chrome Webview
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Realme
@@ -2168,7 +2168,7 @@
     name: Chrome Webview
     version: 90.0.4430.61
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.61"
   device:
     type: smartphone
     brand: Realme
@@ -2186,7 +2186,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Onkyo
@@ -2204,7 +2204,7 @@
     name: Huawei Browser Mobile
     version: 12.0.2.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -2222,7 +2222,7 @@
     name: Huawei Browser Mobile
     version: 12.0.0.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -2240,7 +2240,7 @@
     name: Huawei Browser Mobile
     version: 12.0.1.300
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -2258,7 +2258,7 @@
     name: Chrome Webview
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: OPPO
@@ -2276,7 +2276,7 @@
     name: Chrome Webview
     version: 90.0.4430.61
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.61"
   device:
     type: smartphone
     brand: OPPO
@@ -2294,7 +2294,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Vivo
@@ -2438,7 +2438,7 @@
     name: Chrome Webview
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Vivo
@@ -2456,7 +2456,7 @@
     name: Chrome Webview
     version: 75.0.3770.156
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.156"
   device:
     type: smartphone
     brand: Coolpad
@@ -2474,7 +2474,7 @@
     name: Chrome Mobile
     version: 71.0.3578.98
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.98"
   device:
     type: smartphone
     brand: Smartfren
@@ -2492,7 +2492,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: KOPO
@@ -2510,7 +2510,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: KOPO
@@ -2546,7 +2546,7 @@
     name: Chrome Webview
     version: 75.0.3770.156
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.156"
   device:
     type: smartphone
     brand: Gionee
@@ -2564,7 +2564,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Gionee
@@ -2598,7 +2598,7 @@
     name: Huawei Browser Mobile
     version: 12.0.0.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: U-Magic
@@ -2616,7 +2616,7 @@
     name: Microsoft Edge
     version: 97.0.1072.78
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.99"
   device:
     type: smartphone
     brand: U-Magic
@@ -2670,7 +2670,7 @@
     name: Huawei Browser Mobile
     version: 12.0.3.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -2706,7 +2706,7 @@
     name: Huawei Browser Mobile
     version: 11.1.1.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: China Telecom
@@ -2758,7 +2758,7 @@
     name: Chrome Mobile
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: ZTE
@@ -2776,7 +2776,7 @@
     name: Chrome Webview
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: ZTE
@@ -2794,7 +2794,7 @@
     name: Chrome Webview
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Xiaomi
@@ -2812,7 +2812,7 @@
     name: Chrome Webview
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Xiaomi
@@ -2830,7 +2830,7 @@
     name: Chrome Webview
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Xiaomi
@@ -2848,7 +2848,7 @@
     name: Huawei Browser Mobile
     version: 11.1.2.330
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -2866,7 +2866,7 @@
     name: Huawei Browser Mobile
     version: 12.0.2.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -2884,7 +2884,7 @@
     name: Huawei Browser Mobile
     version: 12.0.3.310
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -2902,7 +2902,7 @@
     name: Huawei Browser Mobile
     version: 12.0.3.310
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -2920,7 +2920,7 @@
     name: Huawei Browser Mobile
     version: 12.0.2.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -2938,7 +2938,7 @@
     name: Huawei Browser Mobile
     version: 12.0.0.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -2956,7 +2956,7 @@
     name: Huawei Browser Mobile
     version: 12.0.0.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -2974,7 +2974,7 @@
     name: Huawei Browser Mobile
     version: 12.0.3.310
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -2992,7 +2992,7 @@
     name: Chrome Webview
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: DORLAND
@@ -3010,7 +3010,7 @@
     name: Huawei Browser Mobile
     version: 12.0.0.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -3028,7 +3028,7 @@
     name: Chrome Webview
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -3082,7 +3082,7 @@
     name: Chrome Webview
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Xiaomi
@@ -3100,7 +3100,7 @@
     name: Huawei Browser Mobile
     version: 12.0.3.310
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -3118,7 +3118,7 @@
     name: Huawei Browser Mobile
     version: 12.0.3.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -3136,7 +3136,7 @@
     name: Chrome Webview
     version: 83.0.4103.120
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.120"
   device:
     type: smartphone
     brand: Conquest
@@ -3154,7 +3154,7 @@
     name: Huawei Browser Mobile
     version: 12.0.3.310
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -3172,7 +3172,7 @@
     name: Huawei Browser Mobile
     version: 12.0.0.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -3190,7 +3190,7 @@
     name: Huawei Browser Mobile
     version: 12.0.3.310
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -3208,7 +3208,7 @@
     name: Huawei Browser Mobile
     version: 12.0.3.310
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -3226,7 +3226,7 @@
     name: Huawei Browser Mobile
     version: 12.0.3.310
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -3260,7 +3260,7 @@
     name: Huawei Browser Mobile
     version: 12.0.3.310
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -3278,7 +3278,7 @@
     name: Huawei Browser Mobile
     version: 12.0.3.310
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -3296,7 +3296,7 @@
     name: Chrome Webview
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -3314,7 +3314,7 @@
     name: Huawei Browser Mobile
     version: 12.0.3.310
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -3332,7 +3332,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.311
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -3350,7 +3350,7 @@
     name: Chrome Webview
     version: 90.0.4430.61
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.61"
   device:
     type: smartphone
     brand: OPPO
@@ -3368,7 +3368,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Lava
@@ -3548,7 +3548,7 @@
     name: Chrome Webview
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: OPPO
@@ -3584,7 +3584,7 @@
     name: Chrome Webview
     version: 90.0.4430.61
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.61"
   device:
     type: smartphone
     brand: OPPO
@@ -3638,7 +3638,7 @@
     name: Chrome Webview
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Angelcare
@@ -3692,7 +3692,7 @@
     name: Chrome Mobile
     version: 89.0.4389.72
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.72"
   device:
     type: smartphone
     brand: OPPO
@@ -3710,7 +3710,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: OPPO
@@ -3728,7 +3728,7 @@
     name: Chrome Webview
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: OPPO
@@ -3746,7 +3746,7 @@
     name: Chrome Webview
     version: 58.0.3029.125
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.125"
   device:
     type: smartphone
     brand: Condor
@@ -3764,7 +3764,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: MTC
@@ -3782,7 +3782,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Soyes
@@ -3800,7 +3800,7 @@
     name: Chrome Mobile
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Highscreen
@@ -3834,7 +3834,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: LG
@@ -3852,7 +3852,7 @@
     name: Chrome Webview
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: ZTE
@@ -3870,7 +3870,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Logicom
@@ -3888,7 +3888,7 @@
     name: Chrome Mobile
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Quantum
@@ -3906,7 +3906,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Sugar
@@ -3924,7 +3924,7 @@
     name: Chrome Webview
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Sugar
@@ -3958,7 +3958,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Blu
@@ -4120,7 +4120,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Realme
@@ -4138,7 +4138,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: POCO
@@ -4156,7 +4156,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -4174,7 +4174,7 @@
     name: Huawei Browser Mobile
     version: 11.0.8.305
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Huawei
@@ -4192,7 +4192,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: smartphone
     brand: Huawei
@@ -4210,7 +4210,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Vivo
@@ -4228,7 +4228,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: OPPO
@@ -4246,7 +4246,7 @@
     name: Chrome Webview
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Motorola
@@ -4264,7 +4264,7 @@
     name: Chrome Webview
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: Motorola
@@ -4282,7 +4282,7 @@
     name: Chrome Webview
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Motorola
@@ -4300,7 +4300,7 @@
     name: Chrome Mobile
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: ZTE
@@ -4318,7 +4318,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: ZTE
@@ -4336,7 +4336,7 @@
     name: Chrome Mobile
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: smartphone
     brand: ZTE
@@ -4354,7 +4354,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: ZTE
@@ -4372,7 +4372,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: ZTE
@@ -4390,7 +4390,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: ZTE
@@ -4408,7 +4408,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: ZTE
@@ -4426,7 +4426,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: ZTE
@@ -4444,7 +4444,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: ZTE
@@ -4462,7 +4462,7 @@
     name: Yandex Browser
     version: 18.1.1.642.00
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.132"
   device:
     type: smartphone
     brand: ZTE
@@ -4480,7 +4480,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: ZTE
@@ -4514,7 +4514,7 @@
     name: Chrome Mobile
     version: 45.0.2454.94
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.94"
   device:
     type: smartphone
     brand: "360"
@@ -4532,7 +4532,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: ecom
@@ -4550,7 +4550,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: ZTE
@@ -4584,7 +4584,7 @@
     name: Chrome Webview
     version: 69.0.3497.86
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.86"
   device:
     type: smartphone
     brand: SFR
@@ -4602,7 +4602,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: STK
@@ -4620,7 +4620,7 @@
     name: Chrome Mobile
     version: 66.0.3359.126
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: STK
@@ -4638,7 +4638,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Konrow
@@ -4656,7 +4656,7 @@
     name: Chrome Mobile
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Doogee
@@ -4674,7 +4674,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Archos
@@ -4692,7 +4692,7 @@
     name: Chrome Mobile
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: smartphone
     brand: Zen
@@ -4710,7 +4710,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: TechPad
@@ -4728,7 +4728,7 @@
     name: Chrome Mobile
     version: 85.0.4183.120
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: smartphone
     brand: S-TELL
@@ -4746,7 +4746,7 @@
     name: Chrome Webview
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Joy
@@ -4764,7 +4764,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Joy
@@ -4782,7 +4782,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Joy
@@ -4800,7 +4800,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: smartphone
     brand: iHunt
@@ -4818,7 +4818,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Leader Phone
@@ -4836,7 +4836,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Leader Phone
@@ -4854,7 +4854,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: QMobile
@@ -4872,7 +4872,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Positivo BGH
@@ -4890,7 +4890,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Condor
@@ -4908,7 +4908,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: iHunt
@@ -4926,7 +4926,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Logicom

--- a/Tests/fixtures/smartphone-3.yml
+++ b/Tests/fixtures/smartphone-3.yml
@@ -10,7 +10,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Bravis
@@ -46,7 +46,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Bravis
@@ -64,7 +64,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Bravis
@@ -82,7 +82,7 @@
     name: Opera Mobile
     version: "55.1.2719.50626"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Bravis
@@ -100,7 +100,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Bravis
@@ -118,7 +118,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Bravis
@@ -136,7 +136,7 @@
     name: Opera Mobile
     version: "55.1.2719.50626"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Bravis
@@ -154,7 +154,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Bravis
@@ -190,7 +190,7 @@
     name: Chrome Mobile
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: Bravis
@@ -208,7 +208,7 @@
     name: Chrome Mobile
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: smartphone
     brand: Bravis
@@ -348,7 +348,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: bq
@@ -366,7 +366,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: bq
@@ -438,7 +438,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: bq
@@ -456,7 +456,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: bq
@@ -474,7 +474,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: bq
@@ -492,7 +492,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: bq
@@ -510,7 +510,7 @@
     name: Chrome Mobile
     version: "40.0.2214.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: smartphone
     brand: bq
@@ -528,7 +528,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: bq
@@ -546,7 +546,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: bq
@@ -564,7 +564,7 @@
     name: Chrome Mobile
     version: "72.0.3626.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: bq
@@ -582,7 +582,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: bq
@@ -600,7 +600,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: bq
@@ -618,7 +618,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: bq
@@ -636,7 +636,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: bq
@@ -654,7 +654,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: bq
@@ -672,7 +672,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: bq
@@ -690,7 +690,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: bq
@@ -708,7 +708,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: bq
@@ -726,7 +726,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: bq
@@ -744,7 +744,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: bq
@@ -762,7 +762,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: bq
@@ -780,7 +780,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: bq
@@ -798,7 +798,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: bq
@@ -816,7 +816,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: bq
@@ -834,7 +834,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: bq
@@ -852,7 +852,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: bq
@@ -870,7 +870,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: bq
@@ -888,7 +888,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: bq
@@ -906,7 +906,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: bq
@@ -924,7 +924,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: bq
@@ -942,7 +942,7 @@
     name: Yandex Browser
     version: "19.6.0.612.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.169"
   device:
     type: smartphone
     brand: bq
@@ -960,7 +960,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: bq
@@ -978,7 +978,7 @@
     name: Yandex Browser
     version: "19.6.1.396.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.169"
   device:
     type: smartphone
     brand: bq
@@ -996,7 +996,7 @@
     name: Chrome Webview
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: bq
@@ -1014,7 +1014,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: bq
@@ -1032,7 +1032,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: bq
@@ -1068,7 +1068,7 @@
     name: Yandex Browser
     version: "18.4.0.649.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.181"
   device:
     type: smartphone
     brand: bq
@@ -1086,7 +1086,7 @@
     name: Chrome Webview
     version: "43.0.2357.65"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.65"
   device:
     type: smartphone
     brand: bq
@@ -1104,7 +1104,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: bq
@@ -1158,7 +1158,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: bq
@@ -1176,7 +1176,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: bq
@@ -1194,7 +1194,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: bq
@@ -1212,7 +1212,7 @@
     name: Yandex Browser
     version: "19.4.3.352.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.103"
   device:
     type: smartphone
     brand: bq
@@ -1230,7 +1230,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: bq
@@ -1248,7 +1248,7 @@
     name: Chrome Webview
     version: "43.0.2357.65"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.65"
   device:
     type: smartphone
     brand: bq
@@ -1266,7 +1266,7 @@
     name: Opera Mobile
     version: "52.2.2517.139816"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: bq
@@ -1302,7 +1302,7 @@
     name: Yandex Browser
     version: "14.5.1847.18432.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.131"
   device:
     type: smartphone
     brand: bq
@@ -1320,7 +1320,7 @@
     name: Yandex Browser
     version: "17.11.1.628.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.94"
   device:
     type: smartphone
     brand: bq
@@ -1338,7 +1338,7 @@
     name: Opera Mobile
     version: "51.3.2461.138727"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: bq
@@ -1374,7 +1374,7 @@
     name: Yandex Browser
     version: "19.4.5.141.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.103"
   device:
     type: smartphone
     brand: bq
@@ -1392,7 +1392,7 @@
     name: Yandex Browser
     version: "19.4.5.141.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.103"
   device:
     type: smartphone
     brand: bq
@@ -1410,7 +1410,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: bq
@@ -1446,7 +1446,7 @@
     name: Chrome Webview
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: bq
@@ -1464,7 +1464,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: bq
@@ -1482,7 +1482,7 @@
     name: Yandex Browser
     version: "19.6.1.396.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.169"
   device:
     type: smartphone
     brand: bq
@@ -1500,7 +1500,7 @@
     name: Yandex Browser
     version: "8.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: bq
@@ -1518,7 +1518,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: bq
@@ -1536,7 +1536,7 @@
     name: Chrome Webview
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: bq
@@ -1554,7 +1554,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: bq
@@ -1572,7 +1572,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: bq
@@ -1590,7 +1590,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: bq
@@ -1626,7 +1626,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: bq
@@ -1644,7 +1644,7 @@
     name: Yandex Browser
     version: "15.10.2454.3908.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.101"
   device:
     type: smartphone
     brand: bq
@@ -1662,7 +1662,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: bq
@@ -1698,7 +1698,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: bq
@@ -1716,7 +1716,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: bq
@@ -1734,7 +1734,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: bq
@@ -1752,7 +1752,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: bq
@@ -1770,7 +1770,7 @@
     name: Chrome Webview
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: bq
@@ -1788,7 +1788,7 @@
     name: Chrome Webview
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: bq
@@ -1806,7 +1806,7 @@
     name: Yandex Browser
     version: "9.60"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: bq
@@ -1824,7 +1824,7 @@
     name: Yandex Browser
     version: "18.11.2.730.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: smartphone
     brand: bq
@@ -1842,7 +1842,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: bq
@@ -1860,7 +1860,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: bq
@@ -1878,7 +1878,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: bq
@@ -1896,7 +1896,7 @@
     name: Opera Mobile
     version: "40.1.2254.138129"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: bq
@@ -1914,7 +1914,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: bq
@@ -1932,7 +1932,7 @@
     name: Opera Mobile
     version: "47.0.2254.146543"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: bq
@@ -1950,7 +1950,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: bq
@@ -1968,7 +1968,7 @@
     name: Yandex Browser
     version: "18.10.2.113.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: bq
@@ -2004,7 +2004,7 @@
     name: Yandex Browser
     version: "19.6.4.48.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.169"
   device:
     type: smartphone
     brand: bq
@@ -2040,7 +2040,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: bq
@@ -2058,7 +2058,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: bq
@@ -2076,7 +2076,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: bq
@@ -2094,7 +2094,7 @@
     name: Yandex Browser
     version: "19.6.1.396.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.169"
   device:
     type: smartphone
     brand: bq
@@ -2112,7 +2112,7 @@
     name: Yandex Browser
     version: "19.4.1.454.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.103"
   device:
     type: smartphone
     brand: bq
@@ -2130,7 +2130,7 @@
     name: Chrome Webview
     version: "43.0.2357.65"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.65"
   device:
     type: smartphone
     brand: bq
@@ -2148,7 +2148,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: bq
@@ -2166,7 +2166,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: bq
@@ -2184,7 +2184,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: bq
@@ -2202,7 +2202,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: bq
@@ -2220,7 +2220,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: bq
@@ -2238,7 +2238,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: bq
@@ -2256,7 +2256,7 @@
     name: Yandex Browser
     version: "8.40"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: bq
@@ -2326,7 +2326,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: bq
@@ -2362,7 +2362,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: bq
@@ -2380,7 +2380,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: bq
@@ -2398,7 +2398,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: bq
@@ -2434,7 +2434,7 @@
     name: Chrome Webview
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: bq
@@ -2470,7 +2470,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: bq
@@ -2506,7 +2506,7 @@
     name: Chrome Webview
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: bq
@@ -2524,7 +2524,7 @@
     name: Chrome Webview
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: bq
@@ -2542,7 +2542,7 @@
     name: Chrome Webview
     version: "43.0.2357.65"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.65"
   device:
     type: smartphone
     brand: bq
@@ -2560,7 +2560,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: bq
@@ -2578,7 +2578,7 @@
     name: Chrome Webview
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: bq
@@ -2596,7 +2596,7 @@
     name: Chrome Webview
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: bq
@@ -2614,7 +2614,7 @@
     name: Opera Mobile
     version: "42.0.2254.139276"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: bq
@@ -2632,7 +2632,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: bq
@@ -2668,7 +2668,7 @@
     name: Chrome Mobile
     version: "49.0.2623.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: smartphone
     brand: bq
@@ -2686,7 +2686,7 @@
     name: Yandex Browser
     version: "7.50"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: bq
@@ -2704,7 +2704,7 @@
     name: Chrome Webview
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: bq
@@ -2722,7 +2722,7 @@
     name: Chrome Webview
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: bq
@@ -2740,7 +2740,7 @@
     name: Yandex Browser
     version: "17.11.1.632.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.94"
   device:
     type: smartphone
     brand: bq
@@ -2758,7 +2758,7 @@
     name: Chrome Webview
     version: "43.0.2357.65"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.65"
   device:
     type: smartphone
     brand: bq
@@ -2776,7 +2776,7 @@
     name: Yandex Browser
     version: "18.9.2.31.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.106"
   device:
     type: smartphone
     brand: bq
@@ -2794,7 +2794,7 @@
     name: Chrome Webview
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: bq
@@ -2812,7 +2812,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: bq
@@ -2830,7 +2830,7 @@
     name: Chrome Webview
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: bq
@@ -2848,7 +2848,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: bq
@@ -2866,7 +2866,7 @@
     name: Chrome Webview
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: bq
@@ -2884,7 +2884,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: bq
@@ -2902,7 +2902,7 @@
     name: Chrome Mobile
     version: "74.0.3729.112"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: smartphone
     brand: bq
@@ -2920,7 +2920,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: bq
@@ -2938,7 +2938,7 @@
     name: Chrome Mobile
     version: "71.0.3578.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.98"
   device:
     type: smartphone
     brand: bq
@@ -2956,7 +2956,7 @@
     name: Opera Mobile
     version: "46.0.2254.145391"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: bq
@@ -2974,7 +2974,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: bq
@@ -2992,7 +2992,7 @@
     name: Opera Mobile
     version: "47.1.2254.147528"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: bq
@@ -3010,7 +3010,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: bq
@@ -3028,7 +3028,7 @@
     name: Yandex Browser
     version: "17.1.0.412.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.95"
   device:
     type: smartphone
     brand: bq
@@ -3046,7 +3046,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: bq
@@ -3064,7 +3064,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: bq
@@ -3082,7 +3082,7 @@
     name: Yandex Browser
     version: "14.5.1847.18432.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.131"
   device:
     type: smartphone
     brand: bq
@@ -3100,7 +3100,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: bq
@@ -3136,7 +3136,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: bq
@@ -3154,7 +3154,7 @@
     name: Opera Mobile
     version: "43.2.2254.140293"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: bq
@@ -3172,7 +3172,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: bq
@@ -3190,7 +3190,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: bq
@@ -3208,7 +3208,7 @@
     name: Yandex Browser
     version: "8.50"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.169"
   device:
     type: smartphone
     brand: bq
@@ -3226,7 +3226,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: bq
@@ -3262,7 +3262,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: bq
@@ -3280,7 +3280,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: bq
@@ -3298,7 +3298,7 @@
     name: Chrome Webview
     version: "43.0.2357.65"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.65"
   device:
     type: smartphone
     brand: bq
@@ -3316,7 +3316,7 @@
     name: Chrome Mobile
     version: "42.0.2311.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.68"
   device:
     type: smartphone
     brand: bq
@@ -3334,7 +3334,7 @@
     name: Yandex Browser
     version: "14.5.1847.18432.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.131"
   device:
     type: smartphone
     brand: bq
@@ -3424,7 +3424,7 @@
     name: Yandex Browser
     version: "14.5.1847.18432.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.131"
   device:
     type: smartphone
     brand: bq
@@ -3442,7 +3442,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: bq
@@ -3460,7 +3460,7 @@
     name: Chrome Webview
     version: "50.0.2661.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: bq
@@ -3478,7 +3478,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: bq
@@ -3496,7 +3496,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Bezkam
@@ -3514,7 +3514,7 @@
     name: Chrome Webview
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Clout
@@ -3566,7 +3566,7 @@
     name: Opera Mobile
     version: "33.0.2254.125672"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Clout
@@ -3584,7 +3584,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Clout
@@ -3602,7 +3602,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Clout
@@ -3620,7 +3620,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Clout
@@ -3638,7 +3638,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Crosscall
@@ -3656,7 +3656,7 @@
     name: Chrome Mobile
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Crosscall
@@ -3692,7 +3692,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Crosscall
@@ -3728,7 +3728,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Crosscall
@@ -3746,7 +3746,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Crosscall
@@ -3764,7 +3764,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Crosscall
@@ -3782,7 +3782,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Crosscall
@@ -3800,7 +3800,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Crosscall
@@ -3836,7 +3836,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: China Mobile
@@ -3854,7 +3854,7 @@
     name: Chrome Mobile
     version: "30.0.1599.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.92"
   device:
     type: smartphone
     brand: China Mobile
@@ -3872,7 +3872,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: China Mobile
@@ -3908,7 +3908,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: China Mobile
@@ -3926,7 +3926,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: China Mobile
@@ -3944,7 +3944,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Cyrus
@@ -3962,7 +3962,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Cyrus
@@ -3980,7 +3980,7 @@
     name: Chrome Mobile
     version: "48.0.2564.95"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.95"
   device:
     type: smartphone
     brand: Condor
@@ -3998,7 +3998,7 @@
     name: Chrome Mobile
     version: "59.0.3071.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.92"
   device:
     type: smartphone
     brand: Condor
@@ -4016,7 +4016,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Condor
@@ -4052,7 +4052,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Condor
@@ -4070,7 +4070,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Condor
@@ -4106,7 +4106,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Condor
@@ -4124,7 +4124,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Condor
@@ -4142,7 +4142,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Condor
@@ -4160,7 +4160,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Condor
@@ -4178,7 +4178,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Condor
@@ -4214,7 +4214,7 @@
     name: Chrome Mobile
     version: "38.0.2125.102"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: smartphone
     brand: Condor
@@ -4232,7 +4232,7 @@
     name: Chrome Webview
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Condor
@@ -4250,7 +4250,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Condor
@@ -4268,7 +4268,7 @@
     name: Chrome Mobile
     version: "60.0.3112.50"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.50"
   device:
     type: smartphone
     brand: Condor
@@ -4286,7 +4286,7 @@
     name: Chrome Mobile
     version: "45.0.2454.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.84"
   device:
     type: smartphone
     brand: Condor
@@ -4304,7 +4304,7 @@
     name: Chrome Mobile
     version: "49.0.2623.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: smartphone
     brand: Condor
@@ -4322,7 +4322,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Condor
@@ -4340,7 +4340,7 @@
     name: Chrome Webview
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Condor
@@ -4358,7 +4358,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Condor
@@ -4394,7 +4394,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Condor
@@ -4430,7 +4430,7 @@
     name: Chrome Webview
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Condor
@@ -4448,7 +4448,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Condor
@@ -4466,7 +4466,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Condor
@@ -4484,7 +4484,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Condor
@@ -4502,7 +4502,7 @@
     name: Chrome Mobile
     version: "80.0.3987.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Condor
@@ -4520,7 +4520,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Condor
@@ -4538,7 +4538,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Condor
@@ -4556,7 +4556,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Condor
@@ -4574,7 +4574,7 @@
     name: Chrome Webview
     version: "59.0.3071.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.92"
   device:
     type: smartphone
     brand: Condor
@@ -4592,7 +4592,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Condor
@@ -4610,7 +4610,7 @@
     name: Opera Mobile
     version: "35.0.2254.127755"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Condor
@@ -4628,7 +4628,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Condor
@@ -4646,7 +4646,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Condor
@@ -4664,7 +4664,7 @@
     name: Chrome Webview
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Condor
@@ -4682,7 +4682,7 @@
     name: Chrome Webview
     version: "60.0.3112.107"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.107"
   device:
     type: smartphone
     brand: Condor
@@ -4700,7 +4700,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Condor
@@ -4718,7 +4718,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Condor
@@ -4736,7 +4736,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Condor
@@ -4754,7 +4754,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Condor
@@ -4790,7 +4790,7 @@
     name: Chrome Webview
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Condor
@@ -4808,7 +4808,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Condor
@@ -4844,7 +4844,7 @@
     name: Chrome Mobile
     version: "80.0.3987.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Condor
@@ -4862,7 +4862,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Comio
@@ -4880,7 +4880,7 @@
     name: Chrome Webview
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Comio
@@ -4898,7 +4898,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: ComTrade Tesla
@@ -4916,7 +4916,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: ComTrade Tesla
@@ -4934,7 +4934,7 @@
     name: Chrome Webview
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: ComTrade Tesla
@@ -4952,7 +4952,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: ComTrade Tesla
@@ -4970,7 +4970,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: ComTrade Tesla
@@ -4988,7 +4988,7 @@
     name: Chrome Webview
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: ComTrade Tesla
@@ -5006,7 +5006,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: ComTrade Tesla
@@ -5024,7 +5024,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: ComTrade Tesla
@@ -5042,7 +5042,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: ComTrade Tesla
@@ -5060,7 +5060,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: ComTrade Tesla
@@ -5078,7 +5078,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: ComTrade Tesla
@@ -5096,7 +5096,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: ComTrade Tesla
@@ -5114,7 +5114,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: ComTrade Tesla
@@ -5132,7 +5132,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: ComTrade Tesla
@@ -5150,7 +5150,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Concord
@@ -5168,7 +5168,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Concord
@@ -5186,7 +5186,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: CAGI
@@ -5204,7 +5204,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Cat
@@ -5240,7 +5240,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: CUBOT
@@ -5276,7 +5276,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: CUBOT
@@ -5312,7 +5312,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: CUBOT
@@ -5330,7 +5330,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: CUBOT
@@ -5348,7 +5348,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: CUBOT
@@ -5420,7 +5420,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: CUBOT
@@ -5438,7 +5438,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: CUBOT
@@ -5456,7 +5456,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: CUBOT
@@ -5474,7 +5474,7 @@
     name: Opera Mobile
     version: "28.0.2254.119224"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: CUBOT
@@ -5492,7 +5492,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: CUBOT
@@ -5510,7 +5510,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: CUBOT
@@ -5528,7 +5528,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: CUBOT
@@ -5546,7 +5546,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: CUBOT
@@ -5564,7 +5564,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: CUBOT
@@ -5582,7 +5582,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: CUBOT
@@ -5600,7 +5600,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: CUBOT
@@ -5618,7 +5618,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: CUBOT
@@ -5672,7 +5672,7 @@
     name: Chrome Mobile
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: CUBOT
@@ -5690,7 +5690,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: CUBOT
@@ -5726,7 +5726,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: CUBOT
@@ -5744,7 +5744,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: CUBOT
@@ -5762,7 +5762,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: CUBOT
@@ -5780,7 +5780,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: CUBOT
@@ -5798,7 +5798,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: CUBOT
@@ -5816,7 +5816,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: CUBOT
@@ -5870,7 +5870,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: CUBOT
@@ -5888,7 +5888,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: CUBOT
@@ -5924,7 +5924,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: CUBOT
@@ -5942,7 +5942,7 @@
     name: Chrome Mobile
     version: "77.0.3865.42"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.42"
   device:
     type: smartphone
     brand: CUBOT
@@ -5978,7 +5978,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Cloudfone
@@ -5996,7 +5996,7 @@
     name: Chrome Mobile
     version: "74.0.3729.112"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: smartphone
     brand: Cloudfone
@@ -6014,7 +6014,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Cloudfone
@@ -6032,7 +6032,7 @@
     name: Chrome Webview
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Cloudfone
@@ -6050,7 +6050,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Cloudfone
@@ -6284,7 +6284,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6302,7 +6302,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6320,7 +6320,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6338,7 +6338,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6356,7 +6356,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6374,7 +6374,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6392,7 +6392,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6410,7 +6410,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6428,7 +6428,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6446,7 +6446,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6464,7 +6464,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6482,7 +6482,7 @@
     name: Chrome Mobile
     version: "66.0.3359.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.106"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6500,7 +6500,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6518,7 +6518,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6536,7 +6536,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6554,7 +6554,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6572,7 +6572,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6590,7 +6590,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6608,7 +6608,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6626,7 +6626,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6644,7 +6644,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6662,7 +6662,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6680,7 +6680,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6698,7 +6698,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6716,7 +6716,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6734,7 +6734,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6752,7 +6752,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6770,7 +6770,7 @@
     name: Chrome Webview
     version: "84.0.4147.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6806,7 +6806,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6824,7 +6824,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6842,7 +6842,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -6878,7 +6878,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Cherry Mobile
@@ -7214,7 +7214,7 @@
     name: Chrome Webview
     version: "62.0.3202.97"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.97"
   device:
     type: smartphone
     brand: Coolpad
@@ -7268,7 +7268,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Coolpad
@@ -7304,7 +7304,7 @@
     name: Chrome Webview
     version: "56.0.2924.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.116"
   device:
     type: smartphone
     brand: Coolpad
@@ -7322,7 +7322,7 @@
     name: Chrome Mobile
     version: "68.0.3440.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.85"
   device:
     type: smartphone
     brand: Coolpad
@@ -7340,7 +7340,7 @@
     name: Hawk Quick Browser
     version: 2.4.28.115670
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Coolpad
@@ -7358,7 +7358,7 @@
     name: Chrome Webview
     version: "52.0.2743.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: smartphone
     brand: Coolpad
@@ -7394,7 +7394,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Coolpad
@@ -7412,7 +7412,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Coolpad
@@ -7430,7 +7430,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Coolpad
@@ -7448,7 +7448,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Coolpad
@@ -7466,7 +7466,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Coolpad
@@ -7484,7 +7484,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Coolpad
@@ -7502,7 +7502,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Coolpad
@@ -7538,7 +7538,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Casio
@@ -7556,7 +7556,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Crescent
@@ -7592,7 +7592,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Crescent
@@ -7610,7 +7610,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Crescent
@@ -7628,7 +7628,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Doopro
@@ -7646,7 +7646,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Datsun
@@ -7664,7 +7664,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Datsun
@@ -7682,7 +7682,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Digma
@@ -7806,7 +7806,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Digma
@@ -7842,7 +7842,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Digma
@@ -7896,7 +7896,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Digma
@@ -7914,7 +7914,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Digma
@@ -7932,7 +7932,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Digma
@@ -7950,7 +7950,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Digma
@@ -7968,7 +7968,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Digma
@@ -7986,7 +7986,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Digma
@@ -8004,7 +8004,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Digma
@@ -8022,7 +8022,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Digma
@@ -8040,7 +8040,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Digma
@@ -8058,7 +8058,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Digma
@@ -8094,7 +8094,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Digma
@@ -8112,7 +8112,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Digma
@@ -8130,7 +8130,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Digma
@@ -8148,7 +8148,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Digma
@@ -8166,7 +8166,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Digma
@@ -8184,7 +8184,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Digicel
@@ -8202,7 +8202,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Digi
@@ -8220,7 +8220,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Digi
@@ -8238,7 +8238,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Digi
@@ -8274,7 +8274,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Droxio
@@ -8310,7 +8310,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Danew
@@ -8328,7 +8328,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Danew
@@ -8346,7 +8346,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Danew
@@ -8364,7 +8364,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Danew
@@ -8382,7 +8382,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Danew
@@ -8490,7 +8490,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: DNS
@@ -8508,7 +8508,7 @@
     name: Chrome Mobile
     version: "71.0.3578.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.98"
   device:
     type: smartphone
     brand: DNS
@@ -8526,7 +8526,7 @@
     name: Opera Mobile
     version: "22.0.1485.78487"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.138"
   device:
     type: smartphone
     brand: DNS
@@ -8544,7 +8544,7 @@
     name: Opera Mobile
     version: "50.3.2426.136976"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: DNS
@@ -8580,7 +8580,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Doogee
@@ -8598,7 +8598,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Doogee
@@ -8632,7 +8632,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Doogee
@@ -8650,7 +8650,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Doogee
@@ -8668,7 +8668,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Doogee
@@ -8686,7 +8686,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Doogee
@@ -8722,7 +8722,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Doogee
@@ -8740,7 +8740,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Doogee
@@ -8812,7 +8812,7 @@
     name: Chrome Webview
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: Doogee
@@ -8866,7 +8866,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Doogee
@@ -8884,7 +8884,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Doogee
@@ -8920,7 +8920,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Doogee
@@ -8938,7 +8938,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Doogee
@@ -8956,7 +8956,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Doogee
@@ -8974,7 +8974,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Doogee
@@ -8992,7 +8992,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Allview
@@ -9010,7 +9010,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Allview
@@ -9028,7 +9028,7 @@
     name: Chrome Mobile
     version: "58.0.3029.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.125"
   device:
     type: smartphone
     brand: Allview
@@ -9046,7 +9046,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Okapia
@@ -9064,7 +9064,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Okapia
@@ -9082,7 +9082,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Okapia
@@ -9224,7 +9224,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Google
@@ -9242,7 +9242,7 @@
     name: Chrome Webview
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Movic
@@ -9260,7 +9260,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Cricket
@@ -9278,7 +9278,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Cricket
@@ -9296,7 +9296,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Ulefone
@@ -9350,7 +9350,7 @@
     name: Opera Mobile
     version: 35.1.2254.128301
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9368,7 +9368,7 @@
     name: Opera Mobile
     version: 56.0.2254.57357
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9386,7 +9386,7 @@
     name: Chrome Mobile
     version: 66.0.3359.126
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9404,7 +9404,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9422,7 +9422,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9440,7 +9440,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9458,7 +9458,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9476,7 +9476,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9494,7 +9494,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9512,7 +9512,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9530,7 +9530,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9584,7 +9584,7 @@
     name: Opera Mobile
     version: 55.0.2254.56695
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9638,7 +9638,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9656,7 +9656,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9674,7 +9674,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9692,7 +9692,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9710,7 +9710,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9728,7 +9728,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9746,7 +9746,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9764,7 +9764,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9782,7 +9782,7 @@
     name: Chrome Mobile
     version: 66.0.3359.126
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9800,7 +9800,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9818,7 +9818,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -9934,7 +9934,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Samsung
@@ -9952,7 +9952,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: TCL
@@ -9970,7 +9970,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Hisense
@@ -10024,7 +10024,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Motorola
@@ -10042,7 +10042,7 @@
     name: Chrome Webview
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Motorola
@@ -10060,7 +10060,7 @@
     name: Chrome Webview
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Sony
@@ -10078,7 +10078,7 @@
     name: Chrome Webview
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Sony
@@ -10096,7 +10096,7 @@
     name: Chrome Webview
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: LG
@@ -10114,7 +10114,7 @@
     name: Chrome Webview
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Cellution
@@ -10132,7 +10132,7 @@
     name: Chrome Webview
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Cellution
@@ -10150,7 +10150,7 @@
     name: Chrome Webview
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Kazuna
@@ -10181,7 +10181,7 @@
     name: Chrome Webview
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Alcatel
@@ -10199,7 +10199,7 @@
     name: Chrome Webview
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: Alcatel
@@ -10217,7 +10217,7 @@
     name: Chrome Webview
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -10235,7 +10235,7 @@
     name: Chrome Webview
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Motorola
@@ -10253,7 +10253,7 @@
     name: Chrome Webview
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Motorola
@@ -10287,7 +10287,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Alcatel
@@ -10305,7 +10305,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Alcatel
@@ -10323,7 +10323,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: Alcatel
@@ -10341,7 +10341,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: TCL
@@ -10359,7 +10359,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Alcatel
@@ -10377,7 +10377,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Alcatel
@@ -10395,7 +10395,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: TCL
@@ -10413,7 +10413,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -10431,7 +10431,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: UMIDIGI
@@ -10449,7 +10449,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Alcatel
@@ -10467,7 +10467,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Bmobile
@@ -10485,7 +10485,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Hyundai
@@ -10503,7 +10503,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Blu
@@ -10521,7 +10521,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Blu
@@ -10539,7 +10539,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: IKU Mobile
@@ -10557,7 +10557,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: MicroMax
@@ -10575,7 +10575,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: KRIP
@@ -10593,7 +10593,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Epik One
@@ -10611,7 +10611,7 @@
     name: Chrome Mobile
     version: 91.0.4472.134
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.134"
   device:
     type: smartphone
     brand: Huawei
@@ -10629,7 +10629,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Safaricom
@@ -10647,7 +10647,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: TCL
@@ -10665,7 +10665,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Alcatel
@@ -10683,7 +10683,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Vivo
@@ -10701,7 +10701,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Vivo
@@ -10737,7 +10737,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Vivo
@@ -10755,7 +10755,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: MobiWire
@@ -10773,7 +10773,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Blu
@@ -10791,7 +10791,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Positivo
@@ -10809,7 +10809,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Dazen
@@ -10827,7 +10827,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Blu
@@ -10845,7 +10845,7 @@
     name: Chrome Webview
     version: 74.0.3729.186
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.186"
   device:
     type: smartphone
     brand: CellAllure
@@ -10863,7 +10863,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Lanix
@@ -10881,7 +10881,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: smartphone
     brand: M-Tech
@@ -10899,7 +10899,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Realme
@@ -10917,7 +10917,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Wolki
@@ -10935,7 +10935,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Hisense
@@ -10953,7 +10953,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Orbic
@@ -10971,7 +10971,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: T-Mobile
@@ -10989,7 +10989,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: T-Mobile
@@ -11023,7 +11023,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Alcatel
@@ -11041,7 +11041,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Alcatel
@@ -11059,7 +11059,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: TCL
@@ -11077,7 +11077,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: TCL
@@ -11095,7 +11095,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: TCL
@@ -11113,7 +11113,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Alcatel
@@ -11131,7 +11131,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: TCL
@@ -11149,7 +11149,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Zuum
@@ -11167,7 +11167,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Zuum
@@ -11185,7 +11185,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Alcatel
@@ -11203,7 +11203,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Alcatel
@@ -11221,7 +11221,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: TCL
@@ -11239,7 +11239,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: TCL
@@ -11257,7 +11257,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Alcatel
@@ -11275,7 +11275,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Alcatel
@@ -11293,7 +11293,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: TCL
@@ -11311,7 +11311,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: TCL
@@ -11329,7 +11329,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Kodak
@@ -11347,7 +11347,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Kodak
@@ -11365,7 +11365,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Kodak
@@ -11383,7 +11383,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Kodak
@@ -11401,7 +11401,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Kodak
@@ -11419,7 +11419,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Doro
@@ -11437,7 +11437,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Doro
@@ -11455,7 +11455,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Blu
@@ -11473,7 +11473,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Aspera
@@ -11491,7 +11491,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: KRIP
@@ -11509,7 +11509,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: KRIP
@@ -11527,7 +11527,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: KRIP
@@ -11545,7 +11545,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: KRIP
@@ -11563,7 +11563,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: KRIP
@@ -11581,7 +11581,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: KRIP
@@ -11599,7 +11599,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: KRIP
@@ -11617,7 +11617,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Sky
@@ -11635,7 +11635,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Sky
@@ -11653,7 +11653,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Smooth Mobile
@@ -11671,7 +11671,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Smooth Mobile
@@ -11689,7 +11689,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Smooth Mobile
@@ -11707,7 +11707,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Smooth Mobile
@@ -11725,7 +11725,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: smartphone
     brand: Smooth Mobile
@@ -11743,7 +11743,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: DISH
@@ -11761,7 +11761,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Wiko
@@ -11779,7 +11779,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: smartphone
     brand: Wiko
@@ -11797,7 +11797,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Wiko
@@ -11815,7 +11815,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: smartphone
     brand: Wiko
@@ -11833,7 +11833,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: iPro
@@ -11851,7 +11851,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: OpelMobile
@@ -11869,7 +11869,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Hi
@@ -11887,7 +11887,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Sky
@@ -11905,7 +11905,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Sky
@@ -11923,7 +11923,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Sky
@@ -11941,7 +11941,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Sky
@@ -11959,7 +11959,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: CORN
@@ -11977,7 +11977,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: CORN
@@ -11995,7 +11995,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: CORN
@@ -12013,7 +12013,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: CORN
@@ -12031,7 +12031,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: CORN
@@ -12049,7 +12049,7 @@
     name: Chrome Mobile
     version: 66.0.3359.126
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Evertek
@@ -12067,7 +12067,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: ZTE
@@ -12085,7 +12085,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: ZTE
@@ -12103,7 +12103,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: ZTE
@@ -12121,7 +12121,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: ZTE
@@ -12139,7 +12139,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: ZTE
@@ -12157,7 +12157,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: ZTE
@@ -12175,7 +12175,7 @@
     name: Chrome Mobile
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: ZTE
@@ -12193,7 +12193,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Vivo
@@ -12211,7 +12211,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Vivo
@@ -12229,7 +12229,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Vivo
@@ -12247,7 +12247,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Vivo
@@ -12265,7 +12265,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Vivo
@@ -12283,7 +12283,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Vivo
@@ -12301,7 +12301,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Vivo
@@ -12319,7 +12319,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Vivo
@@ -12337,7 +12337,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Vivo
@@ -12355,7 +12355,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Coolpad
@@ -12373,7 +12373,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Coolpad
@@ -12391,7 +12391,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Huavi
@@ -12409,7 +12409,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Cricket
@@ -12427,7 +12427,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Cricket
@@ -12445,7 +12445,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Cricket
@@ -12463,7 +12463,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Cricket
@@ -12481,7 +12481,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Cricket
@@ -12499,7 +12499,7 @@
     name: Chrome Webview
     version: 58.0.3029.125
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.125"
   device:
     type: smartphone
     brand: Brondi
@@ -12517,7 +12517,7 @@
     name: Chrome Mobile
     version: 60.0.3112.116
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Mafe
@@ -12535,7 +12535,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Bmobile
@@ -12553,7 +12553,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Bmobile
@@ -12571,7 +12571,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Cricket
@@ -12589,7 +12589,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Naomi Phone
@@ -12607,7 +12607,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Konrow
@@ -12625,7 +12625,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: iHunt
@@ -12643,7 +12643,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: iHunt
@@ -12661,7 +12661,7 @@
     name: Chrome Mobile
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Hotwav
@@ -12679,7 +12679,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: MobiWire
@@ -12697,7 +12697,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: Digicel
@@ -12715,7 +12715,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: iSWAG
@@ -12733,7 +12733,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: X-TIGI
@@ -12751,7 +12751,7 @@
     name: Chrome Mobile
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: smartphone
     brand: Cloud
@@ -12769,7 +12769,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Virzo
@@ -12803,7 +12803,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Gtel
@@ -12821,7 +12821,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Logic
@@ -12839,7 +12839,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Logic
@@ -12857,7 +12857,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Logic
@@ -12875,7 +12875,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: Logic
@@ -12893,7 +12893,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Logic
@@ -12929,7 +12929,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: 'AT&T'
@@ -12947,7 +12947,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: 'AT&T'
@@ -12965,7 +12965,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Cloud
@@ -12983,7 +12983,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Crosscall
@@ -13001,7 +13001,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Maxwest
@@ -13037,7 +13037,7 @@
     name: Chrome Mobile
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Crosscall
@@ -13055,7 +13055,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Blu
@@ -13073,7 +13073,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Blu
@@ -13091,7 +13091,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Blu
@@ -13109,7 +13109,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Blu
@@ -13127,7 +13127,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Blu
@@ -13145,7 +13145,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: STG Telecom
@@ -13163,7 +13163,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: INSYS
@@ -13181,7 +13181,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Turkcell
@@ -13199,7 +13199,7 @@
     name: Chrome Mobile
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Türk Telekom
@@ -13217,7 +13217,7 @@
     name: Chrome
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: T-Mobile
@@ -13235,7 +13235,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: Evoo
@@ -13325,7 +13325,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Turkcell
@@ -13361,7 +13361,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Turkcell
@@ -13433,7 +13433,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Samsung
@@ -13451,7 +13451,7 @@
     name: Chrome Webview
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: TechPad
@@ -13469,7 +13469,7 @@
     name: Chrome Webview
     version: 44.0.2403.119
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: STF Mobile
@@ -13487,7 +13487,7 @@
     name: Chrome Webview
     version: 44.0.2403.119
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: CellAllure
@@ -13505,7 +13505,7 @@
     name: Chrome Webview
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Advan
@@ -13523,7 +13523,7 @@
     name: Chrome Webview
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Advan
@@ -13541,7 +13541,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Remdun
@@ -13559,7 +13559,7 @@
     name: Chrome Webview
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Dreamgate
@@ -13577,7 +13577,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: HERO
@@ -13595,7 +13595,7 @@
     name: Chrome Mobile
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: 'AT&T'
@@ -13613,7 +13613,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Vsmart
@@ -13631,7 +13631,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Samsung
@@ -13649,7 +13649,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: A1
@@ -13667,7 +13667,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: smartphone
     brand: Evertek
@@ -13685,7 +13685,7 @@
     name: Opera Mobile
     version: 65.2.3381.61420
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: POPTEL
@@ -13703,7 +13703,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: CUBOT
@@ -13721,7 +13721,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: CUBOT
@@ -13739,7 +13739,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Hafury
@@ -13757,7 +13757,7 @@
     name: Opera Mobile
     version: 65.2.3381.61420
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Xiaomi
@@ -13775,7 +13775,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: CUBOT
@@ -13793,7 +13793,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Alcatel
@@ -13811,7 +13811,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Blaupunkt
@@ -13883,7 +13883,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Blu
@@ -13901,7 +13901,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: T-Mobile

--- a/Tests/fixtures/smartphone-4.yml
+++ b/Tests/fixtures/smartphone-4.yml
@@ -10,7 +10,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Doogee
@@ -28,7 +28,7 @@
     name: Chrome Webview
     version: "63.0.3239"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239."
   device:
     type: smartphone
     brand: Doro
@@ -346,7 +346,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: DeWalt
@@ -364,7 +364,7 @@
     name: Opera Mobile
     version: "44.1.2254.143214"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: DEXP
@@ -382,7 +382,7 @@
     name: Opera Mobile
     version: "43.3.2254.141404"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: DEXP
@@ -400,7 +400,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: DEXP
@@ -418,7 +418,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: DEXP
@@ -436,7 +436,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: DEXP
@@ -454,7 +454,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: DEXP
@@ -472,7 +472,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: DEXP
@@ -490,7 +490,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: DEXP
@@ -508,7 +508,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: DEXP
@@ -526,7 +526,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: DEXP
@@ -544,7 +544,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: DEXP
@@ -562,7 +562,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: DEXP
@@ -580,7 +580,7 @@
     name: Opera Mobile
     version: "37.0.2192.105088"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.94"
   device:
     type: smartphone
     brand: DEXP
@@ -598,7 +598,7 @@
     name: Yandex Browser
     version: "17.3.0.373.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: DEXP
@@ -616,7 +616,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: DEXP
@@ -634,7 +634,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: DEXP
@@ -652,7 +652,7 @@
     name: Yandex Browser
     version: "19.6.4.349.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.169"
   device:
     type: smartphone
     brand: DEXP
@@ -670,7 +670,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: DEXP
@@ -688,7 +688,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: DEXP
@@ -706,7 +706,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: DEXP
@@ -742,7 +742,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Essentielb
@@ -760,7 +760,7 @@
     name: Chrome Mobile
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: smartphone
     brand: Essentielb
@@ -778,7 +778,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Essentielb
@@ -796,7 +796,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Essentielb
@@ -814,7 +814,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Essentielb
@@ -832,7 +832,7 @@
     name: Chrome Mobile
     version: "67.0.3396.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.81"
   device:
     type: smartphone
     brand: Essentielb
@@ -850,7 +850,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Essentielb
@@ -868,7 +868,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Evolio
@@ -886,7 +886,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Evolio
@@ -904,7 +904,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Evolio
@@ -922,7 +922,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Evolio
@@ -940,7 +940,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Evolio
@@ -958,7 +958,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Evolio
@@ -976,7 +976,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Evolio
@@ -994,7 +994,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Echo Mobiles
@@ -1012,7 +1012,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Echo Mobiles
@@ -1030,7 +1030,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Echo Mobiles
@@ -1048,7 +1048,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Echo Mobiles
@@ -1066,7 +1066,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Echo Mobiles
@@ -1084,7 +1084,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Echo Mobiles
@@ -1102,7 +1102,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Echo Mobiles
@@ -1120,7 +1120,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Echo Mobiles
@@ -1138,7 +1138,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Echo Mobiles
@@ -1156,7 +1156,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Echo Mobiles
@@ -1174,7 +1174,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Echo Mobiles
@@ -1192,7 +1192,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Extrem
@@ -1210,7 +1210,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: EE
@@ -1228,7 +1228,7 @@
     name: Chrome Webview
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Ergo
@@ -1246,7 +1246,7 @@
     name: Chrome Webview
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Ergo
@@ -1264,7 +1264,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Ergo
@@ -1282,7 +1282,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Ergo
@@ -1300,7 +1300,7 @@
     name: Chrome Webview
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Ergo
@@ -1318,7 +1318,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Ergo
@@ -1336,7 +1336,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Ergo
@@ -1354,7 +1354,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Ergo
@@ -1372,7 +1372,7 @@
     name: Chrome Webview
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Ergo
@@ -1390,7 +1390,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Ergo
@@ -1408,7 +1408,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Ergo
@@ -1426,7 +1426,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Ergo
@@ -1444,7 +1444,7 @@
     name: Chrome Webview
     version: "43.0.2357.65"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.65"
   device:
     type: smartphone
     brand: Ergo
@@ -1462,7 +1462,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Ergo
@@ -1480,7 +1480,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Ergo
@@ -1498,7 +1498,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Ergo
@@ -1516,7 +1516,7 @@
     name: Chrome Webview
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Ergo
@@ -1534,7 +1534,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Ergo
@@ -1570,7 +1570,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Ergo
@@ -1588,7 +1588,7 @@
     name: Yandex Browser
     version: "17.10.2.135.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.100"
   device:
     type: smartphone
     brand: Ergo
@@ -1606,7 +1606,7 @@
     name: Yandex Browser
     version: "19.7.3.91.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Ergo
@@ -1624,7 +1624,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Ergo
@@ -1660,7 +1660,7 @@
     name: Yandex Browser
     version: "20.2.4.153.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Ergo
@@ -1678,7 +1678,7 @@
     name: Yandex Browser
     version: "19.12.1.121.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.97"
   device:
     type: smartphone
     brand: Ergo
@@ -1696,7 +1696,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: E-tel
@@ -1750,7 +1750,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Evercoss
@@ -1840,7 +1840,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Evercoss
@@ -1858,7 +1858,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Evercoss
@@ -1980,7 +1980,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: E-Boda
@@ -1998,7 +1998,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: E-Boda
@@ -2016,7 +2016,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Energizer
@@ -2034,7 +2034,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Energizer
@@ -2052,7 +2052,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Energizer
@@ -2070,7 +2070,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Energizer
@@ -2088,7 +2088,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Energizer
@@ -2106,7 +2106,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Energizer
@@ -2124,7 +2124,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Energizer
@@ -2142,7 +2142,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Energizer
@@ -2160,7 +2160,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Essential
@@ -2178,7 +2178,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: EKO
@@ -2196,7 +2196,7 @@
     name: Chrome Webview
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: smartphone
     brand: EKO
@@ -2214,7 +2214,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: EKO
@@ -2232,7 +2232,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Elephone
@@ -2250,7 +2250,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Elephone
@@ -2268,7 +2268,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Elephone
@@ -2304,7 +2304,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Elephone
@@ -2322,7 +2322,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Elephone
@@ -2340,7 +2340,7 @@
     name: Chrome Mobile
     version: "43.0.2357.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.92"
   device:
     type: smartphone
     brand: Elephone
@@ -2376,7 +2376,7 @@
     name: Chrome Mobile
     version: "41.0.2272.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.96"
   device:
     type: smartphone
     brand: Elephone
@@ -2394,7 +2394,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Elephone
@@ -2412,7 +2412,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Elephone
@@ -2466,7 +2466,7 @@
     name: Chrome Mobile
     version: "48.0.2564.95"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.95"
   device:
     type: smartphone
     brand: Elephone
@@ -2484,7 +2484,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Elephone
@@ -2502,7 +2502,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Elephone
@@ -2520,7 +2520,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Elephone
@@ -2538,7 +2538,7 @@
     name: Chrome Mobile
     version: "72.0.3626.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Eks Mobility
@@ -2556,7 +2556,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Eks Mobility
@@ -2726,7 +2726,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Evolveo
@@ -2744,7 +2744,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Evolveo
@@ -2762,7 +2762,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Evolveo
@@ -2780,7 +2780,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Evolveo
@@ -2798,7 +2798,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Evolveo
@@ -2816,7 +2816,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Evolveo
@@ -2834,7 +2834,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Evolveo
@@ -2870,7 +2870,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Eurostar
@@ -2888,7 +2888,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Eurostar
@@ -2942,7 +2942,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Evertek
@@ -3014,7 +3014,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Evertek
@@ -3032,7 +3032,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Evertek
@@ -3050,7 +3050,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Evertek
@@ -3140,7 +3140,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Senwa
@@ -3158,7 +3158,7 @@
     name: Chrome Mobile
     version: "81.0.4044.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Senwa
@@ -3176,7 +3176,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Senwa
@@ -3194,7 +3194,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Senwa
@@ -3212,7 +3212,7 @@
     name: Chrome Mobile
     version: "48.0.2564.95"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.95"
   device:
     type: smartphone
     brand: Senwa
@@ -3248,7 +3248,7 @@
     name: Chrome Mobile
     version: "45.0.2454.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.84"
   device:
     type: smartphone
     brand: Senwa
@@ -3266,7 +3266,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Senwa
@@ -3284,7 +3284,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Senwa
@@ -3302,7 +3302,7 @@
     name: Chrome Mobile
     version: "39.0.2171.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.59"
   device:
     type: smartphone
     brand: Explay
@@ -3320,7 +3320,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Explay
@@ -3338,7 +3338,7 @@
     name: Chrome Mobile
     version: "60.0.3112.97"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.97"
   device:
     type: smartphone
     brand: FinePower
@@ -3356,7 +3356,7 @@
     name: Chrome Webview
     version: "48.0.2531.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2531.0"
   device:
     type: smartphone
     brand: FinePower
@@ -3374,7 +3374,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: FinePower
@@ -3392,7 +3392,7 @@
     name: Yandex Browser
     version: "16.2.1.7529.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.111"
   device:
     type: smartphone
     brand: FinePower
@@ -3410,7 +3410,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: FinePower
@@ -3428,7 +3428,7 @@
     name: Chrome Mobile
     version: "42.0.2311.154"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.154"
   device:
     type: smartphone
     brand: FinePower
@@ -3446,7 +3446,7 @@
     name: Chrome Mobile
     version: "69.0.3497.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: smartphone
     brand: FinePower
@@ -3464,7 +3464,7 @@
     name: Chrome Mobile
     version: "72.0.3626.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: FinePower
@@ -3482,7 +3482,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: FORME
@@ -3518,7 +3518,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: FORME
@@ -3536,7 +3536,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: FireFly Mobile
@@ -3554,7 +3554,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: FireFly Mobile
@@ -3572,7 +3572,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: FireFly Mobile
@@ -3590,7 +3590,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: FireFly Mobile
@@ -3608,7 +3608,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: FireFly Mobile
@@ -3626,7 +3626,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: FireFly Mobile
@@ -3644,7 +3644,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: FireFly Mobile
@@ -3662,7 +3662,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Fero
@@ -3680,7 +3680,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Fero
@@ -3698,7 +3698,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Fairphone
@@ -3734,7 +3734,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Fairphone
@@ -3752,7 +3752,7 @@
     name: Maxthon
     version: "4.5.5.2000"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Fondi
@@ -3770,7 +3770,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Fondi
@@ -3788,7 +3788,7 @@
     name: Chrome Webview
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Fondi
@@ -3806,7 +3806,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: FiGO
@@ -3824,7 +3824,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: FiGO
@@ -3842,7 +3842,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: FiGO
@@ -3860,7 +3860,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: FiGO
@@ -3878,7 +3878,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: FiGO
@@ -3896,7 +3896,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: FiGO
@@ -3914,7 +3914,7 @@
     name: Chrome Webview
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: FiGO
@@ -3932,7 +3932,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: FiGO
@@ -3950,7 +3950,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: FiGO
@@ -3968,7 +3968,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: FiGO
@@ -3986,7 +3986,7 @@
     name: Opera Mobile
     version: "19.0.1340.69721"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.72"
   device:
     type: smartphone
     brand: Fly
@@ -4022,7 +4022,7 @@
     name: Aloha Browser
     version: "1.3.3.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Fly
@@ -4040,7 +4040,7 @@
     name: Chrome Webview
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Fly
@@ -4058,7 +4058,7 @@
     name: Chrome Mobile
     version: "72.0.3626.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Fly
@@ -4076,7 +4076,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Fly
@@ -4094,7 +4094,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Fly
@@ -4130,7 +4130,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Fly
@@ -4148,7 +4148,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Fly
@@ -4166,7 +4166,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Fly
@@ -4184,7 +4184,7 @@
     name: Yandex Browser
     version: "16.6.0.8810.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.102"
   device:
     type: smartphone
     brand: Fly
@@ -4202,7 +4202,7 @@
     name: Chrome Webview
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Fly
@@ -4220,7 +4220,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Fly
@@ -4238,7 +4238,7 @@
     name: Chrome Mobile
     version: "30.0.1599.82"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.82"
   device:
     type: smartphone
     brand: Fly
@@ -4256,7 +4256,7 @@
     name: Chrome Webview
     version: "30.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0"
   device:
     type: smartphone
     brand: Fly
@@ -4274,7 +4274,7 @@
     name: Chrome Mobile
     version: "35.0.1916.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.138"
   device:
     type: smartphone
     brand: Fly
@@ -4292,7 +4292,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: Fly
@@ -4328,7 +4328,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Fly
@@ -4364,7 +4364,7 @@
     name: Opera Mobile
     version: "27.0.1698.89115"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: smartphone
     brand: Fly
@@ -4382,7 +4382,7 @@
     name: Chrome Mobile
     version: "37.0.2062.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.117"
   device:
     type: smartphone
     brand: Fly
@@ -4400,7 +4400,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Fly
@@ -4418,7 +4418,7 @@
     name: Yandex Browser
     version: "14.10.2062.12160.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.124"
   device:
     type: smartphone
     brand: Fly
@@ -4436,7 +4436,7 @@
     name: Opera Mobile
     version: "24.0.1565.82529"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.117"
   device:
     type: smartphone
     brand: Fly
@@ -4454,7 +4454,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Fly
@@ -4526,7 +4526,7 @@
     name: Chrome Mobile
     version: "39.0.2171.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.90"
   device:
     type: smartphone
     brand: Fly
@@ -4559,7 +4559,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Fly
@@ -4595,7 +4595,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Fly
@@ -4613,7 +4613,7 @@
     name: Yandex Browser
     version: "15.4.2272.3842.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.118"
   device:
     type: smartphone
     brand: Fly
@@ -4757,7 +4757,7 @@
     name: Yandex Browser
     version: "1.20.1364.172"
     engine: Blink
-    engine_version: ""
+    engine_version: "25.0.1364.172"
   device:
     type: smartphone
     brand: Fly
@@ -4775,7 +4775,7 @@
     name: Opera Mobile
     version: "15.0.1162.59192"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.45"
   device:
     type: smartphone
     brand: Fly
@@ -4829,7 +4829,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Fly
@@ -4865,7 +4865,7 @@
     name: Hawk Quick Browser
     version: 2.4.30.115711
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Fly
@@ -4901,7 +4901,7 @@
     name: Hawk Quick Browser
     version: 2.4.33.115728
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Fly
@@ -4973,7 +4973,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Fly
@@ -5009,7 +5009,7 @@
     name: Chrome Mobile
     version: "31.0.1650.57"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.57"
   device:
     type: smartphone
     brand: Fly
@@ -5027,7 +5027,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Fly
@@ -5045,7 +5045,7 @@
     name: Chrome Webview
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Fly
@@ -5063,7 +5063,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Fly
@@ -5081,7 +5081,7 @@
     name: Chrome Mobile
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: Fly
@@ -5099,7 +5099,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Fly
@@ -5117,7 +5117,7 @@
     name: Chrome Mobile
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: Fly
@@ -5135,7 +5135,7 @@
     name: Chrome Mobile
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: Fly
@@ -5153,7 +5153,7 @@
     name: Chrome Webview
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Fly
@@ -5171,7 +5171,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Fly
@@ -5189,7 +5189,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Fly
@@ -5207,7 +5207,7 @@
     name: Yandex Browser
     version: "17.3.2.414.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Fly
@@ -5225,7 +5225,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Fly
@@ -5243,7 +5243,7 @@
     name: Yandex Browser
     version: "17.4.0.491.00 alpha"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.137"
   device:
     type: smartphone
     brand: Fly
@@ -5261,7 +5261,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Fly
@@ -5279,7 +5279,7 @@
     name: Chrome Mobile
     version: "44.0.2403.133"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.133"
   device:
     type: smartphone
     brand: Fly
@@ -5315,7 +5315,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Fly
@@ -5333,7 +5333,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Fly
@@ -5351,7 +5351,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Fly
@@ -5369,7 +5369,7 @@
     name: Chrome Webview
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Fly
@@ -5387,7 +5387,7 @@
     name: Chrome Mobile
     version: "72.0.3626.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Fly
@@ -5459,7 +5459,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Fly
@@ -5477,7 +5477,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Fly
@@ -5513,7 +5513,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Fly
@@ -5549,7 +5549,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Fly
@@ -5567,7 +5567,7 @@
     name: Yandex Browser
     version: "16.6.0.8810.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.102"
   device:
     type: smartphone
     brand: Fly
@@ -5603,7 +5603,7 @@
     name: Opera Mobile
     version: "42.6.2246.114522"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Fly
@@ -5621,7 +5621,7 @@
     name: Chrome Webview
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Fly
@@ -5639,7 +5639,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Fly
@@ -5747,7 +5747,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Fly
@@ -5765,7 +5765,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Famoco
@@ -5783,7 +5783,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: FNB
@@ -5801,7 +5801,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: FNB
@@ -5819,7 +5819,7 @@
     name: Chrome Webview
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: smartphone
     brand: FNB
@@ -5837,7 +5837,7 @@
     name: Chrome Mobile
     version: "66.0.3359.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.106"
   device:
     type: smartphone
     brand: FNB
@@ -5909,7 +5909,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Foxconn
@@ -5927,7 +5927,7 @@
     name: Chrome Webview
     version: "50.0.2661.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Forstar
@@ -5945,7 +5945,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Freetel
@@ -5979,7 +5979,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Freetel
@@ -5997,7 +5997,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Freetel
@@ -6015,7 +6015,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Freetel
@@ -6033,7 +6033,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Freetel
@@ -6051,7 +6051,7 @@
     name: Chrome Mobile
     version: "55.0.2883.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.84"
   device:
     type: smartphone
     brand: Freetel
@@ -6069,7 +6069,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Freetel
@@ -6087,7 +6087,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Freetel
@@ -6105,7 +6105,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Freetel
@@ -6123,7 +6123,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Freetel
@@ -6141,7 +6141,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Freetel
@@ -6159,7 +6159,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Freetel
@@ -6177,7 +6177,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Freetel
@@ -6195,7 +6195,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Freetel
@@ -6213,7 +6213,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Freetel
@@ -6231,7 +6231,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Freetel
@@ -6249,7 +6249,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Fujitsu
@@ -6267,7 +6267,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Fujitsu
@@ -6285,7 +6285,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Fujitsu
@@ -6303,7 +6303,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Fujitsu
@@ -6357,7 +6357,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Fujitsu
@@ -6465,7 +6465,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Fujitsu
@@ -6483,7 +6483,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Fujitsu
@@ -6555,7 +6555,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Goophone
@@ -6573,7 +6573,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Goophone
@@ -6591,7 +6591,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Goophone
@@ -6627,7 +6627,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Goophone
@@ -6663,7 +6663,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Goophone
@@ -6681,7 +6681,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: GoMobile
@@ -6699,7 +6699,7 @@
     name: Chrome Mobile
     version: "60.0.3112.107"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.107"
   device:
     type: smartphone
     brand: GoMobile
@@ -6717,7 +6717,7 @@
     name: Chrome Webview
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: GoMobile
@@ -6735,7 +6735,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Gome
@@ -6753,7 +6753,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Gome
@@ -6771,7 +6771,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Gome
@@ -6807,7 +6807,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Gome
@@ -6825,7 +6825,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Gome
@@ -6843,7 +6843,7 @@
     name: Chrome Mobile
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Gome
@@ -6861,7 +6861,7 @@
     name: Chrome Webview
     version: "43.0.2357.65"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.65"
   device:
     type: smartphone
     brand: Gome
@@ -6879,7 +6879,7 @@
     name: Chrome Mobile
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Gome
@@ -6897,7 +6897,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Gree
@@ -6915,7 +6915,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Gree
@@ -6987,7 +6987,7 @@
     name: Chrome
     version: "39.0.2171.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.59"
   device:
     type: smartphone
     brand: GOCLEVER
@@ -7005,7 +7005,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: GOCLEVER
@@ -7041,7 +7041,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: GOCLEVER
@@ -7149,7 +7149,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Geotel
@@ -7167,7 +7167,7 @@
     name: Yandex Browser
     version: "8.11"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.119"
   device:
     type: smartphone
     brand: Geotel
@@ -7203,7 +7203,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Gigabyte
@@ -7221,7 +7221,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Gigabyte
@@ -7239,7 +7239,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Gigabyte
@@ -7293,7 +7293,7 @@
     name: Opera Mobile
     version: "21.0.1437.74904"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.116"
   device:
     type: smartphone
     brand: Gigabyte
@@ -7347,7 +7347,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Ghia
@@ -7365,7 +7365,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Ghia
@@ -7473,7 +7473,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Gionee
@@ -7491,7 +7491,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Gionee
@@ -7509,7 +7509,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Gionee
@@ -7815,7 +7815,7 @@
     name: Chrome Webview
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: Gionee
@@ -7887,7 +7887,7 @@
     name: Chrome Webview
     version: "74.0.3729.112"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: smartphone
     brand: Gionee
@@ -7905,7 +7905,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Gionee
@@ -7923,7 +7923,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Gionee
@@ -7977,7 +7977,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Gionee
@@ -8155,7 +8155,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: General Mobile
@@ -8173,7 +8173,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: General Mobile
@@ -8191,7 +8191,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: General Mobile
@@ -8209,7 +8209,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: Google
@@ -8353,7 +8353,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Google
@@ -8407,7 +8407,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: Google
@@ -8533,7 +8533,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Google
@@ -8567,7 +8567,7 @@
     name: Chrome Mobile
     version: "58.0.3029.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.125"
   device:
     type: smartphone
     brand: Google
@@ -8585,7 +8585,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Google
@@ -8603,7 +8603,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Google
@@ -8621,7 +8621,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Google
@@ -8639,7 +8639,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Google
@@ -8657,7 +8657,7 @@
     name: Chrome Webview
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Google
@@ -8675,7 +8675,7 @@
     name: Chrome Mobile
     version: "83.0.4103.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.109"
   device:
     type: smartphone
     brand: Google
@@ -8693,7 +8693,7 @@
     name: Chrome Mobile
     version: "84.0.4147.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Google
@@ -8711,7 +8711,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Google
@@ -8729,7 +8729,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Google
@@ -8783,7 +8783,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Grape
@@ -8801,7 +8801,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Grape
@@ -8819,7 +8819,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Grape
@@ -8837,7 +8837,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Grape
@@ -8855,7 +8855,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Gigaset
@@ -8873,7 +8873,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Gigaset
@@ -8891,7 +8891,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Gigaset
@@ -8909,7 +8909,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Gigaset
@@ -8927,7 +8927,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Gigaset
@@ -8945,7 +8945,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Gigaset
@@ -8963,7 +8963,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -8981,7 +8981,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -8999,7 +8999,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9017,7 +9017,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9035,7 +9035,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9053,7 +9053,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9071,7 +9071,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9107,7 +9107,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9143,7 +9143,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9161,7 +9161,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9179,7 +9179,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9197,7 +9197,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9215,7 +9215,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9233,7 +9233,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9251,7 +9251,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9359,7 +9359,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9377,7 +9377,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9395,7 +9395,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9413,7 +9413,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9431,7 +9431,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9449,7 +9449,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9467,7 +9467,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9485,7 +9485,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9503,7 +9503,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9521,7 +9521,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9539,7 +9539,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9557,7 +9557,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9575,7 +9575,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9593,7 +9593,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Samsung
@@ -9611,7 +9611,7 @@
     name: Chrome Webview
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Wolki
@@ -9629,7 +9629,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Hurricane
@@ -9647,7 +9647,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: ZTE
@@ -9665,7 +9665,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: TCL
@@ -9683,7 +9683,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Kodak
@@ -9701,7 +9701,7 @@
     name: Huawei Browser Mobile
     version: 12.0.1.302
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: smartphone
     brand: Huawei
@@ -9719,7 +9719,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Kalley
@@ -9737,7 +9737,7 @@
     name: Chrome Mobile
     version: 98.0.4758.87
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.87"
   device:
     type: smartphone
     brand: TCL
@@ -9755,7 +9755,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Allview
@@ -9773,7 +9773,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: OnePlus
@@ -9791,7 +9791,7 @@
     name: Chrome Mobile
     version: 91.0.4472.114
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: smartphone
     brand: Vivo
@@ -9809,7 +9809,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Realme
@@ -9827,7 +9827,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Kalley
@@ -9845,7 +9845,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: TCL
@@ -9863,7 +9863,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Crosscall
@@ -9881,7 +9881,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Alcatel
@@ -9899,7 +9899,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Yezz
@@ -9917,7 +9917,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Digicel
@@ -9935,7 +9935,7 @@
     name: Chrome Mobile
     version: 99.0.4844.48
     engine: Blink
-    engine_version: ""
+    engine_version: "99.0.4844.48"
   device:
     type: smartphone
     brand: Digicel
@@ -9953,7 +9953,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Hyundai
@@ -9971,7 +9971,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Hyundai
@@ -9989,7 +9989,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: 'AT&T'
@@ -10007,7 +10007,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: OpelMobile
@@ -10025,7 +10025,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Kalley
@@ -10043,7 +10043,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Blu
@@ -10061,7 +10061,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Blu
@@ -10079,7 +10079,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Hisense
@@ -10097,7 +10097,7 @@
     name: Microsoft Edge
     version: 98.0.1108.55
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.102"
   device:
     type: smartphone
     brand: HTC
@@ -10115,7 +10115,7 @@
     name: Chrome Mobile
     version: 98.0.4758.87
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.87"
   device:
     type: smartphone
     brand: HTC
@@ -10133,7 +10133,7 @@
     name: Chrome Mobile
     version: 98.0.4758.87
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.87"
   device:
     type: smartphone
     brand: Vivo
@@ -10151,7 +10151,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: KRIP
@@ -10169,7 +10169,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: KRIP
@@ -10187,7 +10187,7 @@
     name: Chrome Mobile
     version: 98.0.4758.87
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.87"
   device:
     type: smartphone
     brand: Logic
@@ -10205,7 +10205,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Logic
@@ -10223,7 +10223,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Logic
@@ -10241,7 +10241,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Mione
@@ -10259,7 +10259,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Motorola
@@ -10277,7 +10277,7 @@
     name: Chrome Mobile
     version: 89.0.4389.90
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.90"
   device:
     type: smartphone
     brand: Motorola
@@ -10295,7 +10295,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Motorola
@@ -10313,7 +10313,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: smartphone
     brand: Motorola
@@ -10331,7 +10331,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Motorola
@@ -10349,7 +10349,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Motorola
@@ -10367,7 +10367,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Motorola
@@ -10385,7 +10385,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Motorola
@@ -10403,7 +10403,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Motorola
@@ -10421,7 +10421,7 @@
     name: Chrome Mobile
     version: 98.0.4758.87
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.87"
   device:
     type: smartphone
     brand: Motorola
@@ -10439,7 +10439,7 @@
     name: Chrome Mobile
     version: 89.0.4389.90
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.90"
   device:
     type: smartphone
     brand: Motorola
@@ -10457,7 +10457,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Motorola
@@ -10475,7 +10475,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Motorola
@@ -10493,7 +10493,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: Motorola
@@ -10511,7 +10511,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Motorola
@@ -10529,7 +10529,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Motorola
@@ -10547,7 +10547,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Motorola
@@ -10565,7 +10565,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Motorola
@@ -10583,7 +10583,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Motorola
@@ -10601,7 +10601,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Motorola
@@ -10619,7 +10619,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Motorola
@@ -10637,7 +10637,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: smartphone
     brand: OpelMobile
@@ -10655,7 +10655,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Sky
@@ -10673,7 +10673,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Xiaomi
@@ -10691,7 +10691,7 @@
     name: Chrome Mobile
     version: 98.0.4758.87
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.87"
   device:
     type: phablet
     brand: Xiaomi
@@ -10709,7 +10709,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Schok
@@ -10727,7 +10727,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Sky
@@ -10745,7 +10745,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Kalley
@@ -10763,7 +10763,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -10781,7 +10781,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -10799,7 +10799,7 @@
     name: Chrome Mobile
     version: 98.0.4758.87
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.87"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -10817,7 +10817,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -10835,7 +10835,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -10853,7 +10853,7 @@
     name: Opera Mobile
     version: 65.2.3381.61420
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Tecno Mobile
@@ -10871,7 +10871,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Tigers
@@ -10889,7 +10889,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Tigers
@@ -10907,7 +10907,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: smartphone
     brand: iHunt
@@ -10925,7 +10925,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Positivo
@@ -10943,7 +10943,7 @@
     name: Chrome
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Pantech
@@ -10961,7 +10961,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: smartphone
     brand: Vios
@@ -10979,7 +10979,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Wiko
@@ -10997,7 +10997,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Yezz
@@ -11015,7 +11015,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Quantum
@@ -11033,7 +11033,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: 'Yes'
@@ -11051,7 +11051,7 @@
     name: Chrome Webview
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: ClearPHONE
@@ -11069,7 +11069,7 @@
     name: Chrome Mobile
     version: 98.0.4758.87
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.87"
   device:
     type: smartphone
     brand: Quantum
@@ -11087,7 +11087,7 @@
     name: Chrome Mobile
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: smartphone
     brand: Wiko
@@ -11105,7 +11105,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: LG
@@ -11123,7 +11123,7 @@
     name: Chrome Mobile
     version: 99.0.4844.48
     engine: Blink
-    engine_version: ""
+    engine_version: "99.0.4844.48"
   device:
     type: smartphone
     brand: Jio
@@ -11141,7 +11141,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Doppio
@@ -11159,7 +11159,7 @@
     name: Chrome Webview
     version: 98.0.4758.87
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.87"
   device:
     type: smartphone
     brand: Yezz

--- a/Tests/fixtures/smartphone-5.yml
+++ b/Tests/fixtures/smartphone-5.yml
@@ -10,7 +10,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Gigaset
@@ -28,7 +28,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Gigaset
@@ -46,7 +46,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Gigaset
@@ -64,7 +64,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: G-TiDE
@@ -82,7 +82,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: G-TiDE
@@ -100,7 +100,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: G-TiDE
@@ -118,7 +118,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: G-TiDE
@@ -136,7 +136,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: G-TiDE
@@ -154,7 +154,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: G-TiDE
@@ -172,7 +172,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: G-TiDE
@@ -190,7 +190,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: G-TiDE
@@ -208,7 +208,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: G-TiDE
@@ -226,7 +226,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: G-TiDE
@@ -262,7 +262,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Ginzzu
@@ -280,7 +280,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Ginzzu
@@ -316,7 +316,7 @@
     name: Opera Mobile
     version: "51.3.2461.138727"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Ginzzu
@@ -334,7 +334,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Ginzzu
@@ -352,7 +352,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Ginzzu
@@ -370,7 +370,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Ginzzu
@@ -388,7 +388,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Ginzzu
@@ -406,7 +406,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Ginzzu
@@ -424,7 +424,7 @@
     name: Chrome Mobile
     version: "75.0.3770.67"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: smartphone
     brand: Ginzzu
@@ -442,7 +442,7 @@
     name: Chrome Webview
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Ginzzu
@@ -460,7 +460,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Ginzzu
@@ -478,7 +478,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Ginzzu
@@ -496,7 +496,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Ginzzu
@@ -514,7 +514,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Ginzzu
@@ -532,7 +532,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Ginzzu
@@ -550,7 +550,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Ginzzu
@@ -568,7 +568,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Ginzzu
@@ -586,7 +586,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Ginzzu
@@ -604,7 +604,7 @@
     name: Opera Mobile
     version: "53.0.2569.141117"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Ginzzu
@@ -622,7 +622,7 @@
     name: Chrome Mobile
     version: "68.0.3440.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.85"
   device:
     type: smartphone
     brand: Hoffmann
@@ -640,7 +640,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Hoffmann
@@ -658,7 +658,7 @@
     name: Chrome Webview
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Hoffmann
@@ -676,7 +676,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Hoffmann
@@ -694,7 +694,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Hoffmann
@@ -712,7 +712,7 @@
     name: Aloha Browser
     version: "2.14.1"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Hoffmann
@@ -730,7 +730,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Hoffmann
@@ -748,7 +748,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Hoffmann
@@ -766,7 +766,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Highscreen
@@ -784,7 +784,7 @@
     name: Yandex Browser
     version: "16.9.0.1424.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.116"
   device:
     type: smartphone
     brand: Highscreen
@@ -820,7 +820,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Highscreen
@@ -856,7 +856,7 @@
     name: Chrome Webview
     version: "80.0.3987.18"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.18"
   device:
     type: smartphone
     brand: Highscreen
@@ -874,7 +874,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Highscreen
@@ -892,7 +892,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Highscreen
@@ -910,7 +910,7 @@
     name: Aloha Browser
     version: "2.4.0.3"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Highscreen
@@ -928,7 +928,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Highscreen
@@ -964,7 +964,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Highscreen
@@ -982,7 +982,7 @@
     name: Chrome Webview
     version: "75.0.3770.67"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: smartphone
     brand: Highscreen
@@ -1000,7 +1000,7 @@
     name: Yandex Browser
     version: "8.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.100"
   device:
     type: smartphone
     brand: Highscreen
@@ -1018,7 +1018,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Highscreen
@@ -1036,7 +1036,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Highscreen
@@ -1054,7 +1054,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Highscreen
@@ -1072,7 +1072,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Highscreen
@@ -1090,7 +1090,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Highscreen
@@ -1108,7 +1108,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Highscreen
@@ -1126,7 +1126,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Highscreen
@@ -1144,7 +1144,7 @@
     name: Chrome Webview
     version: "75.0.3770.67"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: smartphone
     brand: Highscreen
@@ -1162,7 +1162,7 @@
     name: Opera Mobile
     version: "45.0.2254.144848"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Highscreen
@@ -1180,7 +1180,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Highscreen
@@ -1198,7 +1198,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Highscreen
@@ -1216,7 +1216,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Highscreen
@@ -1234,7 +1234,7 @@
     name: Chrome Webview
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Highscreen
@@ -1252,7 +1252,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Highscreen
@@ -1270,7 +1270,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Highscreen
@@ -1288,7 +1288,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Highscreen
@@ -1324,7 +1324,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Highscreen
@@ -1342,7 +1342,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Highscreen
@@ -1360,7 +1360,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Highscreen
@@ -1378,7 +1378,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Highscreen
@@ -1396,7 +1396,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Haier
@@ -1414,7 +1414,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Haier
@@ -1432,7 +1432,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Haier
@@ -1450,7 +1450,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Haier
@@ -1468,7 +1468,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Haier
@@ -1486,7 +1486,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Haier
@@ -1612,7 +1612,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Haier
@@ -1630,7 +1630,7 @@
     name: Chrome Mobile
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: smartphone
     brand: Haier
@@ -1648,7 +1648,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Haier
@@ -1666,7 +1666,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Haier
@@ -1718,7 +1718,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Haier
@@ -1736,7 +1736,7 @@
     name: Yandex Browser
     version: "9.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Haier
@@ -1808,7 +1808,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Haier
@@ -1826,7 +1826,7 @@
     name: Chrome Mobile
     version: "42.0.2311.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.109"
   device:
     type: smartphone
     brand: Haier
@@ -1844,7 +1844,7 @@
     name: Chrome Mobile
     version: "80.0.3987.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: smartphone
     brand: Huadoo
@@ -1862,7 +1862,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Huadoo
@@ -1880,7 +1880,7 @@
     name: Chrome Mobile
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Huadoo
@@ -1898,7 +1898,7 @@
     name: Opera Mobile
     version: "44.1.2254.143214"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Huadoo
@@ -1916,7 +1916,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Huadoo
@@ -1934,7 +1934,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Hafury
@@ -1952,7 +1952,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Hafury
@@ -1970,7 +1970,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Hisense
@@ -1988,7 +1988,7 @@
     name: Chrome Webview
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Hisense
@@ -2006,7 +2006,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Hisense
@@ -2042,7 +2042,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Hisense
@@ -2078,7 +2078,7 @@
     name: Chrome Webview
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Hisense
@@ -2096,7 +2096,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Hisense
@@ -2114,7 +2114,7 @@
     name: Chrome Webview
     version: "48.0.2564.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.116"
   device:
     type: smartphone
     brand: Hisense
@@ -2132,7 +2132,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Hisense
@@ -2150,7 +2150,7 @@
     name: Chrome Webview
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Hisense
@@ -2168,7 +2168,7 @@
     name: Chrome Webview
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Hisense
@@ -2204,7 +2204,7 @@
     name: Chrome Webview
     version: "48.0.2564.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.116"
   device:
     type: smartphone
     brand: Hisense
@@ -2222,7 +2222,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Hisense
@@ -2240,7 +2240,7 @@
     name: Chrome Webview
     version: "48.0.2564.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.116"
   device:
     type: smartphone
     brand: Hisense
@@ -2276,7 +2276,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Hisense
@@ -2312,7 +2312,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Hisense
@@ -2330,7 +2330,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Hisense
@@ -2400,7 +2400,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Hisense
@@ -2418,7 +2418,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Hisense
@@ -2454,7 +2454,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Hisense
@@ -2699,7 +2699,7 @@
     name: Chrome Mobile
     version: "29.0.1547.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "29.0.1547.59"
   device:
     type: smartphone
     brand: Hisense
@@ -2733,7 +2733,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Hisense
@@ -2871,7 +2871,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Hisense
@@ -2889,7 +2889,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Hisense
@@ -2925,7 +2925,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Hisense
@@ -2943,7 +2943,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Hisense
@@ -2961,7 +2961,7 @@
     name: Chrome Webview
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Hisense
@@ -2997,7 +2997,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Hisense
@@ -3051,7 +3051,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Homtom
@@ -3141,7 +3141,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Homtom
@@ -3177,7 +3177,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Homtom
@@ -3231,7 +3231,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Hyundai
@@ -3249,7 +3249,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Hyundai
@@ -3267,7 +3267,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Hyundai
@@ -3285,7 +3285,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Hyundai
@@ -3303,7 +3303,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Hyundai
@@ -3321,7 +3321,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Hyundai
@@ -3339,7 +3339,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Hyundai
@@ -3357,7 +3357,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Hyundai
@@ -3375,7 +3375,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Hyundai
@@ -3393,7 +3393,7 @@
     name: Chrome Webview
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Hyundai
@@ -3411,7 +3411,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Hyundai
@@ -3429,7 +3429,7 @@
     name: Chrome Webview
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Hyundai
@@ -3447,7 +3447,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Hyundai
@@ -3465,7 +3465,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Hyundai
@@ -3657,7 +3657,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: HTC
@@ -3837,7 +3837,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: HTC
@@ -3927,7 +3927,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: HTC
@@ -4017,7 +4017,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: HTC
@@ -4303,7 +4303,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: HTC
@@ -4339,7 +4339,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: HTC
@@ -4373,7 +4373,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: HTC
@@ -4589,7 +4589,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: HTC
@@ -5163,7 +5163,7 @@
     name: Opera Mobile
     version: "15.0.1162.61541"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.63"
   device:
     type: smartphone
     brand: HTC
@@ -5703,7 +5703,7 @@
     name: Chrome Mobile
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: smartphone
     brand: HTC
@@ -5721,7 +5721,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: HTC
@@ -5865,7 +5865,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: HTC
@@ -5935,7 +5935,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: HTC
@@ -5953,7 +5953,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: HTC
@@ -5971,7 +5971,7 @@
     name: Chrome Webview
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: HTC
@@ -6007,7 +6007,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: HTC
@@ -6025,7 +6025,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: HTC
@@ -6043,7 +6043,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: HTC
@@ -6401,7 +6401,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: HTC
@@ -6689,7 +6689,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: HTC
@@ -6797,7 +6797,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: HTC
@@ -6869,7 +6869,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: HTC
@@ -6923,7 +6923,7 @@
     name: Chrome Mobile
     version: "30.0.1599.82"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.82"
   device:
     type: smartphone
     brand: HTC
@@ -7283,7 +7283,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: HTC
@@ -7301,7 +7301,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: HTC
@@ -7319,7 +7319,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: HTC
@@ -7337,7 +7337,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: HTC
@@ -7409,7 +7409,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: HTC
@@ -7499,7 +7499,7 @@
     name: Opera Mobile
     version: "54.3.2672.50220"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: HTC
@@ -7661,7 +7661,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Huawei
@@ -7679,7 +7679,7 @@
     name: Opera Mobile
     version: "46.1.2246.127339"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Huawei
@@ -7751,7 +7751,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -7769,7 +7769,7 @@
     name: Chrome Mobile
     version: "47.0.2526.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.76"
   device:
     type: smartphone
     brand: Huawei
@@ -7787,7 +7787,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Huawei
@@ -7805,7 +7805,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Huawei
@@ -7823,7 +7823,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -7841,7 +7841,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Huawei
@@ -7895,7 +7895,7 @@
     name: Chrome Mobile
     version: "37.0.2062.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.117"
   device:
     type: smartphone
     brand: Huawei
@@ -7913,7 +7913,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -7931,7 +7931,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -7949,7 +7949,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -7967,7 +7967,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -7985,7 +7985,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -8003,7 +8003,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -8021,7 +8021,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -8075,7 +8075,7 @@
     name: Chrome Mobile
     version: "60.0.2729.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.2729.119"
   device:
     type: smartphone
     brand: Huawei
@@ -8093,7 +8093,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Huawei
@@ -8111,7 +8111,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Huawei
@@ -8219,7 +8219,7 @@
     name: Chrome Webview
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: Huawei
@@ -8273,7 +8273,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -8291,7 +8291,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -8309,7 +8309,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -8327,7 +8327,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -8345,7 +8345,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -8363,7 +8363,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -8381,7 +8381,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -8399,7 +8399,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -8417,7 +8417,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -8435,7 +8435,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -8453,7 +8453,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Huawei
@@ -8489,7 +8489,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Huawei
@@ -8507,7 +8507,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -8525,7 +8525,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -8543,7 +8543,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -8561,7 +8561,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Huawei
@@ -8579,7 +8579,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -8597,7 +8597,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Huawei
@@ -8615,7 +8615,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -8633,7 +8633,7 @@
     name: Yandex Browser
     version: "19.3.2.347.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.119"
   device:
     type: smartphone
     brand: Huawei
@@ -8651,7 +8651,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Huawei
@@ -8669,7 +8669,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -8687,7 +8687,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -8723,7 +8723,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -8741,7 +8741,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Huawei
@@ -8759,7 +8759,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Huawei
@@ -8777,7 +8777,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -8813,7 +8813,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -8831,7 +8831,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -8849,7 +8849,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -8867,7 +8867,7 @@
     name: Chrome Mobile
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: Huawei
@@ -8885,7 +8885,7 @@
     name: Chrome Mobile
     version: "72.0.3626.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Huawei
@@ -8903,7 +8903,7 @@
     name: Chrome Mobile
     version: "72.0.3626.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Huawei
@@ -8954,7 +8954,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Huawei
@@ -8990,7 +8990,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Bittium
@@ -9008,7 +9008,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Logic Instrument
@@ -9026,7 +9026,7 @@
     name: Chrome Mobile
     version: 91.0.4472.134
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.134"
   device:
     type: smartphone
     brand: Huawei
@@ -9044,7 +9044,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: iPro
@@ -9062,7 +9062,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Hot Pepper
@@ -9080,7 +9080,7 @@
     name: Chrome Mobile
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: smartphone
     brand: Hi
@@ -9098,7 +9098,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: Sky
@@ -9116,7 +9116,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Sky
@@ -9134,7 +9134,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: Brondi
@@ -9152,7 +9152,7 @@
     name: Chrome Mobile
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: smartphone
     brand: ""
@@ -9170,7 +9170,7 @@
     name: Chrome Mobile
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: smartphone
     brand: Energizer
@@ -9188,7 +9188,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: smartphone
     brand: iPro

--- a/Tests/fixtures/smartphone-6.yml
+++ b/Tests/fixtures/smartphone-6.yml
@@ -80,7 +80,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Huawei
@@ -168,7 +168,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -186,7 +186,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Huawei
@@ -204,7 +204,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Huawei
@@ -222,7 +222,7 @@
     name: Chrome Mobile
     version: "72.0.3626.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Huawei
@@ -240,7 +240,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Huawei
@@ -258,7 +258,7 @@
     name: Chrome Mobile
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: smartphone
     brand: Huawei
@@ -330,7 +330,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -348,7 +348,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -366,7 +366,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Huawei
@@ -384,7 +384,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -402,7 +402,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -420,7 +420,7 @@
     name: Chrome Mobile
     version: "69.0.3497.128"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.128"
   device:
     type: smartphone
     brand: Huawei
@@ -438,7 +438,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Huawei
@@ -456,7 +456,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -474,7 +474,7 @@
     name: Chrome Mobile
     version: "75.0.3770.67"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: smartphone
     brand: Huawei
@@ -492,7 +492,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -510,7 +510,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -528,7 +528,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -546,7 +546,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -564,7 +564,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Huawei
@@ -582,7 +582,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -600,7 +600,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Huawei
@@ -618,7 +618,7 @@
     name: Opera Mobile
     version: "55.1.2719.50626"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Huawei
@@ -636,7 +636,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -654,7 +654,7 @@
     name: Chrome Webview
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -744,7 +744,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Huawei
@@ -884,7 +884,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Huawei
@@ -902,7 +902,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Huawei
@@ -972,7 +972,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Huawei
@@ -990,7 +990,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -1026,7 +1026,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Huawei
@@ -1044,7 +1044,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Huawei
@@ -1062,7 +1062,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Huawei
@@ -1184,7 +1184,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Huawei
@@ -1202,7 +1202,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Huawei
@@ -1220,7 +1220,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Huawei
@@ -1238,7 +1238,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Huawei
@@ -1256,7 +1256,7 @@
     name: Chrome Mobile
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: Huawei
@@ -1274,7 +1274,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Huawei
@@ -1292,7 +1292,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Huawei
@@ -1310,7 +1310,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Huawei
@@ -1328,7 +1328,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Huawei
@@ -1346,7 +1346,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Huawei
@@ -1364,7 +1364,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Huawei
@@ -1382,7 +1382,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Huawei
@@ -1400,7 +1400,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Huawei
@@ -1418,7 +1418,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Huawei
@@ -1436,7 +1436,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Huawei
@@ -1454,7 +1454,7 @@
     name: Chrome Mobile
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: Huawei
@@ -1472,7 +1472,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Huawei
@@ -1490,7 +1490,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Huawei
@@ -1508,7 +1508,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Huawei
@@ -1526,7 +1526,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -1580,7 +1580,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Huawei
@@ -1598,7 +1598,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Huawei
@@ -1616,7 +1616,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Huawei
@@ -1634,7 +1634,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Huawei
@@ -1702,7 +1702,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Huawei
@@ -1720,7 +1720,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Huawei
@@ -1738,7 +1738,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Huawei
@@ -1756,7 +1756,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -1774,7 +1774,7 @@
     name: Yandex Browser
     version: "19.7.2.90.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -1808,7 +1808,7 @@
     name: Chrome
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Huawei
@@ -1826,7 +1826,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Huawei
@@ -1844,7 +1844,7 @@
     name: Chrome Webview
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Huawei
@@ -1862,7 +1862,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Huawei
@@ -1880,7 +1880,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Huawei
@@ -1898,7 +1898,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -1916,7 +1916,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Huawei
@@ -1934,7 +1934,7 @@
     name: Chrome Mobile
     version: "60.0.3112.107"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.107"
   device:
     type: smartphone
     brand: Huawei
@@ -1952,7 +1952,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Huawei
@@ -1970,7 +1970,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Huawei
@@ -1988,7 +1988,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Huawei
@@ -2006,7 +2006,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Huawei
@@ -2076,7 +2076,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Huawei
@@ -2094,7 +2094,7 @@
     name: Chrome Webview
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: Huawei
@@ -2112,7 +2112,7 @@
     name: Chrome Webview
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: Huawei
@@ -2146,7 +2146,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Huawei
@@ -2164,7 +2164,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Huawei
@@ -2182,7 +2182,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Huawei
@@ -2200,7 +2200,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -2218,7 +2218,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Huawei
@@ -2254,7 +2254,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Huawei
@@ -2272,7 +2272,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Huawei
@@ -2290,7 +2290,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -2326,7 +2326,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -2380,7 +2380,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Huawei
@@ -2398,7 +2398,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -2416,7 +2416,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -2434,7 +2434,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Huawei
@@ -2452,7 +2452,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Huawei
@@ -2470,7 +2470,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Huawei
@@ -2488,7 +2488,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Huawei
@@ -2506,7 +2506,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Huawei
@@ -2524,7 +2524,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Huawei
@@ -2542,7 +2542,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Huawei
@@ -2560,7 +2560,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Huawei
@@ -2578,7 +2578,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -2596,7 +2596,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -2614,7 +2614,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Huawei
@@ -2632,7 +2632,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -2668,7 +2668,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -2686,7 +2686,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -2704,7 +2704,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Huawei
@@ -2722,7 +2722,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Huawei
@@ -2740,7 +2740,7 @@
     name: Yandex Browser
     version: "17.11.0.465.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.94"
   device:
     type: smartphone
     brand: Huawei
@@ -2758,7 +2758,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -2776,7 +2776,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Huawei
@@ -2794,7 +2794,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Huawei
@@ -2812,7 +2812,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -2830,7 +2830,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -2848,7 +2848,7 @@
     name: Opera Mobile
     version: "53.0.2551.140375"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Huawei
@@ -2866,7 +2866,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -2884,7 +2884,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -2902,7 +2902,7 @@
     name: Chrome Webview
     version: "71.0.3578.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: smartphone
     brand: Huawei
@@ -2920,7 +2920,7 @@
     name: Chrome Webview
     version: "71.0.3578.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: smartphone
     brand: Huawei
@@ -2938,7 +2938,7 @@
     name: Chrome Webview
     version: "71.0.3578.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: smartphone
     brand: Huawei
@@ -2956,7 +2956,7 @@
     name: Chrome Webview
     version: "71.0.3578.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: smartphone
     brand: Huawei
@@ -2992,7 +2992,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Huawei
@@ -3010,7 +3010,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Huawei
@@ -3028,7 +3028,7 @@
     name: Opera Mobile
     version: "52.4.2517.140781"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Huawei
@@ -3046,7 +3046,7 @@
     name: Yandex Browser
     version: "19.6.4.349.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.169"
   device:
     type: smartphone
     brand: Huawei
@@ -3064,7 +3064,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Huawei
@@ -3082,7 +3082,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Huawei
@@ -3100,7 +3100,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Huawei
@@ -3118,7 +3118,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -3136,7 +3136,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -3154,7 +3154,7 @@
     name: Opera Mobile
     version: "51.3.2461.138727"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Huawei
@@ -3172,7 +3172,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -3190,7 +3190,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -3208,7 +3208,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -3226,7 +3226,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Huawei
@@ -3244,7 +3244,7 @@
     name: Opera Mobile
     version: "43.3.2254.141404"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -3278,7 +3278,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -3296,7 +3296,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -3314,7 +3314,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -3348,7 +3348,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Huawei
@@ -3366,7 +3366,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Huawei
@@ -3384,7 +3384,7 @@
     name: Chrome Webview
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Huawei
@@ -3402,7 +3402,7 @@
     name: Chrome Webview
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Huawei
@@ -3420,7 +3420,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -3438,7 +3438,7 @@
     name: Chrome Webview
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -3456,7 +3456,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Huawei
@@ -3474,7 +3474,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Huawei
@@ -3492,7 +3492,7 @@
     name: Chrome Webview
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -3526,7 +3526,7 @@
     name: Chrome Webview
     version: "73.0.3683.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.121"
   device:
     type: smartphone
     brand: Huawei
@@ -3544,7 +3544,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Huawei
@@ -3562,7 +3562,7 @@
     name: Chrome Webview
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Huawei
@@ -3580,7 +3580,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -3598,7 +3598,7 @@
     name: Chrome Mobile
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Huawei
@@ -3616,7 +3616,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -3634,7 +3634,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Huawei
@@ -3652,7 +3652,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -3670,7 +3670,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -3688,7 +3688,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -3706,7 +3706,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -3740,7 +3740,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -3758,7 +3758,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -3776,7 +3776,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Huawei
@@ -3794,7 +3794,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -3812,7 +3812,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -3900,7 +3900,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -3918,7 +3918,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Huawei
@@ -3936,7 +3936,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Huawei
@@ -3954,7 +3954,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -3972,7 +3972,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -3990,7 +3990,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -4026,7 +4026,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Huawei
@@ -4044,7 +4044,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -4062,7 +4062,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Huawei
@@ -4080,7 +4080,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Huawei
@@ -4098,7 +4098,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Huawei
@@ -4116,7 +4116,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -4150,7 +4150,7 @@
     name: Chrome Mobile
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: Huawei
@@ -4168,7 +4168,7 @@
     name: Chrome Mobile
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: Huawei
@@ -4186,7 +4186,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -4220,7 +4220,7 @@
     name: Chrome Webview
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: Huawei
@@ -4238,7 +4238,7 @@
     name: Chrome Mobile
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Huawei
@@ -4256,7 +4256,7 @@
     name: Chrome Webview
     version: "75.0.3770.156"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.156"
   device:
     type: smartphone
     brand: Huawei
@@ -4274,7 +4274,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -4292,7 +4292,7 @@
     name: Chrome Webview
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -4310,7 +4310,7 @@
     name: Chrome Webview
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -4328,7 +4328,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -4346,7 +4346,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Huawei
@@ -4364,7 +4364,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Huawei
@@ -4382,7 +4382,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Huawei
@@ -4400,7 +4400,7 @@
     name: Yandex Browser
     version: "19.7.7.115.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -4595,7 +4595,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -4613,7 +4613,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Huawei
@@ -4631,7 +4631,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Huawei
@@ -4649,7 +4649,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Huawei
@@ -4667,7 +4667,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Huawei
@@ -4701,7 +4701,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -4719,7 +4719,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -4737,7 +4737,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -4755,7 +4755,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Huawei
@@ -4773,7 +4773,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -4791,7 +4791,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Huawei
@@ -4809,7 +4809,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Huawei
@@ -4827,7 +4827,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -4845,7 +4845,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -4863,7 +4863,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Huawei
@@ -4881,7 +4881,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -4899,7 +4899,7 @@
     name: Huawei Browser Mobile
     version: "9.0.2.305"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Huawei
@@ -4917,7 +4917,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -4935,7 +4935,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Huawei
@@ -4953,7 +4953,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Huawei
@@ -4971,7 +4971,7 @@
     name: Huawei Browser Mobile
     version: "9.0.1.323"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Huawei
@@ -4989,7 +4989,7 @@
     name: Chrome Webview
     version: "73.0.3683.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.121"
   device:
     type: smartphone
     brand: Huawei
@@ -5007,7 +5007,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Huawei
@@ -5025,7 +5025,7 @@
     name: Chrome Webview
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: Huawei
@@ -5043,7 +5043,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -5061,7 +5061,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Huawei
@@ -5079,7 +5079,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -5097,7 +5097,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -5115,7 +5115,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Huawei
@@ -5133,7 +5133,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Huawei
@@ -5151,7 +5151,7 @@
     name: Yandex Browser
     version: "19.12.1.121.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.97"
   device:
     type: smartphone
     brand: Huawei
@@ -5169,7 +5169,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Huawei
@@ -5203,7 +5203,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Huawei
@@ -5237,7 +5237,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -5255,7 +5255,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Huawei
@@ -5273,7 +5273,7 @@
     name: Chrome Mobile
     version: "71.0.3578.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: smartphone
     brand: Huawei
@@ -5291,7 +5291,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Huawei
@@ -5309,7 +5309,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Huawei
@@ -5327,7 +5327,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Huawei
@@ -5345,7 +5345,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -5363,7 +5363,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -5381,7 +5381,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -5471,7 +5471,7 @@
     name: Chrome Webview
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Huawei
@@ -5489,7 +5489,7 @@
     name: Chrome Webview
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Huawei
@@ -5507,7 +5507,7 @@
     name: Chrome Webview
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Huawei
@@ -5525,7 +5525,7 @@
     name: Chrome Webview
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Huawei
@@ -5543,7 +5543,7 @@
     name: Chrome Webview
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Huawei
@@ -5561,7 +5561,7 @@
     name: Chrome Webview
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Huawei
@@ -5579,7 +5579,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Huawei
@@ -5597,7 +5597,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Huawei
@@ -5615,7 +5615,7 @@
     name: Chrome Mobile
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Huawei
@@ -5633,7 +5633,7 @@
     name: Chrome Webview
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Huawei
@@ -5651,7 +5651,7 @@
     name: Chrome Mobile
     version: "71.0.3578.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: smartphone
     brand: Huawei
@@ -5669,7 +5669,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -5705,7 +5705,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Huawei
@@ -5723,7 +5723,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Huawei
@@ -5741,7 +5741,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -5759,7 +5759,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -5777,7 +5777,7 @@
     name: Chrome Mobile
     version: "72.0.3626.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Huawei
@@ -5813,7 +5813,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Huawei
@@ -5831,7 +5831,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Huawei
@@ -5849,7 +5849,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Huawei
@@ -5867,7 +5867,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -5903,7 +5903,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Huawei
@@ -5921,7 +5921,7 @@
     name: Chrome Mobile
     version: "75.0.3770.67"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: smartphone
     brand: Huawei
@@ -5939,7 +5939,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -5957,7 +5957,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Huawei
@@ -5975,7 +5975,7 @@
     name: Chrome Mobile
     version: "75.0.3770.67"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: smartphone
     brand: Huawei
@@ -5993,7 +5993,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -6011,7 +6011,7 @@
     name: Chrome Webview
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: Huawei
@@ -6047,7 +6047,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Huawei
@@ -6065,7 +6065,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -6083,7 +6083,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Huawei
@@ -6101,7 +6101,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -6119,7 +6119,7 @@
     name: Chrome Webview
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -6137,7 +6137,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Huawei
@@ -6155,7 +6155,7 @@
     name: Chrome Webview
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -6173,7 +6173,7 @@
     name: Chrome Webview
     version: "57.0.2987.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.108"
   device:
     type: smartphone
     brand: Huawei
@@ -6191,7 +6191,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -6227,7 +6227,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Huawei
@@ -6245,7 +6245,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -6263,7 +6263,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Huawei
@@ -6281,7 +6281,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Huawei
@@ -6299,7 +6299,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -6317,7 +6317,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -6335,7 +6335,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -6353,7 +6353,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Huawei
@@ -6371,7 +6371,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Huawei
@@ -6389,7 +6389,7 @@
     name: Yandex Browser
     version: "19.6.2.338.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.169"
   device:
     type: smartphone
     brand: Huawei
@@ -6407,7 +6407,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Huawei
@@ -6443,7 +6443,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Huawei
@@ -6461,7 +6461,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -6479,7 +6479,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -6497,7 +6497,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Huawei
@@ -6515,7 +6515,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Huawei
@@ -6533,7 +6533,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -6551,7 +6551,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -6569,7 +6569,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Huawei
@@ -6587,7 +6587,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Huawei
@@ -6657,7 +6657,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -6675,7 +6675,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -6693,7 +6693,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Huawei
@@ -6711,7 +6711,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Huawei
@@ -6729,7 +6729,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Huawei
@@ -6747,7 +6747,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -6765,7 +6765,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -6783,7 +6783,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Huawei
@@ -6801,7 +6801,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -6819,7 +6819,7 @@
     name: Chrome Mobile
     version: "81.0.4044.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: smartphone
     brand: Huawei
@@ -6837,7 +6837,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Huawei
@@ -6855,7 +6855,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -6873,7 +6873,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -6891,7 +6891,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -6909,7 +6909,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Huawei
@@ -6927,7 +6927,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Huawei
@@ -6961,7 +6961,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -6979,7 +6979,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Huawei
@@ -6997,7 +6997,7 @@
     name: Chrome Mobile
     version: "75.0.3770.67"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: smartphone
     brand: Huawei
@@ -7015,7 +7015,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Huawei
@@ -7033,7 +7033,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -7051,7 +7051,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Huawei
@@ -7069,7 +7069,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Huawei
@@ -7087,7 +7087,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Huawei
@@ -7105,7 +7105,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Huawei
@@ -7141,7 +7141,7 @@
     name: Yandex Browser
     version: "19.6.4.349.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.169"
   device:
     type: smartphone
     brand: Huawei
@@ -7159,7 +7159,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Huawei
@@ -7177,7 +7177,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Huawei
@@ -7195,7 +7195,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Huawei
@@ -7213,7 +7213,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -7231,7 +7231,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -7249,7 +7249,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Huawei
@@ -7267,7 +7267,7 @@
     name: Chrome Webview
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -7285,7 +7285,7 @@
     name: Chrome Mobile
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Huawei
@@ -7303,7 +7303,7 @@
     name: Chrome Webview
     version: "73.0.3683.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.121"
   device:
     type: smartphone
     brand: Huawei
@@ -7321,7 +7321,7 @@
     name: Chrome Webview
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -7339,7 +7339,7 @@
     name: Opera Mobile
     version: "58.1.2878.53288"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Huawei
@@ -7375,7 +7375,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Huawei
@@ -7393,7 +7393,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Huawei
@@ -7411,7 +7411,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Huawei
@@ -7429,7 +7429,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -7447,7 +7447,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Huawei
@@ -7465,7 +7465,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -7483,7 +7483,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Huawei
@@ -7501,7 +7501,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Huawei
@@ -7519,7 +7519,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Huawei
@@ -7537,7 +7537,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Huawei
@@ -7555,7 +7555,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Huawei
@@ -7573,7 +7573,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Huawei
@@ -7591,7 +7591,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -7609,7 +7609,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Huawei
@@ -7627,7 +7627,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Huawei
@@ -7645,7 +7645,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Huawei
@@ -7663,7 +7663,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -7681,7 +7681,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -7699,7 +7699,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Huawei
@@ -7717,7 +7717,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Huawei
@@ -7735,7 +7735,7 @@
     name: Chrome Webview
     version: "83.0.4103.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: Huawei
@@ -7753,7 +7753,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -7771,7 +7771,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -7789,7 +7789,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Huawei
@@ -7823,7 +7823,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Huawei
@@ -7841,7 +7841,7 @@
     name: Chrome Mobile
     version: "71.0.3578.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: smartphone
     brand: Huawei
@@ -7859,7 +7859,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -7877,7 +7877,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -8057,7 +8057,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Huawei
@@ -8147,7 +8147,7 @@
     name: Chrome Mobile
     version: "33.0.1750.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.132"
   device:
     type: smartphone
     brand: Huawei
@@ -8255,7 +8255,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Huawei
@@ -8327,7 +8327,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Huawei
@@ -8345,7 +8345,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Huawei
@@ -8363,7 +8363,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Huawei
@@ -8399,7 +8399,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -8417,7 +8417,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -8435,7 +8435,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -8453,7 +8453,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -8471,7 +8471,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -8525,7 +8525,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Huawei
@@ -8543,7 +8543,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Huawei
@@ -8561,7 +8561,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Huawei
@@ -8579,7 +8579,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Huawei
@@ -8597,7 +8597,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -8615,7 +8615,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Huawei
@@ -8633,7 +8633,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Huawei
@@ -8651,7 +8651,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -8669,7 +8669,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -8687,7 +8687,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -8705,7 +8705,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Huawei
@@ -8723,7 +8723,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -8741,7 +8741,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -8759,7 +8759,7 @@
     name: Chrome Webview
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Huawei
@@ -8777,7 +8777,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -8795,7 +8795,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -8813,7 +8813,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -8831,7 +8831,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -8849,7 +8849,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Huawei
@@ -8867,7 +8867,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -8885,7 +8885,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Huawei
@@ -8921,7 +8921,7 @@
     name: Chrome Webview
     version: "50.0.2661.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Huawei
@@ -8939,7 +8939,7 @@
     name: Chrome Webview
     version: "50.0.2661.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Huawei

--- a/Tests/fixtures/smartphone-7.yml
+++ b/Tests/fixtures/smartphone-7.yml
@@ -10,7 +10,7 @@
     name: Chrome Webview
     version: "50.0.2661.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Huawei
@@ -28,7 +28,7 @@
     name: Chrome Webview
     version: "50.0.2661.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Huawei
@@ -46,7 +46,7 @@
     name: Chrome Webview
     version: "50.0.2661.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Huawei
@@ -64,7 +64,7 @@
     name: Chrome Webview
     version: "50.0.2661.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Huawei
@@ -82,7 +82,7 @@
     name: Chrome Webview
     version: "50.0.2661.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Huawei
@@ -100,7 +100,7 @@
     name: Chrome Webview
     version: "50.0.2661.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Huawei
@@ -118,7 +118,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Huawei
@@ -136,7 +136,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -154,7 +154,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Huawei
@@ -172,7 +172,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -190,7 +190,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -208,7 +208,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -226,7 +226,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Huawei
@@ -244,7 +244,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -262,7 +262,7 @@
     name: Chrome Mobile
     version: "85.0.4183.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Huawei
@@ -280,7 +280,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Huawei
@@ -298,7 +298,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Huawei
@@ -316,7 +316,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Huawei
@@ -334,7 +334,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Huawei
@@ -352,7 +352,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -370,7 +370,7 @@
     name: Chrome Mobile
     version: "38.0.2125.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.114"
   device:
     type: smartphone
     brand: Huawei
@@ -388,7 +388,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Huawei
@@ -406,7 +406,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Huawei
@@ -424,7 +424,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Huawei
@@ -442,7 +442,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -460,7 +460,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Huawei
@@ -478,7 +478,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Huawei
@@ -496,7 +496,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -514,7 +514,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Huawei
@@ -550,7 +550,7 @@
     name: Huawei Browser Mobile
     version: "10.1.4.303"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Huawei
@@ -568,7 +568,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -586,7 +586,7 @@
     name: Chrome Mobile
     version: "72.0.3626.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Huawei
@@ -604,7 +604,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -622,7 +622,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -640,7 +640,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -658,7 +658,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Huawei
@@ -676,7 +676,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Huawei
@@ -694,7 +694,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -730,7 +730,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Huawei
@@ -748,7 +748,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Huawei
@@ -766,7 +766,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Huawei
@@ -784,7 +784,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -802,7 +802,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Huawei
@@ -820,7 +820,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Huawei
@@ -838,7 +838,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Huawei
@@ -856,7 +856,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Huawei
@@ -874,7 +874,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Huawei
@@ -908,7 +908,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -926,7 +926,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -944,7 +944,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Huawei
@@ -962,7 +962,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Huawei
@@ -980,7 +980,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Hotwav
@@ -998,7 +998,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Hotwav
@@ -1016,7 +1016,7 @@
     name: Chrome Webview
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Hotwav
@@ -1034,7 +1034,7 @@
     name: Chrome Webview
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Hotwav
@@ -1052,7 +1052,7 @@
     name: Chrome Webview
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Hotwav
@@ -1070,7 +1070,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Hotwav
@@ -1088,7 +1088,7 @@
     name: Chrome Webview
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Hotwav
@@ -1178,7 +1178,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: InFocus
@@ -1250,7 +1250,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: iOcean
@@ -1268,7 +1268,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: iOcean
@@ -1286,7 +1286,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: iOcean
@@ -1304,7 +1304,7 @@
     name: Chrome Mobile
     version: "45.0.2454.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.94"
   device:
     type: smartphone
     brand: iOcean
@@ -1322,7 +1322,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: iOcean
@@ -1358,7 +1358,7 @@
     name: Yandex Browser
     version: "16.7.0.2777.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.106"
   device:
     type: smartphone
     brand: Impression
@@ -1394,7 +1394,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Impression
@@ -1412,7 +1412,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Impression
@@ -1430,7 +1430,7 @@
     name: Chrome Webview
     version: "50.0.2661.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: Impression
@@ -1448,7 +1448,7 @@
     name: Chrome Mobile
     version: "54.0.2840.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.68"
   device:
     type: smartphone
     brand: Impression
@@ -1466,7 +1466,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Impression
@@ -1484,7 +1484,7 @@
     name: Chrome Webview
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Inoi
@@ -1502,7 +1502,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Inoi
@@ -1520,7 +1520,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Inoi
@@ -1538,7 +1538,7 @@
     name: Yandex Browser Lite
     version: "19.1.0.130"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Inoi
@@ -1556,7 +1556,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Inoi
@@ -1574,7 +1574,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Inoi
@@ -1592,7 +1592,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Inoi
@@ -1610,7 +1610,7 @@
     name: Yandex Browser
     version: "18.11.2.730.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: smartphone
     brand: Inoi
@@ -1628,7 +1628,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: InnJoo
@@ -1646,7 +1646,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: InnJoo
@@ -1664,7 +1664,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: InnJoo
@@ -1682,7 +1682,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: InnJoo
@@ -1700,7 +1700,7 @@
     name: Chrome Webview
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: InnJoo
@@ -1718,7 +1718,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: InnJoo
@@ -1736,7 +1736,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: InnJoo
@@ -1754,7 +1754,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: InnJoo
@@ -1772,7 +1772,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: InnJoo
@@ -1808,7 +1808,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: InnJoo
@@ -1826,7 +1826,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: InnJoo
@@ -1844,7 +1844,7 @@
     name: Chrome Webview
     version: "48.0.2564.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.106"
   device:
     type: smartphone
     brand: InnJoo
@@ -1862,7 +1862,7 @@
     name: Chrome Webview
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Irbis
@@ -1880,7 +1880,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Irbis
@@ -1898,7 +1898,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Irbis
@@ -1934,7 +1934,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Irbis
@@ -1952,7 +1952,7 @@
     name: Chrome Webview
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Irbis
@@ -1970,7 +1970,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Irbis
@@ -1988,7 +1988,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Irbis
@@ -2006,7 +2006,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Irbis
@@ -2024,7 +2024,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Irbis
@@ -2060,7 +2060,7 @@
     name: Chrome Webview
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Irbis
@@ -2078,7 +2078,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Irbis
@@ -2096,7 +2096,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Irbis
@@ -2114,7 +2114,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Irbis
@@ -2132,7 +2132,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Irbis
@@ -2150,7 +2150,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Irbis
@@ -2168,7 +2168,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Irbis
@@ -2186,7 +2186,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Irbis
@@ -2204,7 +2204,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Irbis
@@ -2222,7 +2222,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Irbis
@@ -2240,7 +2240,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Irbis
@@ -2258,7 +2258,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Irbis
@@ -2276,7 +2276,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Irbis
@@ -2294,7 +2294,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Irbis
@@ -2312,7 +2312,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Irbis
@@ -2330,7 +2330,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Irbis
@@ -2348,7 +2348,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Irbis
@@ -2384,7 +2384,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: iLA
@@ -2402,7 +2402,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: iVA
@@ -2420,7 +2420,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: iDroid
@@ -2456,7 +2456,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Infinix
@@ -2492,7 +2492,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Infinix
@@ -2510,7 +2510,7 @@
     name: Chrome Webview
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Infinix
@@ -2528,7 +2528,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Infinix
@@ -2546,7 +2546,7 @@
     name: Chrome Mobile
     version: "85.0.4183.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: smartphone
     brand: Infinix
@@ -2564,7 +2564,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Infinix
@@ -2582,7 +2582,7 @@
     name: Chrome Webview
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Infinix
@@ -2600,7 +2600,7 @@
     name: Chrome Webview
     version: "67.0.3396.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.68"
   device:
     type: smartphone
     brand: Infinix
@@ -2672,7 +2672,7 @@
     name: Chrome Mobile
     version: "85.0.4183.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Infinix
@@ -2690,7 +2690,7 @@
     name: Chrome Mobile
     version: "85.0.4183.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: smartphone
     brand: Infinix
@@ -2708,7 +2708,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Infinix
@@ -2796,7 +2796,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: iHunt
@@ -2814,7 +2814,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: iHunt
@@ -2832,7 +2832,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: iHunt
@@ -2850,7 +2850,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: iHunt
@@ -2868,7 +2868,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: iHunt
@@ -2886,7 +2886,7 @@
     name: Chrome Webview
     version: "51.0.2704.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.91"
   device:
     type: smartphone
     brand: iHunt
@@ -2904,7 +2904,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: iHunt
@@ -2922,7 +2922,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: iHunt
@@ -2940,7 +2940,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: iHunt
@@ -2958,7 +2958,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: iHunt
@@ -3120,7 +3120,7 @@
     name: Chrome Webview
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: smartphone
     brand: IMO Mobile
@@ -3138,7 +3138,7 @@
     name: Chrome Mobile
     version: "49.0.2623.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: smartphone
     brand: IMO Mobile
@@ -3156,7 +3156,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: IMO Mobile
@@ -3264,7 +3264,7 @@
     name: Chrome Mobile
     version: "29.0.1547.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "29.0.1547.59"
   device:
     type: smartphone
     brand: IMO Mobile
@@ -3462,7 +3462,7 @@
     name: Chrome Mobile
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: smartphone
     brand: i-mobile
@@ -3624,7 +3624,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: i-mobile
@@ -3642,7 +3642,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: i-mobile
@@ -3714,7 +3714,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: iPro
@@ -3732,7 +3732,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: iPro
@@ -3750,7 +3750,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: iPro
@@ -3768,7 +3768,7 @@
     name: Chrome Webview
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: iPro
@@ -3822,7 +3822,7 @@
     name: Chrome Mobile
     version: "43.0.2357.78"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.78"
   device:
     type: smartphone
     brand: iNew
@@ -3840,7 +3840,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: iNew
@@ -3858,7 +3858,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: iNew
@@ -3894,7 +3894,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: iNew
@@ -3948,7 +3948,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: iNew
@@ -4128,7 +4128,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Intex
@@ -4290,7 +4290,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: iBerry
@@ -4326,7 +4326,7 @@
     name: Opera Mobile
     version: "16.0.1212.64462"
     engine: Blink
-    engine_version: ""
+    engine_version: "29.0.1547.72"
   device:
     type: smartphone
     brand: iBerry
@@ -4524,7 +4524,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: iTel
@@ -4542,7 +4542,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: iTel
@@ -4560,7 +4560,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Just5
@@ -4578,7 +4578,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Just5
@@ -4596,7 +4596,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Just5
@@ -4614,7 +4614,7 @@
     name: Chrome Mobile
     version: "74.0.3729.112"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: smartphone
     brand: Just5
@@ -4632,7 +4632,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Just5
@@ -4650,7 +4650,7 @@
     name: Chrome Mobile
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Just5
@@ -4668,7 +4668,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Just5
@@ -4686,7 +4686,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: Just5
@@ -4722,7 +4722,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Just5
@@ -4740,7 +4740,7 @@
     name: Chrome Mobile
     version: "40.0.2214.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: smartphone
     brand: Just5
@@ -4776,7 +4776,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Jinga
@@ -4794,7 +4794,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Jinga
@@ -4812,7 +4812,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Jinga
@@ -4830,7 +4830,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Jinga
@@ -4848,7 +4848,7 @@
     name: Chrome Mobile
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Jinga
@@ -4884,7 +4884,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Jinga
@@ -4920,7 +4920,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Jinga
@@ -4938,7 +4938,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Jiayu
@@ -4956,7 +4956,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Jiayu
@@ -4974,7 +4974,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Jiayu
@@ -4992,7 +4992,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Jiayu
@@ -5010,7 +5010,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Jiayu
@@ -5028,7 +5028,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Jiayu
@@ -5046,7 +5046,7 @@
     name: Yandex Browser
     version: "18.11.1.1011.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: smartphone
     brand: Jiayu
@@ -5064,7 +5064,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Jiayu
@@ -5154,7 +5154,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: Jiayu
@@ -5172,7 +5172,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Jiayu
@@ -5190,7 +5190,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: JKL
@@ -5226,7 +5226,7 @@
     name: Chrome Webview
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Kiano
@@ -5244,7 +5244,7 @@
     name: Chrome Mobile
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Kiano
@@ -5262,7 +5262,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Kiano
@@ -5280,7 +5280,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Kiano
@@ -5298,7 +5298,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Kiano
@@ -5316,7 +5316,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Kiano
@@ -5334,7 +5334,7 @@
     name: Chrome Webview
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: KRONO
@@ -5352,7 +5352,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Keneksi
@@ -5370,7 +5370,7 @@
     name: Yandex Browser
     version: "18.11.1.1011.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: smartphone
     brand: Keneksi
@@ -5388,7 +5388,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Keneksi
@@ -5406,7 +5406,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Keneksi
@@ -5424,7 +5424,7 @@
     name: Yandex Browser
     version: "18.11.1.1011.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: smartphone
     brand: Keneksi
@@ -5442,7 +5442,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Keneksi
@@ -5496,7 +5496,7 @@
     name: Chrome Mobile
     version: "71.0.3578.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.98"
   device:
     type: smartphone
     brand: Keneksi
@@ -5568,7 +5568,7 @@
     name: Opera Mobile
     version: "50.3.2426.136976"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Keneksi
@@ -5604,7 +5604,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Keneksi
@@ -5640,7 +5640,7 @@
     name: Yandex Browser
     version: "18.11.1.1011.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: smartphone
     brand: Keneksi
@@ -5676,7 +5676,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Keneksi
@@ -5694,7 +5694,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Keneksi
@@ -5748,7 +5748,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Keneksi
@@ -5766,7 +5766,7 @@
     name: Opera Mobile
     version: "50.3.2426.136976"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Keneksi
@@ -5784,7 +5784,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Keneksi
@@ -5802,7 +5802,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Keneksi
@@ -5838,7 +5838,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Keneksi
@@ -5856,7 +5856,7 @@
     name: Yandex Browser
     version: "18.11.1.1011.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: smartphone
     brand: Keneksi
@@ -5874,7 +5874,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Keneksi
@@ -5892,7 +5892,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Kaan
@@ -5910,7 +5910,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Kaan
@@ -5928,7 +5928,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Kaan
@@ -5946,7 +5946,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Kuliao
@@ -6234,7 +6234,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Karbonn
@@ -6252,7 +6252,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Karbonn
@@ -6270,7 +6270,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Karbonn
@@ -6288,7 +6288,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Karbonn
@@ -6306,7 +6306,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Karbonn
@@ -6324,7 +6324,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Karbonn
@@ -6342,7 +6342,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Karbonn
@@ -6360,7 +6360,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Karbonn
@@ -6378,7 +6378,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Karbonn
@@ -6396,7 +6396,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Karbonn
@@ -6414,7 +6414,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Karbonn
@@ -6432,7 +6432,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Karbonn
@@ -6466,7 +6466,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Karbonn
@@ -6484,7 +6484,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Karbonn
@@ -6502,7 +6502,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Karbonn
@@ -6520,7 +6520,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Karbonn
@@ -6538,7 +6538,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Karbonn
@@ -6556,7 +6556,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Karbonn
@@ -6626,7 +6626,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6644,7 +6644,7 @@
     name: Chrome Mobile
     version: "41.0.2272.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.96"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6662,7 +6662,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6680,7 +6680,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6698,7 +6698,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6716,7 +6716,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6734,7 +6734,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6752,7 +6752,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6770,7 +6770,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6788,7 +6788,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6806,7 +6806,7 @@
     name: Chrome Webview
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6824,7 +6824,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6842,7 +6842,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6860,7 +6860,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: 'Krüger&Matz'
@@ -6878,7 +6878,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Kogan
@@ -6932,7 +6932,7 @@
     name: Chrome Mobile
     version: "30.0.1599.36"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.36"
   device:
     type: smartphone
     brand: Kingsun
@@ -6982,7 +6982,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Kingsun
@@ -7000,7 +7000,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Kodak
@@ -7018,7 +7018,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Kodak
@@ -7036,7 +7036,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Kodak
@@ -7054,7 +7054,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Kodak
@@ -7072,7 +7072,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Kodak
@@ -7090,7 +7090,7 @@
     name: Chrome Webview
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Kalley
@@ -7108,7 +7108,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Komu
@@ -7126,7 +7126,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Komu
@@ -7304,7 +7304,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: 'Kempler & Strauss'
@@ -7322,7 +7322,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: 'Kempler & Strauss'
@@ -7340,7 +7340,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: 'Kempler & Strauss'
@@ -7358,7 +7358,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: 'Kempler & Strauss'
@@ -7376,7 +7376,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: 'Kempler & Strauss'
@@ -7748,7 +7748,7 @@
     name: Chrome Mobile
     version: "30.0.1599.36"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.36"
   device:
     type: smartphone
     brand: Kumai
@@ -7766,7 +7766,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Konrow
@@ -7784,7 +7784,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Konrow
@@ -7802,7 +7802,7 @@
     name: Chrome Mobile
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Konrow
@@ -7820,7 +7820,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Konrow
@@ -7838,7 +7838,7 @@
     name: Chrome Webview
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: smartphone
     brand: Konrow
@@ -7856,7 +7856,7 @@
     name: Chrome Webview
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Kenxinda
@@ -7874,7 +7874,7 @@
     name: Chrome Webview
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Kenxinda
@@ -7892,7 +7892,7 @@
     name: Chrome Webview
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Kenxinda
@@ -7910,7 +7910,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Kenxinda
@@ -7928,7 +7928,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Kenxinda
@@ -7946,7 +7946,7 @@
     name: Chrome Mobile
     version: "84.0.4147.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Kyocera
@@ -7964,7 +7964,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Kyocera
@@ -7982,7 +7982,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Kyocera
@@ -8000,7 +8000,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Kyocera
@@ -8018,7 +8018,7 @@
     name: Chrome Mobile
     version: "49.0.2623.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: smartphone
     brand: Kyocera
@@ -8036,7 +8036,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Kyocera
@@ -8054,7 +8054,7 @@
     name: Chrome Webview
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Kyocera
@@ -8088,7 +8088,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Kyocera
@@ -8106,7 +8106,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Kyocera
@@ -8124,7 +8124,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Kyocera
@@ -8142,7 +8142,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Kyocera
@@ -8160,7 +8160,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Kyocera
@@ -8178,7 +8178,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Kyocera
@@ -8196,7 +8196,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Kyocera
@@ -8214,7 +8214,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Kyocera
@@ -8232,7 +8232,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Kyocera
@@ -8250,7 +8250,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Kyocera
@@ -8304,7 +8304,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Kyocera
@@ -8322,7 +8322,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Kyocera
@@ -8358,7 +8358,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Kyocera
@@ -8376,7 +8376,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Kyocera
@@ -8394,7 +8394,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Kyocera
@@ -8430,7 +8430,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Kyocera
@@ -8448,7 +8448,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: Kyocera
@@ -8466,7 +8466,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Kyocera
@@ -8502,7 +8502,7 @@
     name: Chrome Mobile
     version: "60.0.3112.78"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.78"
   device:
     type: smartphone
     brand: Kyocera
@@ -8520,7 +8520,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Kyocera
@@ -8538,7 +8538,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Kyocera
@@ -8556,7 +8556,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Kyocera
@@ -8574,7 +8574,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Kyocera
@@ -8592,7 +8592,7 @@
     name: Chrome Mobile
     version: "84.0.4147.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Kyocera
@@ -8610,7 +8610,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Kyocera
@@ -8628,7 +8628,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Kyocera
@@ -8646,7 +8646,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Kyocera
@@ -8698,7 +8698,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Kyocera
@@ -8716,7 +8716,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Kyocera
@@ -8734,7 +8734,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Kyocera
@@ -8770,7 +8770,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Kyocera
@@ -8788,7 +8788,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Kyocera
@@ -8806,7 +8806,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Kyocera
@@ -8824,7 +8824,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Kyocera
@@ -8842,7 +8842,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Kyocera
@@ -8860,7 +8860,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Kyocera
@@ -8896,7 +8896,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Kazam
@@ -8930,7 +8930,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Kazam
@@ -8948,7 +8948,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Kazam
@@ -8966,7 +8966,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Kazam

--- a/Tests/fixtures/smartphone-8.yml
+++ b/Tests/fixtures/smartphone-8.yml
@@ -10,7 +10,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Kazam
@@ -46,7 +46,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Kazam
@@ -64,7 +64,7 @@
     name: Chrome Mobile
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Kazam
@@ -118,7 +118,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Kazam
@@ -154,7 +154,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: LeEco
@@ -172,7 +172,7 @@
     name: Chrome Webview
     version: "49.0.2623.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: smartphone
     brand: LeEco
@@ -190,7 +190,7 @@
     name: Chrome Webview
     version: "49.0.2623.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: smartphone
     brand: LeEco
@@ -208,7 +208,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: LeEco
@@ -244,7 +244,7 @@
     name: Chrome Webview
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: LeEco
@@ -262,7 +262,7 @@
     name: Chrome Mobile
     version: "54.0.2840.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.68"
   device:
     type: smartphone
     brand: LeEco
@@ -298,7 +298,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: LeEco
@@ -352,7 +352,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: LeEco
@@ -370,7 +370,7 @@
     name: Chrome Mobile
     version: "59.0.3071.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.92"
   device:
     type: smartphone
     brand: LeEco
@@ -388,7 +388,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Landvo
@@ -406,7 +406,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: iVA
@@ -424,7 +424,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Landvo
@@ -442,7 +442,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Landvo
@@ -460,7 +460,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Landvo
@@ -478,7 +478,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Landvo
@@ -496,7 +496,7 @@
     name: Chrome Mobile
     version: "44.0.2403.133"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.133"
   device:
     type: smartphone
     brand: Lexand
@@ -568,7 +568,7 @@
     name: Yandex Browser
     version: "17.4.0.544.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.137"
   device:
     type: smartphone
     brand: Lexand
@@ -604,7 +604,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Lemhoov
@@ -622,7 +622,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Leagoo
@@ -640,7 +640,7 @@
     name: Chrome Webview
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Leagoo
@@ -658,7 +658,7 @@
     name: Chrome Webview
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Leagoo
@@ -676,7 +676,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Leagoo
@@ -694,7 +694,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Leagoo
@@ -712,7 +712,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Leagoo
@@ -730,7 +730,7 @@
     name: Chrome Mobile
     version: "71.0.3578.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: smartphone
     brand: Leagoo
@@ -748,7 +748,7 @@
     name: Chrome Webview
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Leagoo
@@ -766,7 +766,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Leagoo
@@ -784,7 +784,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Leagoo
@@ -802,7 +802,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Leagoo
@@ -820,7 +820,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Leagoo
@@ -838,7 +838,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Leagoo
@@ -856,7 +856,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Leagoo
@@ -874,7 +874,7 @@
     name: Yandex Browser
     version: "18.11.1.979.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: smartphone
     brand: Leagoo
@@ -892,7 +892,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Leagoo
@@ -910,7 +910,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Land Rover
@@ -946,7 +946,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Land Rover
@@ -964,7 +964,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Land Rover
@@ -982,7 +982,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Land Rover
@@ -1036,7 +1036,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Land Rover
@@ -1054,7 +1054,7 @@
     name: Chrome Mobile
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: Land Rover
@@ -1072,7 +1072,7 @@
     name: Chrome Mobile
     version: "72.0.3626.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Land Rover
@@ -1162,7 +1162,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Lephone
@@ -1252,7 +1252,7 @@
     name: Chrome Webview
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Clarmin
@@ -1270,7 +1270,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Luna
@@ -1288,7 +1288,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Luna
@@ -1306,7 +1306,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Luna
@@ -1324,7 +1324,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Luna
@@ -1342,7 +1342,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Lanix
@@ -1360,7 +1360,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Lanix
@@ -1378,7 +1378,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Lanix
@@ -1396,7 +1396,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Lanix
@@ -1414,7 +1414,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Lanix
@@ -1432,7 +1432,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Lanix
@@ -1450,7 +1450,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Lanix
@@ -1468,7 +1468,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Lanix
@@ -1486,7 +1486,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Lanix
@@ -1504,7 +1504,7 @@
     name: Chrome Mobile
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: Lanix
@@ -1522,7 +1522,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Lanix
@@ -1540,7 +1540,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Lanix
@@ -1558,7 +1558,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Lanix
@@ -1576,7 +1576,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Lanix
@@ -1594,7 +1594,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Lanix
@@ -1612,7 +1612,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Lanix
@@ -1630,7 +1630,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Lanix
@@ -1648,7 +1648,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Lanix
@@ -1666,7 +1666,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Lanix
@@ -1684,7 +1684,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Lanix
@@ -1702,7 +1702,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Lanix
@@ -1720,7 +1720,7 @@
     name: Chrome Mobile
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Lanix
@@ -1738,7 +1738,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Lanix
@@ -1756,7 +1756,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Lanix
@@ -1774,7 +1774,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Lanix
@@ -1792,7 +1792,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Lanix
@@ -1810,7 +1810,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Lanix
@@ -1828,7 +1828,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Lanix
@@ -1846,7 +1846,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Lanix
@@ -1864,7 +1864,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Lanix
@@ -1882,7 +1882,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Lanix
@@ -1900,7 +1900,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Lanix
@@ -1918,7 +1918,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Lanix
@@ -1936,7 +1936,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Lanix
@@ -1954,7 +1954,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Lanix
@@ -1972,7 +1972,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Lanix
@@ -1990,7 +1990,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Lanix
@@ -2008,7 +2008,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Lanix
@@ -2026,7 +2026,7 @@
     name: Chrome Mobile
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: Lanix
@@ -2044,7 +2044,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Lanix
@@ -2062,7 +2062,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Lanix
@@ -2080,7 +2080,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Lanix
@@ -2116,7 +2116,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Ledstar
@@ -2278,7 +2278,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Lenovo
@@ -2296,7 +2296,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Lenovo
@@ -2458,7 +2458,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Lenovo
@@ -2476,7 +2476,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Lenovo
@@ -2494,7 +2494,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Lenovo
@@ -2512,7 +2512,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Lenovo
@@ -2530,7 +2530,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: Lenovo
@@ -2548,7 +2548,7 @@
     name: Chrome Mobile
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Lenovo
@@ -2566,7 +2566,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Lenovo
@@ -2584,7 +2584,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Lenovo
@@ -2602,7 +2602,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Lenovo
@@ -2620,7 +2620,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Lenovo
@@ -2638,7 +2638,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Lenovo
@@ -2656,7 +2656,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Lenovo
@@ -2674,7 +2674,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Lenovo
@@ -2692,7 +2692,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Lenovo
@@ -2710,7 +2710,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Lenovo
@@ -2728,7 +2728,7 @@
     name: Chrome Webview
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Lenovo
@@ -2746,7 +2746,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Lenovo
@@ -2800,7 +2800,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: Lenovo
@@ -2854,7 +2854,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Lenovo
@@ -2944,7 +2944,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Lenovo
@@ -2962,7 +2962,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Lenovo
@@ -2980,7 +2980,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Lenovo
@@ -2998,7 +2998,7 @@
     name: Chrome Mobile
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Lenovo
@@ -3016,7 +3016,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Lenovo
@@ -3034,7 +3034,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Lenovo
@@ -3052,7 +3052,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Lenovo
@@ -3070,7 +3070,7 @@
     name: Chrome Mobile
     version: "85.0.4183.127"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: smartphone
     brand: Lenovo
@@ -3088,7 +3088,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Lenovo
@@ -3106,7 +3106,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Lenovo
@@ -3124,7 +3124,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Lenovo
@@ -3160,7 +3160,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Lenovo
@@ -3178,7 +3178,7 @@
     name: Chrome Mobile
     version: "47.0.2526.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.76"
   device:
     type: smartphone
     brand: Lenovo
@@ -3196,7 +3196,7 @@
     name: Chrome
     version: "45.0.2454.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.94"
   device:
     type: smartphone
     brand: Lenovo
@@ -3214,7 +3214,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Lenovo
@@ -3250,7 +3250,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Lenovo
@@ -3268,7 +3268,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Lenovo
@@ -3286,7 +3286,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Lenovo
@@ -3340,7 +3340,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Lenovo
@@ -3358,7 +3358,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Lenovo
@@ -3376,7 +3376,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Lenovo
@@ -3464,7 +3464,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: LG
@@ -3500,7 +3500,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: LG
@@ -3536,7 +3536,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: LG
@@ -3788,7 +3788,7 @@
     name: Chrome Mobile
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: smartphone
     brand: LG
@@ -3842,7 +3842,7 @@
     name: Chrome Mobile
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: smartphone
     brand: LG
@@ -3950,7 +3950,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: LG
@@ -3968,7 +3968,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: LG
@@ -3986,7 +3986,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: LG
@@ -4004,7 +4004,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: LG
@@ -4058,7 +4058,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: LG
@@ -4076,7 +4076,7 @@
     name: Chrome Webview
     version: "30.0.1599.103"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.103"
   device:
     type: smartphone
     brand: LG
@@ -4094,7 +4094,7 @@
     name: Chrome Webview
     version: "38.0.2125.102"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: smartphone
     brand: LG
@@ -4112,7 +4112,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: LG
@@ -4130,7 +4130,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: LG
@@ -4148,7 +4148,7 @@
     name: Chrome Webview
     version: "38.0.2125.102"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: smartphone
     brand: LG
@@ -4166,7 +4166,7 @@
     name: Chrome Webview
     version: "38.0.2125.102"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: smartphone
     brand: LG
@@ -4184,7 +4184,7 @@
     name: Chrome Webview
     version: "38.0.2125.102"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: smartphone
     brand: LG
@@ -4202,7 +4202,7 @@
     name: Chrome Webview
     version: "38.0.2125.102"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: smartphone
     brand: LG
@@ -4220,7 +4220,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: LG
@@ -4238,7 +4238,7 @@
     name: Chrome Webview
     version: "38.0.2125.102"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: smartphone
     brand: LG
@@ -4256,7 +4256,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: LG
@@ -4292,7 +4292,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: LG
@@ -4310,7 +4310,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: LG
@@ -4328,7 +4328,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: LG
@@ -4346,7 +4346,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: LG
@@ -4364,7 +4364,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: LG
@@ -4400,7 +4400,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: LG
@@ -4436,7 +4436,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: LG
@@ -4454,7 +4454,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: LG
@@ -4472,7 +4472,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: LG
@@ -4490,7 +4490,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: LG
@@ -4508,7 +4508,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: LG
@@ -4542,7 +4542,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: LG
@@ -4560,7 +4560,7 @@
     name: Chrome Mobile
     version: "83.0.4103.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: smartphone
     brand: LG
@@ -4612,7 +4612,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: LG
@@ -4630,7 +4630,7 @@
     name: Chrome Webview
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: LG
@@ -4648,7 +4648,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: LG
@@ -4666,7 +4666,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: LG
@@ -4684,7 +4684,7 @@
     name: Chrome Webview
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: LG
@@ -4702,7 +4702,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: LG
@@ -4720,7 +4720,7 @@
     name: Chrome Mobile
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: LG
@@ -4738,7 +4738,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: LG
@@ -4756,7 +4756,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: LG
@@ -4774,7 +4774,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: LG
@@ -4792,7 +4792,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: LG
@@ -4810,7 +4810,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: LG
@@ -4828,7 +4828,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: LG
@@ -4846,7 +4846,7 @@
     name: Chrome Mobile
     version: "84.0.4147.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: LG
@@ -4864,7 +4864,7 @@
     name: Chrome Mobile
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: smartphone
     brand: LG
@@ -4882,7 +4882,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: LG
@@ -4900,7 +4900,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: LG
@@ -4918,7 +4918,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: LG
@@ -4936,7 +4936,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: LG
@@ -4972,7 +4972,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: LG
@@ -4990,7 +4990,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: LG
@@ -5008,7 +5008,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: LG
@@ -5026,7 +5026,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: LG
@@ -5080,7 +5080,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: LG
@@ -5098,7 +5098,7 @@
     name: Chrome Webview
     version: "30.0.1599.103"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.103"
   device:
     type: smartphone
     brand: LG
@@ -5116,7 +5116,7 @@
     name: Chrome Mobile
     version: "39.0.2171.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.59"
   device:
     type: smartphone
     brand: LG
@@ -5152,7 +5152,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: LG
@@ -5170,7 +5170,7 @@
     name: Chrome Mobile
     version: "61.0.3313.67"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3313.67"
   device:
     type: smartphone
     brand: LG
@@ -5188,7 +5188,7 @@
     name: Chrome Webview
     version: "38.0.2125.102"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: smartphone
     brand: LG
@@ -5222,7 +5222,7 @@
     name: Chrome Webview
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: LG
@@ -5240,7 +5240,7 @@
     name: Chrome Webview
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: LG
@@ -5276,7 +5276,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: LG
@@ -5294,7 +5294,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: LG
@@ -5330,7 +5330,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: LG
@@ -5366,7 +5366,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: LG
@@ -5456,7 +5456,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: LG
@@ -5582,7 +5582,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: LG
@@ -5618,7 +5618,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: LG
@@ -5636,7 +5636,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: LG
@@ -5744,7 +5744,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: LG
@@ -5942,7 +5942,7 @@
     name: Chrome Mobile
     version: "29.0.1547.72"
     engine: Blink
-    engine_version: ""
+    engine_version: "29.0.1547.72"
   device:
     type: smartphone
     brand: LG
@@ -6068,7 +6068,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: LG
@@ -6086,7 +6086,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: LG
@@ -6104,7 +6104,7 @@
     name: Chrome Webview
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: LG
@@ -6140,7 +6140,7 @@
     name: Chrome Webview
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: LG
@@ -6158,7 +6158,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: LG
@@ -6176,7 +6176,7 @@
     name: Chrome Mobile
     version: "71.0.3578.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: smartphone
     brand: LG
@@ -6194,7 +6194,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: LG
@@ -6212,7 +6212,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: LG
@@ -6230,7 +6230,7 @@
     name: Chrome Webview
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: LG
@@ -6248,7 +6248,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: LG
@@ -6266,7 +6266,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: LG
@@ -6302,7 +6302,7 @@
     name: Chrome Webview
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: LG
@@ -6356,7 +6356,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: LG
@@ -6374,7 +6374,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: LG
@@ -6392,7 +6392,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: LG
@@ -6410,7 +6410,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: LG
@@ -6428,7 +6428,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: LG
@@ -6446,7 +6446,7 @@
     name: Chrome Webview
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: LG
@@ -6464,7 +6464,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: LG
@@ -6482,7 +6482,7 @@
     name: Chrome Webview
     version: "38.0.2125.102"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: smartphone
     brand: LG
@@ -6500,7 +6500,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: LG
@@ -6518,7 +6518,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: LG
@@ -6536,7 +6536,7 @@
     name: Chrome Mobile
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: LG
@@ -6554,7 +6554,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: LG
@@ -6572,7 +6572,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: LG
@@ -6608,7 +6608,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: LG
@@ -6626,7 +6626,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: LG
@@ -6644,7 +6644,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: LG
@@ -6662,7 +6662,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: LG
@@ -6714,7 +6714,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: LG
@@ -6732,7 +6732,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: LG
@@ -6750,7 +6750,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: LG
@@ -6786,7 +6786,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: LG
@@ -6804,7 +6804,7 @@
     name: Chrome Webview
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: LG
@@ -6822,7 +6822,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: LG
@@ -6840,7 +6840,7 @@
     name: Opera Mobile
     version: "59.0.2925.53812"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: LG
@@ -6858,7 +6858,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: LG
@@ -6876,7 +6876,7 @@
     name: Chrome Mobile
     version: "83.0.4103.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: smartphone
     brand: LG
@@ -6894,7 +6894,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: LG
@@ -6912,7 +6912,7 @@
     name: Chrome Mobile
     version: "67.0.3396.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.68"
   device:
     type: smartphone
     brand: LG
@@ -6948,7 +6948,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: LG
@@ -7020,7 +7020,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: LG
@@ -7038,7 +7038,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: LG
@@ -7110,7 +7110,7 @@
     name: Chrome Mobile
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: LG
@@ -7182,7 +7182,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: LG
@@ -7200,7 +7200,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: LG
@@ -7218,7 +7218,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: LG
@@ -7236,7 +7236,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: LG
@@ -7362,7 +7362,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Lark
@@ -7398,7 +7398,7 @@
     name: Opera Mobile
     version: "51.2.2461.137690"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Lark
@@ -7416,7 +7416,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Lark
@@ -7434,7 +7434,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Lark
@@ -7452,7 +7452,7 @@
     name: Chrome Webview
     version: "48.0.2564.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.106"
   device:
     type: smartphone
     brand: Lark
@@ -7470,7 +7470,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Lark
@@ -7506,7 +7506,7 @@
     name: Chrome Mobile
     version: "44.0.2403.133"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.133"
   device:
     type: smartphone
     brand: Lark
@@ -7524,7 +7524,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Logicom
@@ -7542,7 +7542,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Logicom
@@ -7560,7 +7560,7 @@
     name: Chrome Mobile
     version: "84.0.4147.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: Logicom
@@ -7578,7 +7578,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Logicom
@@ -7596,7 +7596,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Logicom
@@ -7614,7 +7614,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Logicom
@@ -7632,7 +7632,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Logicom
@@ -7650,7 +7650,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Logicom
@@ -7668,7 +7668,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Logicom
@@ -7686,7 +7686,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: LAIQ
@@ -7704,7 +7704,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: LAIQ
@@ -7740,7 +7740,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: MLS
@@ -7758,7 +7758,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: MLS
@@ -7776,7 +7776,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: MLS
@@ -7794,7 +7794,7 @@
     name: Chrome
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: MLS
@@ -7812,7 +7812,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: MLS
@@ -7830,7 +7830,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: MLS
@@ -7864,7 +7864,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: MLS
@@ -7882,7 +7882,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: MLS
@@ -7918,7 +7918,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: MLS
@@ -7936,7 +7936,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: MLS
@@ -7970,7 +7970,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: MLS
@@ -7988,7 +7988,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: MLS
@@ -8006,7 +8006,7 @@
     name: Chrome Mobile
     version: "54.0.2840.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.68"
   device:
     type: smartphone
     brand: MLS
@@ -8024,7 +8024,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: MLS
@@ -8060,7 +8060,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: MLS
@@ -8078,7 +8078,7 @@
     name: Chrome Mobile
     version: "47.0.2526.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.76"
   device:
     type: smartphone
     brand: MLS
@@ -8096,7 +8096,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: MLS
@@ -8132,7 +8132,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: MLS
@@ -8150,7 +8150,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: MLS
@@ -8168,7 +8168,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: MLS
@@ -8186,7 +8186,7 @@
     name: Chrome Webview
     version: "81.0.40"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.40"
   device:
     type: smartphone
     brand: MLS
@@ -8204,7 +8204,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: MLS
@@ -8222,7 +8222,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: MLS
@@ -8240,7 +8240,7 @@
     name: Chrome Mobile
     version: "60.0.3112.107"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.107"
   device:
     type: smartphone
     brand: MLS
@@ -8258,7 +8258,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: MLS
@@ -8276,7 +8276,7 @@
     name: Chrome Mobile
     version: "68.0.3440.40"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.40"
   device:
     type: smartphone
     brand: MLS
@@ -8294,7 +8294,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: MLS
@@ -8312,7 +8312,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: MLS
@@ -8330,7 +8330,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Leotec
@@ -8348,7 +8348,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Leotec
@@ -8366,7 +8366,7 @@
     name: Chrome Webview
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Leotec
@@ -8384,7 +8384,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Lumus
@@ -8402,7 +8402,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Lumus
@@ -8420,7 +8420,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: Lumus
@@ -8438,7 +8438,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Lava
@@ -8456,7 +8456,7 @@
     name: Chrome Webview
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Lava
@@ -8474,7 +8474,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Lava
@@ -8492,7 +8492,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Lava
@@ -8510,7 +8510,7 @@
     name: Chrome Webview
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: Lava
@@ -8672,7 +8672,7 @@
     name: Chrome Mobile
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: smartphone
     brand: Lava
@@ -8708,7 +8708,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Lava
@@ -8726,7 +8726,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Lava
@@ -8757,7 +8757,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Lava
@@ -8775,7 +8775,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Lava
@@ -8811,7 +8811,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Lava
@@ -8829,7 +8829,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Lava
@@ -8847,7 +8847,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: LYF
@@ -8865,7 +8865,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: LYF
@@ -8919,7 +8919,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: LYF
@@ -8937,7 +8937,7 @@
     name: Chrome Mobile
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: LYF
@@ -8955,7 +8955,7 @@
     name: Chrome Mobile
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: LYF
@@ -8973,7 +8973,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: LYF
@@ -8991,7 +8991,7 @@
     name: Chrome Mobile
     version: 35.0.1916.141
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: smartphone
     brand: ZTE
@@ -9027,7 +9027,7 @@
     name: Chrome Mobile
     version: 75.0.3770.89
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: ZTE
@@ -9063,7 +9063,7 @@
     name: Opera Mobile
     version: 36.2.2254.130496
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: bq
@@ -9117,7 +9117,7 @@
     name: Chrome Mobile
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: smartphone
     brand: Blu
@@ -9153,7 +9153,7 @@
     name: Chrome Webview
     version: 69.0.3497.86
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.86"
   device:
     type: smartphone
     brand: Asus
@@ -9171,7 +9171,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: M-Horse
@@ -9189,7 +9189,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: M-Horse
@@ -9207,7 +9207,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: MyPhone
@@ -9225,7 +9225,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Doogee
@@ -9243,7 +9243,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Doogee
@@ -9261,7 +9261,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Doogee
@@ -9279,7 +9279,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Doogee
@@ -9297,7 +9297,7 @@
     name: Chrome Webview
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Digma
@@ -9315,7 +9315,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Blackview
@@ -9333,7 +9333,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Panasonic
@@ -9351,7 +9351,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Energizer
@@ -9369,7 +9369,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: CUBOT
@@ -9387,7 +9387,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: Sirin labs
@@ -9405,7 +9405,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: Santin
@@ -9423,7 +9423,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: smartphone
     brand: Santin
@@ -9441,7 +9441,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: S-TELL
@@ -9459,7 +9459,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: S-TELL
@@ -9477,7 +9477,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: MDC Store
@@ -9495,7 +9495,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: smartphone
     brand: MDC Store
@@ -9513,7 +9513,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Santin
@@ -9531,7 +9531,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: smartphone
     brand: Philips
@@ -9549,7 +9549,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: smartphone
     brand: Alcatel
@@ -9567,7 +9567,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: smartphone
     brand: 4Good
@@ -9585,7 +9585,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: smartphone
     brand: Lark
@@ -9603,7 +9603,7 @@
     name: Yandex Browser
     version: 21.5.1.107.00
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: smartphone
     brand: Philips
@@ -9621,7 +9621,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: Google
@@ -9639,7 +9639,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: POCO
@@ -9657,7 +9657,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: smartphone
     brand: OPPO
@@ -9675,7 +9675,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Sony
@@ -9693,7 +9693,7 @@
     name: Chrome Mobile
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Sharp
@@ -9711,7 +9711,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Oukitel
@@ -9729,7 +9729,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Oukitel
@@ -9747,7 +9747,7 @@
     name: Chrome Mobile
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: smartphone
     brand: Asus
@@ -9765,7 +9765,7 @@
     name: Chrome Webview
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: smartphone
     brand: Fujitsu
@@ -9783,7 +9783,7 @@
     name: Chrome Mobile
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: smartphone
     brand: Blackview
@@ -9801,7 +9801,7 @@
     name: Opera Mobile
     version: 55.1.2254.56965
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: smartphone
     brand: Blackview

--- a/Tests/fixtures/smartphone-9.yml
+++ b/Tests/fixtures/smartphone-9.yml
@@ -10,7 +10,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: LYF
@@ -28,7 +28,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: LYF
@@ -46,7 +46,7 @@
     name: Chrome Webview
     version: "48.0.2564.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.106"
   device:
     type: smartphone
     brand: LYF
@@ -64,7 +64,7 @@
     name: Chrome
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: LYF
@@ -82,7 +82,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: LYF
@@ -118,7 +118,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: LYF
@@ -136,7 +136,7 @@
     name: Chrome Mobile
     version: "49.0.2623.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: smartphone
     brand: LYF
@@ -154,7 +154,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: LYF
@@ -172,7 +172,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: LYF
@@ -190,7 +190,7 @@
     name: Chrome Webview
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: LYF
@@ -208,7 +208,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: LYF
@@ -226,7 +226,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: LYF
@@ -244,7 +244,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: LYF
@@ -262,7 +262,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: LYF
@@ -280,7 +280,7 @@
     name: Chrome Webview
     version: "54.0.2840.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.68"
   device:
     type: smartphone
     brand: LYF
@@ -298,7 +298,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: LYF
@@ -316,7 +316,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: LYF
@@ -334,7 +334,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: LYF
@@ -352,7 +352,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: LYF
@@ -370,7 +370,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: LYF
@@ -388,7 +388,7 @@
     name: Chrome Webview
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: smartphone
     brand: LYF
@@ -406,7 +406,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: LYF
@@ -424,7 +424,7 @@
     name: Chrome Mobile
     version: "48.0.2564.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.106"
   device:
     type: smartphone
     brand: LYF
@@ -442,7 +442,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: LYF
@@ -460,7 +460,7 @@
     name: Chrome Webview
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: LYF
@@ -478,7 +478,7 @@
     name: Chrome Mobile
     version: "50.0.2661.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: smartphone
     brand: LYF
@@ -496,7 +496,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Lesia
@@ -514,7 +514,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Maze
@@ -532,7 +532,7 @@
     name: Opera Mobile
     version: "44.1.2254.143214"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Maze Speed
@@ -550,7 +550,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Maze Speed
@@ -744,7 +744,7 @@
     name: Chrome Webview
     version: "40.0.2214.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.114"
   device:
     type: smartphone
     brand: Meizu
@@ -830,7 +830,7 @@
     name: Yandex Browser
     version: "16.10.2.1487.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.116"
   device:
     type: smartphone
     brand: Meizu
@@ -882,7 +882,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Meizu
@@ -900,7 +900,7 @@
     name: Chrome Webview
     version: "45.0.2454.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.94"
   device:
     type: smartphone
     brand: Meizu
@@ -918,7 +918,7 @@
     name: Chrome Webview
     version: "44.0.2403.131"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.131"
   device:
     type: smartphone
     brand: Meizu
@@ -936,7 +936,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Meizu
@@ -972,7 +972,7 @@
     name: Chrome Mobile
     version: "70.0.3538.27"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.27"
   device:
     type: smartphone
     brand: Meizu
@@ -1008,7 +1008,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Meizu
@@ -1170,7 +1170,7 @@
     name: Chrome Mobile
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: smartphone
     brand: Meizu
@@ -1206,7 +1206,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Meizu
@@ -1224,7 +1224,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Meizu
@@ -1294,7 +1294,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Meizu
@@ -1346,7 +1346,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: MEEG
@@ -1364,7 +1364,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Modecom
@@ -1490,7 +1490,7 @@
     name: Chrome Webview
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1508,7 +1508,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1526,7 +1526,7 @@
     name: Chrome Mobile
     version: "36.0.1985.131"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.131"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1544,7 +1544,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1562,7 +1562,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1580,7 +1580,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1598,7 +1598,7 @@
     name: Chrome Mobile
     version: "52.0.2743.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.91"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1616,7 +1616,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1634,7 +1634,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1732,7 +1732,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1750,7 +1750,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1786,7 +1786,7 @@
     name: Chrome Mobile
     version: "67.0.3396.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.81"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1838,7 +1838,7 @@
     name: Chrome Mobile
     version: "67.0.3396.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.68"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1872,7 +1872,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1890,7 +1890,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1908,7 +1908,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1926,7 +1926,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1960,7 +1960,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1978,7 +1978,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Mobiistar
@@ -1996,7 +1996,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Mobiistar
@@ -2014,7 +2014,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Mobiistar
@@ -2050,7 +2050,7 @@
     name: Chrome Webview
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Mobiistar
@@ -2068,7 +2068,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Mobiistar
@@ -2086,7 +2086,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Mobiistar
@@ -2104,7 +2104,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Mobiistar
@@ -2122,7 +2122,7 @@
     name: Chrome Mobile
     version: "67.0.3396.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.81"
   device:
     type: smartphone
     brand: Mobiistar
@@ -2140,7 +2140,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Mobiistar
@@ -2194,7 +2194,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Myria
@@ -2212,7 +2212,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Myria
@@ -2230,7 +2230,7 @@
     name: Chrome Webview
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: Myria
@@ -2248,7 +2248,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Myria
@@ -2266,7 +2266,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Myria
@@ -2284,7 +2284,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Myria
@@ -2302,7 +2302,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Myria
@@ -2320,7 +2320,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Myria
@@ -2338,7 +2338,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Myria
@@ -2356,7 +2356,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Myria
@@ -2374,7 +2374,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: MTC
@@ -2410,7 +2410,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: MTC
@@ -2428,7 +2428,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: MTC
@@ -2446,7 +2446,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: MTC
@@ -2464,7 +2464,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: MTC
@@ -2482,7 +2482,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: MTC
@@ -2500,7 +2500,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: MTC
@@ -2518,7 +2518,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: MTC
@@ -2536,7 +2536,7 @@
     name: Yandex Browser
     version: "19.1.3.198.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: MTC
@@ -2554,7 +2554,7 @@
     name: Yandex Browser
     version: "7.63"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: MTC
@@ -2572,7 +2572,7 @@
     name: Chrome Mobile
     version: "60.0.3435.52"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3435.52"
   device:
     type: smartphone
     brand: MTC
@@ -2590,7 +2590,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: MTC
@@ -2608,7 +2608,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: MTC
@@ -2644,7 +2644,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: MTC
@@ -2662,7 +2662,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: MTC
@@ -2680,7 +2680,7 @@
     name: Yandex Browser
     version: "18.3.1.651.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.186"
   device:
     type: smartphone
     brand: MTC
@@ -2698,7 +2698,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: MTC
@@ -2716,7 +2716,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: Manta Multimedia
@@ -2734,7 +2734,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Manta Multimedia
@@ -2752,7 +2752,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Manta Multimedia
@@ -2770,7 +2770,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Manta Multimedia
@@ -2788,7 +2788,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Manta Multimedia
@@ -2806,7 +2806,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Mobistel
@@ -2860,7 +2860,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Mobistel
@@ -2896,7 +2896,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Mobistel
@@ -2932,7 +2932,7 @@
     name: Chrome Mobile
     version: "43.0.2357.78"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.78"
   device:
     type: smartphone
     brand: Mediacom
@@ -2986,7 +2986,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Mediacom
@@ -3004,7 +3004,7 @@
     name: Chrome Mobile
     version: "40.0.2214.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: smartphone
     brand: Mediacom
@@ -3022,7 +3022,7 @@
     name: Chrome Mobile
     version: "43.0.2357.78"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.78"
   device:
     type: smartphone
     brand: Mediacom
@@ -3076,7 +3076,7 @@
     name: Opera Mobile
     version: "29.0.1809.92697"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.107"
   device:
     type: smartphone
     brand: Mediacom
@@ -3112,7 +3112,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Mediacom
@@ -3148,7 +3148,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Medion
@@ -3166,7 +3166,7 @@
     name: Chrome Mobile
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: smartphone
     brand: Medion
@@ -3202,7 +3202,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Medion
@@ -3220,7 +3220,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Medion
@@ -3238,7 +3238,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Medion
@@ -3292,7 +3292,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Medion
@@ -3310,7 +3310,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Medion
@@ -3328,7 +3328,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Medion
@@ -3346,7 +3346,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Medion
@@ -3414,7 +3414,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Mofut
@@ -3432,7 +3432,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Mofut
@@ -3522,7 +3522,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: MyWigo
@@ -3540,7 +3540,7 @@
     name: Chrome Mobile
     version: "60.0.3112.107"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.107"
   device:
     type: smartphone
     brand: Mobiola
@@ -3558,7 +3558,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Mobiola
@@ -3576,7 +3576,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Mobiola
@@ -3630,7 +3630,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Mobiola
@@ -3648,7 +3648,7 @@
     name: Chrome Mobile
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: smartphone
     brand: Mobiola
@@ -3684,7 +3684,7 @@
     name: Chrome Webview
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: Mobiola
@@ -3702,7 +3702,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Mobiola
@@ -3720,7 +3720,7 @@
     name: Opera Mobile
     version: "37.0.2192.105088"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.94"
   device:
     type: smartphone
     brand: Mobiola
@@ -3756,7 +3756,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Mobiola
@@ -3774,7 +3774,7 @@
     name: Chrome Webview
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Mobiola
@@ -3792,7 +3792,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Mobiola
@@ -3810,7 +3810,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: MicroMax
@@ -3846,7 +3846,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: MicroMax
@@ -3882,7 +3882,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: MicroMax
@@ -4096,7 +4096,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: MicroMax
@@ -4114,7 +4114,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: MicroMax
@@ -4132,7 +4132,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: MicroMax
@@ -4150,7 +4150,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: MicroMax
@@ -4168,7 +4168,7 @@
     name: Chrome Webview
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: MicroMax
@@ -4186,7 +4186,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: MicroMax
@@ -4204,7 +4204,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: MicroMax
@@ -4222,7 +4222,7 @@
     name: Chrome Webview
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: MicroMax
@@ -4240,7 +4240,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: MicroMax
@@ -4258,7 +4258,7 @@
     name: Chrome Mobile
     version: "36.0.1985.131"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.131"
   device:
     type: smartphone
     brand: Majestic
@@ -4276,7 +4276,7 @@
     name: Chrome Mobile
     version: "43.0.2357.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.92"
   device:
     type: smartphone
     brand: Majestic
@@ -4294,7 +4294,7 @@
     name: Chrome Webview
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Majestic
@@ -4504,7 +4504,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: M4tel
@@ -4522,7 +4522,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: M4tel
@@ -4540,7 +4540,7 @@
     name: Chrome Webview
     version: "64.0.3282.123"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: smartphone
     brand: M4tel
@@ -4558,7 +4558,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: M4tel
@@ -4576,7 +4576,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: M4tel
@@ -4594,7 +4594,7 @@
     name: Chrome Mobile
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: M4tel
@@ -4612,7 +4612,7 @@
     name: Chrome Mobile
     version: "71.0.3578.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.98"
   device:
     type: smartphone
     brand: M4tel
@@ -4630,7 +4630,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: M4tel
@@ -4648,7 +4648,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: M4tel
@@ -4666,7 +4666,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: M4tel
@@ -4684,7 +4684,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: M4tel
@@ -4702,7 +4702,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: M4tel
@@ -4720,7 +4720,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: M4tel
@@ -4738,7 +4738,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: M4tel
@@ -4756,7 +4756,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: M4tel
@@ -4774,7 +4774,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: M4tel
@@ -4792,7 +4792,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: M4tel
@@ -4810,7 +4810,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: M4tel
@@ -4828,7 +4828,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: M4tel
@@ -4846,7 +4846,7 @@
     name: Chrome Mobile
     version: "41.0.2272.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.96"
   device:
     type: smartphone
     brand: M4tel
@@ -4864,7 +4864,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: M4tel
@@ -4882,7 +4882,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: M4tel
@@ -4900,7 +4900,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: M4tel
@@ -4918,7 +4918,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Mio
@@ -4936,7 +4936,7 @@
     name: Chrome
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: MegaFon
@@ -4954,7 +4954,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: MegaFon
@@ -4972,7 +4972,7 @@
     name: Yandex Browser
     version: "17.10.2.145.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.100"
   device:
     type: smartphone
     brand: MegaFon
@@ -5026,7 +5026,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: MegaFon
@@ -5440,7 +5440,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Motorola
@@ -5494,7 +5494,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Motorola
@@ -5674,7 +5674,7 @@
     name: Chrome Mobile
     version: "31.0.1631.1"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1631.1"
   device:
     type: smartphone
     brand: Motorola
@@ -5710,7 +5710,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Motorola
@@ -5728,7 +5728,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Motorola
@@ -5746,7 +5746,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Motorola
@@ -5782,7 +5782,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Motorola
@@ -5836,7 +5836,7 @@
     name: Chrome Mobile
     version: "33.0.1750.170"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.170"
   device:
     type: smartphone
     brand: Motorola
@@ -5872,7 +5872,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Motorola
@@ -5890,7 +5890,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Motorola
@@ -5944,7 +5944,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Motorola
@@ -5962,7 +5962,7 @@
     name: Chrome Mobile
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: smartphone
     brand: Motorola
@@ -6034,7 +6034,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Motorola
@@ -6392,7 +6392,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Motorola
@@ -6410,7 +6410,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Motorola
@@ -6446,7 +6446,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Motorola
@@ -6464,7 +6464,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Motorola
@@ -6482,7 +6482,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Motorola
@@ -6500,7 +6500,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Motorola
@@ -6518,7 +6518,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Motorola
@@ -6536,7 +6536,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Motorola
@@ -6554,7 +6554,7 @@
     name: Chrome Mobile
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: smartphone
     brand: Motorola
@@ -6572,7 +6572,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: smartphone
     brand: Motorola
@@ -6590,7 +6590,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Motorola
@@ -6608,7 +6608,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Motorola
@@ -6626,7 +6626,7 @@
     name: Chrome
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Motorola
@@ -6662,7 +6662,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Motorola
@@ -6680,7 +6680,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Motorola
@@ -6698,7 +6698,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Motorola
@@ -6716,7 +6716,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Motorola
@@ -6734,7 +6734,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Motorola
@@ -6770,7 +6770,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Motorola
@@ -6788,7 +6788,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Motorola
@@ -6806,7 +6806,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Motorola
@@ -6824,7 +6824,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Motorola
@@ -6842,7 +6842,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: smartphone
     brand: Motorola
@@ -6860,7 +6860,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Motorola
@@ -6896,7 +6896,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Motorola
@@ -6950,7 +6950,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Motorola
@@ -6968,7 +6968,7 @@
     name: Chrome Mobile
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: smartphone
     brand: Motorola
@@ -6986,7 +6986,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: smartphone
     brand: Motorola
@@ -7004,7 +7004,7 @@
     name: Chrome Mobile
     version: "33.0.1750.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.135"
   device:
     type: smartphone
     brand: Motorola
@@ -7022,7 +7022,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Motorola
@@ -7040,7 +7040,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Motorola
@@ -7058,7 +7058,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: smartphone
     brand: Motorola
@@ -7076,7 +7076,7 @@
     name: Chrome Mobile
     version: "33.0.1750.170"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.170"
   device:
     type: smartphone
     brand: Motorola
@@ -7094,7 +7094,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Motorola
@@ -7112,7 +7112,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Motorola
@@ -7130,7 +7130,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Motorola
@@ -7166,7 +7166,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Motorola
@@ -7184,7 +7184,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Motorola
@@ -7308,7 +7308,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Motorola
@@ -7578,7 +7578,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Motorola
@@ -7596,7 +7596,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Motorola
@@ -7614,7 +7614,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Motorola
@@ -7650,7 +7650,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Motorola
@@ -8430,7 +8430,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Movic
@@ -8448,7 +8448,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Movic
@@ -8466,7 +8466,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Movic
@@ -8484,7 +8484,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Movic
@@ -8502,7 +8502,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Maxwest
@@ -8520,7 +8520,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Maxwest
@@ -8538,7 +8538,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Maxwest
@@ -8556,7 +8556,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Maxwest
@@ -8610,7 +8610,7 @@
     name: Chrome Mobile
     version: "33.0.1750.170"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.170"
   device:
     type: smartphone
     brand: MyPhone
@@ -8646,7 +8646,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: MyPhone
@@ -8664,7 +8664,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: MyPhone
@@ -8682,7 +8682,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: MyPhone
@@ -8700,7 +8700,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: MyPhone
@@ -8718,7 +8718,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: MyPhone
@@ -8736,7 +8736,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: MyPhone
@@ -8754,7 +8754,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: MyPhone
@@ -8772,7 +8772,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: MyPhone
@@ -8790,7 +8790,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: MyPhone
@@ -8808,7 +8808,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: MyPhone
@@ -8826,7 +8826,7 @@
     name: Chrome Mobile
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: MyPhone
@@ -8844,7 +8844,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: MyPhone
@@ -8862,7 +8862,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: MyPhone
@@ -8880,7 +8880,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: MyPhone
@@ -8898,7 +8898,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: MyPhone

--- a/Tests/fixtures/smartphone.yml
+++ b/Tests/fixtures/smartphone.yml
@@ -82,7 +82,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: ""
@@ -190,7 +190,7 @@
     name: DuckDuckGo Privacy Browser
     version: "5"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: ""
@@ -208,7 +208,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: Accent
@@ -226,7 +226,7 @@
     name: Chrome Webview
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: smartphone
     brand: meanIT
@@ -244,7 +244,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: meanIT
@@ -262,7 +262,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: meanIT
@@ -280,7 +280,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: meanIT
@@ -316,7 +316,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: meanIT
@@ -334,7 +334,7 @@
     name: Chrome Webview
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: meanIT
@@ -352,7 +352,7 @@
     name: Chrome Mobile
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: meanIT
@@ -370,7 +370,7 @@
     name: Chrome Mobile
     version: "80.0.3987.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: smartphone
     brand: meanIT
@@ -388,7 +388,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: AIS
@@ -406,7 +406,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: BB Mobile
@@ -424,7 +424,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: MAXVI
@@ -442,7 +442,7 @@
     name: Chrome Webview
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Melrose
@@ -460,7 +460,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Melrose
@@ -478,7 +478,7 @@
     name: Chrome
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: iTruck
@@ -496,7 +496,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Klipad
@@ -514,7 +514,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Lumigon
@@ -532,7 +532,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Newman
@@ -550,7 +550,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Newman
@@ -568,7 +568,7 @@
     name: Chrome Mobile
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: POCO
@@ -586,7 +586,7 @@
     name: Chrome Webview
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: POCO
@@ -604,7 +604,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: SEMP TCL
@@ -640,7 +640,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: SEMP TCL
@@ -658,7 +658,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: SEMP TCL
@@ -676,7 +676,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: SEMP TCL
@@ -694,7 +694,7 @@
     name: Chrome Mobile
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: smartphone
     brand: Tone
@@ -712,7 +712,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Tone
@@ -730,7 +730,7 @@
     name: Chrome Webview
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Vipro
@@ -748,7 +748,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Vipro
@@ -766,7 +766,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Vipro
@@ -784,7 +784,7 @@
     name: Chrome Webview
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Vipro
@@ -802,7 +802,7 @@
     name: Chrome Webview
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Swipe
@@ -820,7 +820,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Alba
@@ -838,7 +838,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Billion
@@ -892,7 +892,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: smartphone
     brand: Etuline
@@ -910,7 +910,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Etuline
@@ -946,7 +946,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: smartphone
     brand: iMars
@@ -964,7 +964,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Kzen
@@ -982,7 +982,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Logic
@@ -1018,7 +1018,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Logic
@@ -1036,7 +1036,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Logic
@@ -1054,7 +1054,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Logic
@@ -1090,7 +1090,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Logic
@@ -1108,7 +1108,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Logic
@@ -1126,7 +1126,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: Logic
@@ -1144,7 +1144,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Logic
@@ -1162,7 +1162,7 @@
     name: Chrome Mobile
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Logic
@@ -1180,7 +1180,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Neomi
@@ -1198,7 +1198,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Neomi
@@ -1216,7 +1216,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Neomi
@@ -1234,7 +1234,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Phicomm
@@ -1252,7 +1252,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Phicomm
@@ -1270,7 +1270,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Phicomm
@@ -1288,7 +1288,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Phicomm
@@ -1306,7 +1306,7 @@
     name: Chrome Mobile
     version: "80.0.3983.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3983.0"
   device:
     type: smartphone
     brand: Phicomm
@@ -1396,7 +1396,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Multilaser
@@ -1414,7 +1414,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Multilaser
@@ -1540,7 +1540,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Multilaser
@@ -1594,7 +1594,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Multilaser
@@ -1630,7 +1630,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Multilaser
@@ -1648,7 +1648,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Multilaser
@@ -1702,7 +1702,7 @@
     name: Opera Mobile
     version: "44.1.2254.142553"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Sigma
@@ -1738,7 +1738,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Sigma
@@ -1774,7 +1774,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Sigma
@@ -1792,7 +1792,7 @@
     name: Chrome Mobile
     version: "60.0.3112.107"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.107"
   device:
     type: smartphone
     brand: Sigma
@@ -1810,7 +1810,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Sigma
@@ -1828,7 +1828,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Sigma
@@ -1864,7 +1864,7 @@
     name: Opera Mobile
     version: "44.1.2254.142088"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Sigma
@@ -1882,7 +1882,7 @@
     name: Chrome Mobile
     version: "69.0.3497.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.86"
   device:
     type: smartphone
     brand: Sigma
@@ -1918,7 +1918,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Sigma
@@ -1936,7 +1936,7 @@
     name: Chrome Mobile
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: smartphone
     brand: Sigma
@@ -1954,7 +1954,7 @@
     name: Chrome Mobile
     version: "74.0.3729.112"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: smartphone
     brand: Sigma
@@ -1972,7 +1972,7 @@
     name: Chrome Webview
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Sigma
@@ -2008,7 +2008,7 @@
     name: Chrome Mobile
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: smartphone
     brand: Sigma
@@ -2062,7 +2062,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Turbo
@@ -2080,7 +2080,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Turbo
@@ -2098,7 +2098,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Turbo
@@ -2116,7 +2116,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: smartphone
     brand: Turbo
@@ -2152,7 +2152,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Turbo
@@ -2170,7 +2170,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Turbo
@@ -2188,7 +2188,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Turbo
@@ -2206,7 +2206,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Ghong
@@ -2296,7 +2296,7 @@
     name: Chrome Webview
     version: "51.0.2704.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.106"
   device:
     type: smartphone
     brand: Tele2
@@ -2314,7 +2314,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Tele2
@@ -2332,7 +2332,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Tele2
@@ -2350,7 +2350,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Tele2
@@ -2386,7 +2386,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Masstel
@@ -2548,7 +2548,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Masstel
@@ -2566,7 +2566,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Masstel
@@ -2584,7 +2584,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Masstel
@@ -2602,7 +2602,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Masstel
@@ -2620,7 +2620,7 @@
     name: Chrome Webview
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: smartphone
     brand: Masstel
@@ -2638,7 +2638,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Masstel
@@ -2674,7 +2674,7 @@
     name: Chrome Mobile
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Masstel
@@ -2692,7 +2692,7 @@
     name: Aloha Browser
     version: "2.9.0.2"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: smartphone
     brand: Nomu
@@ -2710,7 +2710,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Nomu
@@ -2728,7 +2728,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Tinai
@@ -2782,7 +2782,7 @@
     name: Chrome Webview
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: i-Cherry
@@ -2800,7 +2800,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: i-Cherry
@@ -2836,7 +2836,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: i-Cherry
@@ -2854,7 +2854,7 @@
     name: Chrome Webview
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: i-Cherry
@@ -2872,7 +2872,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: i-Cherry
@@ -2890,7 +2890,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: i-Cherry
@@ -2908,7 +2908,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: i-Cherry
@@ -2926,7 +2926,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: i-Cherry
@@ -2944,7 +2944,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: i-Cherry
@@ -2962,7 +2962,7 @@
     name: Chrome Webview
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: smartphone
     brand: i-Cherry
@@ -2980,7 +2980,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Meitu
@@ -3016,7 +3016,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: smartphone
     brand: Meitu
@@ -3034,7 +3034,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Meitu
@@ -3052,7 +3052,7 @@
     name: Opera Mobile
     version: "48.0.2331.132663"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Meitu
@@ -3070,7 +3070,7 @@
     name: Chrome Webview
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Meitu
@@ -3088,7 +3088,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Meitu
@@ -3124,7 +3124,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Meitu
@@ -3142,7 +3142,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Meitu
@@ -3178,7 +3178,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Meitu
@@ -3196,7 +3196,7 @@
     name: Chrome Mobile
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Meitu
@@ -3214,7 +3214,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: smartphone
     brand: Meitu
@@ -3322,7 +3322,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Positivo BGH
@@ -3484,7 +3484,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Positivo BGH
@@ -3520,7 +3520,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: VVETIME
@@ -3538,7 +3538,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: Aligator
@@ -3556,7 +3556,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Aligator
@@ -3574,7 +3574,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Aligator
@@ -3592,7 +3592,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Aligator
@@ -3610,7 +3610,7 @@
     name: Chrome Webview
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Aligator
@@ -3628,7 +3628,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Aligator
@@ -3646,7 +3646,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Aligator
@@ -3664,7 +3664,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: 4Good
@@ -3682,7 +3682,7 @@
     name: Opera Mobile
     version: "44.1.2254.143214"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: 4Good
@@ -3700,7 +3700,7 @@
     name: Yandex Browser
     version: "16.2.1.7529.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.111"
   device:
     type: smartphone
     brand: 4Good
@@ -3718,7 +3718,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: 4Good
@@ -3736,7 +3736,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: 4Good
@@ -3754,7 +3754,7 @@
     name: Chrome Mobile
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: smartphone
     brand: 4Good
@@ -3772,7 +3772,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: 4Good
@@ -3790,7 +3790,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Mobicel
@@ -3808,7 +3808,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Mobicel
@@ -3826,7 +3826,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: Philco
@@ -3844,7 +3844,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: smartphone
     brand: ArmPhone
@@ -3862,7 +3862,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: ArmPhone
@@ -3880,7 +3880,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: 2E
@@ -3898,7 +3898,7 @@
     name: Chrome Mobile
     version: "81.0.4021.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4021.0"
   device:
     type: smartphone
     brand: 2E
@@ -3934,7 +3934,7 @@
     name: Yandex Browser
     version: "17.1.2.339.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.95"
   device:
     type: smartphone
     brand: Mann
@@ -3952,7 +3952,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Mann
@@ -3970,7 +3970,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Nos
@@ -3988,7 +3988,7 @@
     name: Opera Mobile
     version: "57.1.2830.52480"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: smartphone
     brand: Nos
@@ -4006,7 +4006,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Nos
@@ -4024,7 +4024,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Nos
@@ -4042,7 +4042,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Nos
@@ -4060,7 +4060,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Nos
@@ -4078,7 +4078,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Phonemax
@@ -4114,7 +4114,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Phonemax
@@ -4132,7 +4132,7 @@
     name: Chrome Webview
     version: "84.0.4147.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: smartphone
     brand: 'AT&T'
@@ -4150,7 +4150,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: smartphone
     brand: 'AT&T'
@@ -4168,7 +4168,7 @@
     name: Chrome Webview
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: smartphone
     brand: Primux
@@ -4186,7 +4186,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Spectrum
@@ -4204,7 +4204,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Spectrum
@@ -4222,7 +4222,7 @@
     name: Chrome Mobile
     version: "66.0.3359.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.106"
   device:
     type: smartphone
     brand: Spectrum
@@ -4240,7 +4240,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Spectrum
@@ -4258,7 +4258,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Twoe
@@ -4276,7 +4276,7 @@
     name: Chrome Webview
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Maxtron
@@ -4348,7 +4348,7 @@
     name: Chrome Mobile
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: smartphone
     brand: iBrit
@@ -4366,7 +4366,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: iBrit
@@ -4384,7 +4384,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: iBrit
@@ -4402,7 +4402,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: smartphone
     brand: iBrit
@@ -4420,7 +4420,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Maxcom
@@ -4438,7 +4438,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Maxcom
@@ -4456,7 +4456,7 @@
     name: Chrome Mobile
     version: "60.0.3112.107"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.107"
   device:
     type: smartphone
     brand: Maxcom
@@ -4474,7 +4474,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Maxcom
@@ -4492,7 +4492,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Maxcom
@@ -4510,7 +4510,7 @@
     name: Chrome Mobile
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: smartphone
     brand: Maxcom
@@ -4528,7 +4528,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: smartphone
     brand: Maxcom
@@ -4546,7 +4546,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: smartphone
     brand: Shift Phones
@@ -4600,7 +4600,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Mito
@@ -4654,7 +4654,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Mito
@@ -4834,7 +4834,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Mito
@@ -5068,7 +5068,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: IQM
@@ -5086,7 +5086,7 @@
     name: Yandex Browser
     version: "19.9.2.117.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: IQM
@@ -5104,7 +5104,7 @@
     name: Yandex Browser
     version: "19.10.1.81.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: IQM
@@ -5122,7 +5122,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Soyes
@@ -5140,7 +5140,7 @@
     name: Chrome Mobile
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: smartphone
     brand: Soyes
@@ -5158,7 +5158,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Amigoo
@@ -5176,7 +5176,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Amigoo
@@ -5194,7 +5194,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Amigoo
@@ -5212,7 +5212,7 @@
     name: Chrome Webview
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Amigoo
@@ -5230,7 +5230,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: smartphone
     brand: Sugar
@@ -5248,7 +5248,7 @@
     name: Chrome Webview
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Sugar
@@ -5302,7 +5302,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Sugar
@@ -5320,7 +5320,7 @@
     name: Chrome Mobile
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: smartphone
     brand: Sugar
@@ -5338,7 +5338,7 @@
     name: Chrome Webview
     version: "48.0.2564.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.116"
   device:
     type: smartphone
     brand: Sugar
@@ -5356,7 +5356,7 @@
     name: Chrome Mobile
     version: "81.0.4044.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: smartphone
     brand: Sugar
@@ -5428,7 +5428,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Sugar
@@ -5446,7 +5446,7 @@
     name: Chrome Mobile
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: smartphone
     brand: Sugar
@@ -5482,7 +5482,7 @@
     name: Chrome Webview
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: ANS
@@ -5518,7 +5518,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Allview
@@ -5536,7 +5536,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Allview
@@ -5554,7 +5554,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Allview
@@ -5590,7 +5590,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Allview
@@ -5608,7 +5608,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Allview
@@ -5626,7 +5626,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Allview
@@ -5644,7 +5644,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Allview
@@ -5662,7 +5662,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Allview
@@ -5680,7 +5680,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Allview
@@ -5698,7 +5698,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Allview
@@ -5716,7 +5716,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: smartphone
     brand: Allview
@@ -5734,7 +5734,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Allview
@@ -5752,7 +5752,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Allview
@@ -5770,7 +5770,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Allview
@@ -5788,7 +5788,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Allview
@@ -5824,7 +5824,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Allview
@@ -5842,7 +5842,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Allview
@@ -5860,7 +5860,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Allview
@@ -5878,7 +5878,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Allview
@@ -5896,7 +5896,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Allview
@@ -5914,7 +5914,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Allview
@@ -5950,7 +5950,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Allview
@@ -5968,7 +5968,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: smartphone
     brand: Allview
@@ -5986,7 +5986,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: smartphone
     brand: Allview
@@ -6004,7 +6004,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Allview
@@ -6022,7 +6022,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Allview
@@ -6040,7 +6040,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Allview
@@ -6058,7 +6058,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Allview
@@ -6076,7 +6076,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Allview
@@ -6094,7 +6094,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Allview
@@ -6112,7 +6112,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Allview
@@ -6130,7 +6130,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Allview
@@ -6148,7 +6148,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: Allview
@@ -6166,7 +6166,7 @@
     name: Chrome Mobile
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Allview
@@ -6184,7 +6184,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Allview
@@ -6202,7 +6202,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Allview
@@ -6220,7 +6220,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Allview
@@ -6256,7 +6256,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Allview
@@ -6274,7 +6274,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Allview
@@ -6292,7 +6292,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Allview
@@ -6310,7 +6310,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Allview
@@ -6328,7 +6328,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Allview
@@ -6346,7 +6346,7 @@
     name: Chrome Mobile
     version: "63.0.3239.107"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.107"
   device:
     type: smartphone
     brand: Allview
@@ -6364,7 +6364,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Allview
@@ -6382,7 +6382,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Allview
@@ -6400,7 +6400,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Allview
@@ -6436,7 +6436,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Allview
@@ -6454,7 +6454,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Allview
@@ -6472,7 +6472,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Allview
@@ -6490,7 +6490,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Allview
@@ -6508,7 +6508,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Allview
@@ -6526,7 +6526,7 @@
     name: Chrome Mobile
     version: "72.0.3626.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Allview
@@ -6544,7 +6544,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Allview
@@ -6562,7 +6562,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Allview
@@ -6580,7 +6580,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Allview
@@ -6598,7 +6598,7 @@
     name: Chrome Webview
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Allview
@@ -6616,7 +6616,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Allview
@@ -6634,7 +6634,7 @@
     name: Chrome Mobile
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: smartphone
     brand: Allview
@@ -6652,7 +6652,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Allview
@@ -6670,7 +6670,7 @@
     name: Chrome Mobile
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: smartphone
     brand: Allview
@@ -6688,7 +6688,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Allview
@@ -6706,7 +6706,7 @@
     name: Chrome Mobile
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Allview
@@ -6724,7 +6724,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Allview
@@ -6742,7 +6742,7 @@
     name: Chrome Mobile
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: smartphone
     brand: Allview
@@ -6760,7 +6760,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Allview
@@ -6778,7 +6778,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Allview
@@ -6796,7 +6796,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Allview
@@ -6814,7 +6814,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Allview
@@ -6832,7 +6832,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Allview
@@ -6850,7 +6850,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Allview
@@ -6868,7 +6868,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Allview
@@ -6886,7 +6886,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Allview
@@ -6904,7 +6904,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Allview
@@ -6922,7 +6922,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Allview
@@ -6940,7 +6940,7 @@
     name: Chrome Mobile
     version: "72.0.3626.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: smartphone
     brand: Allview
@@ -6958,7 +6958,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Allview
@@ -6976,7 +6976,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Allview
@@ -6994,7 +6994,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Allview
@@ -7012,7 +7012,7 @@
     name: Chrome Mobile
     version: "71.0.3578.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.98"
   device:
     type: smartphone
     brand: Allview
@@ -7030,7 +7030,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Allview
@@ -7048,7 +7048,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Allview
@@ -7066,7 +7066,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Allview
@@ -7084,7 +7084,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Allview
@@ -7102,7 +7102,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Allview
@@ -7120,7 +7120,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Allview
@@ -7138,7 +7138,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Allview
@@ -7156,7 +7156,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Allview
@@ -7174,7 +7174,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Allview
@@ -7192,7 +7192,7 @@
     name: Chrome Mobile
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Allview
@@ -7210,7 +7210,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Allview
@@ -7228,7 +7228,7 @@
     name: Chrome Mobile
     version: "61.0.3163.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.81"
   device:
     type: smartphone
     brand: Allview
@@ -7246,7 +7246,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Allview
@@ -7264,7 +7264,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Allview
@@ -7282,7 +7282,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Allview
@@ -7300,7 +7300,7 @@
     name: Chrome Mobile
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: smartphone
     brand: Allview
@@ -7318,7 +7318,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Allview
@@ -7336,7 +7336,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Allview
@@ -7354,7 +7354,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Allview
@@ -7372,7 +7372,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Allview
@@ -7390,7 +7390,7 @@
     name: Chrome Mobile
     version: "71.0.3578.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: smartphone
     brand: Allview
@@ -7408,7 +7408,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Allview
@@ -7426,7 +7426,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: Allview
@@ -7444,7 +7444,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Allview
@@ -7462,7 +7462,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: Allview
@@ -7480,7 +7480,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Allview
@@ -7498,7 +7498,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Allview
@@ -7516,7 +7516,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Allview
@@ -7534,7 +7534,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Allview
@@ -7552,7 +7552,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Allview
@@ -7570,7 +7570,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Allview
@@ -7588,7 +7588,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Allview
@@ -7606,7 +7606,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Allview
@@ -7624,7 +7624,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Allview
@@ -7642,7 +7642,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Allview
@@ -7660,7 +7660,7 @@
     name: Chrome Mobile
     version: "80.0.3987.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: smartphone
     brand: Allview
@@ -7678,7 +7678,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: AGM
@@ -7696,7 +7696,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: smartphone
     brand: AGM
@@ -7714,7 +7714,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: AGM
@@ -7732,7 +7732,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: smartphone
     brand: AGM
@@ -7768,7 +7768,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Ask
@@ -7786,7 +7786,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: smartphone
     brand: altron
@@ -7804,7 +7804,7 @@
     name: Chrome Webview
     version: "38.0.2125.102"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: smartphone
     brand: Ark
@@ -7822,7 +7822,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Ark
@@ -7840,7 +7840,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Ark
@@ -7858,7 +7858,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Ark
@@ -7876,7 +7876,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Ark
@@ -7894,7 +7894,7 @@
     name: Opera Mobile
     version: "22.0.1485.78487"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.138"
   device:
     type: smartphone
     brand: Ark
@@ -7912,7 +7912,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Ark
@@ -7948,7 +7948,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Ark
@@ -7984,7 +7984,7 @@
     name: Chrome Webview
     version: "47.0.2526.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.100"
   device:
     type: smartphone
     brand: Ark
@@ -8002,7 +8002,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Ark
@@ -8038,7 +8038,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Ark
@@ -8074,7 +8074,7 @@
     name: Chrome Webview
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: smartphone
     brand: Ark
@@ -8092,7 +8092,7 @@
     name: Chrome Webview
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Ark
@@ -8110,7 +8110,7 @@
     name: Yandex Browser
     version: "17.1.0.412.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.95"
   device:
     type: smartphone
     brand: Ark
@@ -8128,7 +8128,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Ark
@@ -8146,7 +8146,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: smartphone
     brand: Ark
@@ -8164,7 +8164,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Ark
@@ -8182,7 +8182,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: smartphone
     brand: Ark
@@ -8200,7 +8200,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Ark
@@ -8218,7 +8218,7 @@
     name: Yandex Browser
     version: "16.10.0.1326.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.116"
   device:
     type: smartphone
     brand: Ark
@@ -8236,7 +8236,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Ark
@@ -8254,7 +8254,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Ark
@@ -8290,7 +8290,7 @@
     name: Yandex Browser
     version: "16.9.0.1424.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.116"
   device:
     type: smartphone
     brand: Ark
@@ -8308,7 +8308,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: smartphone
     brand: Ark
@@ -8344,7 +8344,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Ark
@@ -8362,7 +8362,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Ark
@@ -8380,7 +8380,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: smartphone
     brand: Ark
@@ -8398,7 +8398,7 @@
     name: Chrome Mobile
     version: "48.0.2564.95"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.95"
   device:
     type: smartphone
     brand: Ark
@@ -8416,7 +8416,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Ark
@@ -8434,7 +8434,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: smartphone
     brand: Ark
@@ -8452,7 +8452,7 @@
     name: Chrome Webview
     version: "69.0.3497.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: smartphone
     brand: Ark
@@ -8470,7 +8470,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Ark
@@ -8488,7 +8488,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Ark
@@ -8506,7 +8506,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: smartphone
     brand: Ark
@@ -8524,7 +8524,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Ark
@@ -8542,7 +8542,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: smartphone
     brand: Ark
@@ -8560,7 +8560,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: smartphone
     brand: Ark
@@ -8578,7 +8578,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: smartphone
     brand: Ark
@@ -8596,7 +8596,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: smartphone
     brand: Ark
@@ -8614,7 +8614,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Assistant
@@ -8632,7 +8632,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: smartphone
     brand: Assistant
@@ -8650,7 +8650,7 @@
     name: Chrome Mobile
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: smartphone
     brand: Assistant
@@ -8686,7 +8686,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Assistant
@@ -8704,7 +8704,7 @@
     name: Opera Mobile
     version: "53.1.2569.142848"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: smartphone
     brand: Assistant
@@ -8722,7 +8722,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: smartphone
     brand: Assistant
@@ -8740,7 +8740,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Assistant
@@ -8758,7 +8758,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: smartphone
     brand: Assistant
@@ -8776,7 +8776,7 @@
     name: Chrome Mobile
     version: "76.0.3809.21"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.21"
   device:
     type: smartphone
     brand: Assistant
@@ -8794,7 +8794,7 @@
     name: Chrome Mobile
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: smartphone
     brand: Assistant
@@ -8812,7 +8812,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: smartphone
     brand: Assistant
@@ -8830,7 +8830,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: smartphone
     brand: Assistant
@@ -8848,7 +8848,7 @@
     name: Chrome Mobile
     version: "73.0.3683.75"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.75"
   device:
     type: smartphone
     brand: Assistant
@@ -8866,7 +8866,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: smartphone
     brand: Assistant
@@ -8884,7 +8884,7 @@
     name: Chrome Mobile
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: smartphone
     brand: Assistant
@@ -8902,7 +8902,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Assistant
@@ -8920,7 +8920,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: smartphone
     brand: Assistant
@@ -8938,7 +8938,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Advan
@@ -8956,7 +8956,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: smartphone
     brand: Advan
@@ -8974,7 +8974,7 @@
     name: Chrome Mobile
     version: 28.0.1500.94
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: smartphone
     brand: Gigabyte

--- a/Tests/fixtures/tablet-1.yml
+++ b/Tests/fixtures/tablet-1.yml
@@ -44,7 +44,7 @@
     name: Chrome
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Beeline
@@ -62,7 +62,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Beeline
@@ -80,7 +80,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Beeline
@@ -98,7 +98,7 @@
     name: Chrome
     version: "75.0.3770.67"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: tablet
     brand: Beeline
@@ -116,7 +116,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: BDF
@@ -134,7 +134,7 @@
     name: Chrome
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: BDF
@@ -152,7 +152,7 @@
     name: Yandex Browser
     version: "10.44"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: BDF
@@ -170,7 +170,7 @@
     name: Chrome
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: BDF
@@ -188,7 +188,7 @@
     name: Chrome
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: tablet
     brand: BDF
@@ -206,7 +206,7 @@
     name: Chrome Webview
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tablet
     brand: BDF
@@ -224,7 +224,7 @@
     name: Chrome
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: tablet
     brand: BDF
@@ -242,7 +242,7 @@
     name: Chrome Mobile
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: BDF
@@ -260,7 +260,7 @@
     name: Chrome
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Bitmore
@@ -278,7 +278,7 @@
     name: Opera
     version: "51.0.2461.137246"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: tablet
     brand: Bitmore
@@ -296,7 +296,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Bobarry
@@ -314,7 +314,7 @@
     name: Chrome Webview
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Bobarry
@@ -332,7 +332,7 @@
     name: Chrome
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: BGH
@@ -350,7 +350,7 @@
     name: Chrome
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: tablet
     brand: BGH
@@ -368,7 +368,7 @@
     name: Chrome
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: tablet
     brand: BGH
@@ -386,7 +386,7 @@
     name: Chrome
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: BGH
@@ -404,7 +404,7 @@
     name: Chrome
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: BGH
@@ -422,7 +422,7 @@
     name: Chrome
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: tablet
     brand: BGH
@@ -440,7 +440,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: BGH
@@ -458,7 +458,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: BGH
@@ -530,7 +530,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: 'Barnes & Noble'
@@ -548,7 +548,7 @@
     name: Chrome
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: tablet
     brand: 'Barnes & Noble'
@@ -602,7 +602,7 @@
     name: Chrome
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Blaupunkt
@@ -620,7 +620,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: tablet
     brand: Blaupunkt
@@ -638,7 +638,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Blaupunkt
@@ -656,7 +656,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Blaupunkt
@@ -674,7 +674,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Blaupunkt
@@ -692,7 +692,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Blaupunkt
@@ -710,7 +710,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Blaupunkt
@@ -728,7 +728,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: Blaupunkt
@@ -746,7 +746,7 @@
     name: Chrome
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Blaupunkt
@@ -782,7 +782,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Blaupunkt
@@ -800,7 +800,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: Blaupunkt
@@ -818,7 +818,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Blaupunkt
@@ -836,7 +836,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: tablet
     brand: Blaupunkt
@@ -854,7 +854,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Blaupunkt
@@ -872,7 +872,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Blaupunkt
@@ -908,7 +908,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Brondi
@@ -926,7 +926,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Bravis
@@ -944,7 +944,7 @@
     name: Chrome Webview
     version: "67.0.3396.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.81"
   device:
     type: tablet
     brand: Bravis
@@ -962,7 +962,7 @@
     name: Chrome Webview
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tablet
     brand: Bravis
@@ -980,7 +980,7 @@
     name: Chrome Webview
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Bravis
@@ -998,7 +998,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Bravis
@@ -1016,7 +1016,7 @@
     name: Chrome
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Bravis
@@ -1034,7 +1034,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Bravis
@@ -1052,7 +1052,7 @@
     name: Chrome
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Bravis
@@ -1070,7 +1070,7 @@
     name: Chrome
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: tablet
     brand: Bravis
@@ -1088,7 +1088,7 @@
     name: Chrome
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: Bravis
@@ -1106,7 +1106,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Bravis
@@ -1124,7 +1124,7 @@
     name: Chrome
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Bravis
@@ -1142,7 +1142,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Bravis
@@ -1160,7 +1160,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Bravis
@@ -1196,7 +1196,7 @@
     name: Opera
     version: "37.1.2254.132401"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: bq
@@ -1214,7 +1214,7 @@
     name: Chrome Webview
     version: "43.0.2357.65"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.65"
   device:
     type: tablet
     brand: bq
@@ -1232,7 +1232,7 @@
     name: Chrome
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: tablet
     brand: bq
@@ -1250,7 +1250,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: bq
@@ -1268,7 +1268,7 @@
     name: Yandex Browser
     version: "9.40"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: bq
@@ -1286,7 +1286,7 @@
     name: Chrome Webview
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: bq
@@ -1304,7 +1304,7 @@
     name: Yandex Browser
     version: "8.50"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: bq
@@ -1322,7 +1322,7 @@
     name: Yandex Browser
     version: "8.50"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: bq
@@ -1340,7 +1340,7 @@
     name: Chrome
     version: "81.0.4044.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: bq
@@ -1358,7 +1358,7 @@
     name: Chrome Webview
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: bq
@@ -1376,7 +1376,7 @@
     name: Chrome
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: bq
@@ -1412,7 +1412,7 @@
     name: Yandex Browser
     version: "14.5.1847.18432.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.131"
   device:
     type: tablet
     brand: bq
@@ -1430,7 +1430,7 @@
     name: Opera Mobile
     version: "49.2.2361.134358"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: bq
@@ -1466,7 +1466,7 @@
     name: Yandex Browser
     version: "17.1.0.412.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.95"
   device:
     type: tablet
     brand: bq
@@ -1484,7 +1484,7 @@
     name: Chrome
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: bq
@@ -1502,7 +1502,7 @@
     name: Yandex Browser
     version: "14.5.1847.18432.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.131"
   device:
     type: tablet
     brand: bq
@@ -1520,7 +1520,7 @@
     name: Chrome
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: bq
@@ -1556,7 +1556,7 @@
     name: Yandex Browser
     version: "19.3.2.347.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.119"
   device:
     type: tablet
     brand: bq
@@ -1574,7 +1574,7 @@
     name: Chrome
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tablet
     brand: bq
@@ -1592,7 +1592,7 @@
     name: Chrome Webview
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: bq
@@ -1628,7 +1628,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: bq
@@ -1700,7 +1700,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: bq
@@ -1736,7 +1736,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: bq
@@ -1772,7 +1772,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: bq
@@ -1790,7 +1790,7 @@
     name: Chrome
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: bq
@@ -1808,7 +1808,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: bq
@@ -1826,7 +1826,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: bq
@@ -1844,7 +1844,7 @@
     name: Opera Mobile
     version: "42.0.2254.139276"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: bq
@@ -1862,7 +1862,7 @@
     name: Chrome
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tablet
     brand: bq
@@ -1880,7 +1880,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: bq
@@ -1898,7 +1898,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: bq
@@ -1916,7 +1916,7 @@
     name: Chrome Webview
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: bq
@@ -1934,7 +1934,7 @@
     name: Chrome Webview
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: bq
@@ -1952,7 +1952,7 @@
     name: Opera Mobile
     version: "52.4.2517.140781"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: bq
@@ -1970,7 +1970,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: bq
@@ -1988,7 +1988,7 @@
     name: Chrome Mobile
     version: "73.0.3683.75"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.75"
   device:
     type: tablet
     brand: bq
@@ -2006,7 +2006,7 @@
     name: Chrome Mobile
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: bq
@@ -2024,7 +2024,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: bq
@@ -2042,7 +2042,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: bq
@@ -2060,7 +2060,7 @@
     name: Chrome
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: bq
@@ -2078,7 +2078,7 @@
     name: Chrome
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: bq
@@ -2114,7 +2114,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: bq
@@ -2132,7 +2132,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: bq
@@ -2150,7 +2150,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: bq
@@ -2168,7 +2168,7 @@
     name: Chrome
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tablet
     brand: bq
@@ -2186,7 +2186,7 @@
     name: Yandex Browser
     version: "19.7.0.117.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.100"
   device:
     type: tablet
     brand: bq
@@ -2204,7 +2204,7 @@
     name: Yandex Browser
     version: "8.50"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: bq
@@ -2222,7 +2222,7 @@
     name: Chrome Webview
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: tablet
     brand: bq
@@ -2240,7 +2240,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: bq
@@ -2258,7 +2258,7 @@
     name: Chrome
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: bq
@@ -2276,7 +2276,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: bq
@@ -2348,7 +2348,7 @@
     name: Chrome
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Condor
@@ -2366,7 +2366,7 @@
     name: Chrome Webview
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Condor
@@ -2456,7 +2456,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: ComTrade Tesla
@@ -2474,7 +2474,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: ComTrade Tesla
@@ -2492,7 +2492,7 @@
     name: Chrome
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: tablet
     brand: ComTrade Tesla
@@ -2510,7 +2510,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: ComTrade Tesla
@@ -2528,7 +2528,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: ComTrade Tesla
@@ -2546,7 +2546,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: ComTrade Tesla
@@ -2564,7 +2564,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: tablet
     brand: ComTrade Tesla
@@ -2582,7 +2582,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: tablet
     brand: ComTrade Tesla
@@ -2600,7 +2600,7 @@
     name: Chrome Mobile
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: ComTrade Tesla
@@ -2618,7 +2618,7 @@
     name: Chrome Webview
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: tablet
     brand: ComTrade Tesla
@@ -2636,7 +2636,7 @@
     name: Chrome
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: ComTrade Tesla
@@ -2654,7 +2654,7 @@
     name: Chrome
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: ComTrade Tesla
@@ -2672,7 +2672,7 @@
     name: Chrome Mobile
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: ComTrade Tesla
@@ -2690,7 +2690,7 @@
     name: Chrome Mobile
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: tablet
     brand: ComTrade Tesla
@@ -2798,7 +2798,7 @@
     name: Chrome
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: tablet
     brand: Cat
@@ -2816,7 +2816,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Cat
@@ -2924,7 +2924,7 @@
     name: Chrome
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: tablet
     brand: Carrefour
@@ -2960,7 +2960,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Carrefour
@@ -2978,7 +2978,7 @@
     name: Chrome
     version: "40.0.2214.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: tablet
     brand: Carrefour
@@ -3014,7 +3014,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Carrefour
@@ -3032,7 +3032,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Carrefour
@@ -3122,7 +3122,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Captiva
@@ -3140,7 +3140,7 @@
     name: Chrome
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: tablet
     brand: Captiva
@@ -3158,7 +3158,7 @@
     name: Chrome
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: Captiva
@@ -3176,7 +3176,7 @@
     name: Chrome
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Cube
@@ -3194,7 +3194,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Cube
@@ -3212,7 +3212,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Cube
@@ -3230,7 +3230,7 @@
     name: Chrome
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Cube
@@ -3248,7 +3248,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Cube
@@ -3266,7 +3266,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Cube
@@ -3284,7 +3284,7 @@
     name: Chrome
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: Cube
@@ -3302,7 +3302,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Cube
@@ -3320,7 +3320,7 @@
     name: Chrome
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Cube
@@ -3338,7 +3338,7 @@
     name: Chrome
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Cube
@@ -3356,7 +3356,7 @@
     name: Opera
     version: "43.0.2246.121183"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Cube
@@ -3392,7 +3392,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Cube
@@ -3410,7 +3410,7 @@
     name: Chrome
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: tablet
     brand: Cube
@@ -3482,7 +3482,7 @@
     name: Chrome
     version: "35.0.1916.69"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.69"
   device:
     type: tablet
     brand: Cube
@@ -3500,7 +3500,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Cube
@@ -3554,7 +3554,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Cube
@@ -3932,7 +3932,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Coby Kyros
@@ -3950,7 +3950,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Coby Kyros
@@ -4148,7 +4148,7 @@
     name: Chrome Webview
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Digma
@@ -4166,7 +4166,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Digma
@@ -4184,7 +4184,7 @@
     name: Chrome
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: tablet
     brand: Digma
@@ -4202,7 +4202,7 @@
     name: Chrome
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Digma
@@ -4220,7 +4220,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Digma
@@ -4256,7 +4256,7 @@
     name: Yandex Browser
     version: "17.1.1.359.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.95"
   device:
     type: tablet
     brand: Digma
@@ -4274,7 +4274,7 @@
     name: Chrome
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: Digma
@@ -4292,7 +4292,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Digma
@@ -4310,7 +4310,7 @@
     name: Chrome
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: Digma
@@ -4328,7 +4328,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Digma
@@ -4346,7 +4346,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Digma
@@ -4364,7 +4364,7 @@
     name: Chrome
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Digma
@@ -4382,7 +4382,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Digma
@@ -4400,7 +4400,7 @@
     name: Opera
     version: "54.3.2672.50220"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Digma
@@ -4418,7 +4418,7 @@
     name: Opera Mobile
     version: "44.1.2254.143214"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: Digma
@@ -4436,7 +4436,7 @@
     name: Chrome Webview
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: Digma
@@ -4454,7 +4454,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Digma
@@ -4472,7 +4472,7 @@
     name: Chrome
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: tablet
     brand: Digma
@@ -4508,7 +4508,7 @@
     name: Chrome
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Digma
@@ -4526,7 +4526,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Digma
@@ -4544,7 +4544,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: tablet
     brand: Digma
@@ -4598,7 +4598,7 @@
     name: Yandex Browser
     version: "16.10.2.1487.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.116"
   device:
     type: tablet
     brand: Digma
@@ -4706,7 +4706,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Digma
@@ -4724,7 +4724,7 @@
     name: Opera
     version: "53.0.2569.141184"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Digma
@@ -4742,7 +4742,7 @@
     name: Chrome Webview
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: tablet
     brand: Digma
@@ -4778,7 +4778,7 @@
     name: Hawk Quick Browser
     version: 2.4.21.22910
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: tablet
     brand: Digma
@@ -4796,7 +4796,7 @@
     name: Yandex Browser
     version: "15.10.2454.3845.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.101"
   device:
     type: tablet
     brand: Digma
@@ -4832,7 +4832,7 @@
     name: Yandex Browser
     version: "17.1.2.339.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.95"
   device:
     type: tablet
     brand: Digma
@@ -4850,7 +4850,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Digma
@@ -4868,7 +4868,7 @@
     name: Yandex Browser
     version: "16.2.1.7529.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.111"
   device:
     type: tablet
     brand: Digma
@@ -4886,7 +4886,7 @@
     name: Chrome
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Digma
@@ -4904,7 +4904,7 @@
     name: Chrome
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: tablet
     brand: Digma
@@ -4940,7 +4940,7 @@
     name: Chrome Mobile
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: tablet
     brand: Digma
@@ -4958,7 +4958,7 @@
     name: Yandex Browser
     version: "14.5.1847.18211.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.131"
   device:
     type: tablet
     brand: Digma
@@ -4976,7 +4976,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: Digma
@@ -5030,7 +5030,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Danew
@@ -5156,7 +5156,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Danew
@@ -5300,7 +5300,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Danew
@@ -5318,7 +5318,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Digiland
@@ -5444,7 +5444,7 @@
     name: Chrome
     version: "33.0.1750.170"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.170"
   device:
     type: tablet
     brand: Denver
@@ -5462,7 +5462,7 @@
     name: Chrome
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: Denver
@@ -5480,7 +5480,7 @@
     name: Chrome Webview
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Denver
@@ -5498,7 +5498,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Denver
@@ -5516,7 +5516,7 @@
     name: Chrome Webview
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Denver
@@ -5534,7 +5534,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: tablet
     brand: Denver
@@ -5552,7 +5552,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: Denver
@@ -5624,7 +5624,7 @@
     name: Opera
     version: "55.1.2719.50626"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Dell
@@ -5642,7 +5642,7 @@
     name: Chrome
     version: "40.0.2214.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: tablet
     brand: Dell
@@ -5660,7 +5660,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: Dell
@@ -5678,7 +5678,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Dell
@@ -5696,7 +5696,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Dell
@@ -5714,7 +5714,7 @@
     name: Chrome
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: tablet
     brand: Dell
@@ -5750,7 +5750,7 @@
     name: Opera
     version: "28.0.1764.89981"
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.74"
   device:
     type: tablet
     brand: DNS
@@ -5768,7 +5768,7 @@
     name: Chrome
     version: "54.0.2840.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.68"
   device:
     type: tablet
     brand: DEXP
@@ -5786,7 +5786,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: DEXP
@@ -5804,7 +5804,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: DEXP
@@ -5822,7 +5822,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: DEXP
@@ -5840,7 +5840,7 @@
     name: Yandex Browser
     version: "19.10.1.100.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: DEXP
@@ -5858,7 +5858,7 @@
     name: Yandex Browser
     version: "20.2.2.121.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.117"
   device:
     type: tablet
     brand: DEXP
@@ -5876,7 +5876,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: EvroMedia
@@ -5894,7 +5894,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: EvroMedia
@@ -5912,7 +5912,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: EvroMedia
@@ -6092,7 +6092,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Elenberg
@@ -6128,7 +6128,7 @@
     name: Chrome
     version: "74.0.3729.112"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: tablet
     brand: Elenberg
@@ -6146,7 +6146,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Elenberg
@@ -6164,7 +6164,7 @@
     name: Yandex Browser
     version: "18.7.0.823.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.103"
   device:
     type: tablet
     brand: Elenberg
@@ -6182,7 +6182,7 @@
     name: Chrome
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: Elenberg
@@ -6200,7 +6200,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Elenberg
@@ -6218,7 +6218,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Elenberg
@@ -6254,7 +6254,7 @@
     name: Chrome
     version: "41.0.2272.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.96"
   device:
     type: tablet
     brand: ECS
@@ -6272,7 +6272,7 @@
     name: Chrome
     version: "33.0.1750.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.132"
   device:
     type: tablet
     brand: ECS
@@ -6290,7 +6290,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: ECS
@@ -6308,7 +6308,7 @@
     name: Chrome
     version: "35.0.1916.122"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.122"
   device:
     type: tablet
     brand: ECS
@@ -6398,7 +6398,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Evertek
@@ -6416,7 +6416,7 @@
     name: Chrome
     version: "36.0.1985.131"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.131"
   device:
     type: tablet
     brand: Explay
@@ -6452,7 +6452,7 @@
     name: Yandex Browser
     version: "15.12.2.6773.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.86"
   device:
     type: tablet
     brand: Explay
@@ -6470,7 +6470,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Explay
@@ -6488,7 +6488,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Explay
@@ -6506,7 +6506,7 @@
     name: Chrome Mobile
     version: "60.0.2959.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.2959.138"
   device:
     type: tablet
     brand: Explay
@@ -6524,7 +6524,7 @@
     name: Opera Mobile
     version: "16.0.1212.65583"
     engine: Blink
-    engine_version: ""
+    engine_version: "29.0.1547.72"
   device:
     type: tablet
     brand: Explay
@@ -6578,7 +6578,7 @@
     name: Chrome
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: tablet
     brand: Explay
@@ -6614,7 +6614,7 @@
     name: Yandex Browser
     version: "15.4.2272.3842.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.118"
   device:
     type: tablet
     brand: Explay
@@ -6632,7 +6632,7 @@
     name: Yandex Browser
     version: "16.4.0.9404.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.110"
   device:
     type: tablet
     brand: Explay
@@ -6650,7 +6650,7 @@
     name: Yandex Browser
     version: "14.10.2062.11375.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.124"
   device:
     type: tablet
     brand: Explay
@@ -6668,7 +6668,7 @@
     name: Chrome
     version: "39.0.2171.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.59"
   device:
     type: tablet
     brand: Explay
@@ -6740,7 +6740,7 @@
     name: Opera
     version: "52.3.2517.140547"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: FinePower
@@ -6758,7 +6758,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: FinePower
@@ -6776,7 +6776,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: FinePower
@@ -6812,7 +6812,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Fondi
@@ -6830,7 +6830,7 @@
     name: Chrome
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tablet
     brand: Fondi
@@ -6848,7 +6848,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Fondi
@@ -6866,7 +6866,7 @@
     name: Chrome
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: Fondi
@@ -6884,7 +6884,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Fondi
@@ -6920,7 +6920,7 @@
     name: Chrome
     version: "43.0.2357.78"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.78"
   device:
     type: tablet
     brand: Fondi
@@ -6938,7 +6938,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Fondi
@@ -6974,7 +6974,7 @@
     name: Chrome Webview
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: Fengxiang
@@ -6992,7 +6992,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Fengxiang
@@ -7046,7 +7046,7 @@
     name: Chrome
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: tablet
     brand: Fujitsu
@@ -7064,7 +7064,7 @@
     name: Chrome
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Fujitsu
@@ -7118,7 +7118,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Fujitsu
@@ -7136,7 +7136,7 @@
     name: Chrome
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: Globex
@@ -7154,7 +7154,7 @@
     name: Opera Mobile
     version: "50.3.2426.136976"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Globex
@@ -7172,7 +7172,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Globex
@@ -7190,7 +7190,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Globex
@@ -7208,7 +7208,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Globex
@@ -7262,7 +7262,7 @@
     name: Chrome
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: GOCLEVER
@@ -7280,7 +7280,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: GOCLEVER
@@ -7298,7 +7298,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: GOCLEVER
@@ -7316,7 +7316,7 @@
     name: Chrome
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: GOCLEVER
@@ -7352,7 +7352,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: GOCLEVER
@@ -7370,7 +7370,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: GOCLEVER
@@ -7388,7 +7388,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: GOCLEVER
@@ -7406,7 +7406,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: GOCLEVER
@@ -7586,7 +7586,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Ghia
@@ -7622,7 +7622,7 @@
     name: Chrome
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: tablet
     brand: Google
@@ -7676,7 +7676,7 @@
     name: Chrome
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: tablet
     brand: Google
@@ -7694,7 +7694,7 @@
     name: Chrome
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: tablet
     brand: Google
@@ -7748,7 +7748,7 @@
     name: Chrome
     version: "38.0.2125.509"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.509"
   device:
     type: tablet
     brand: Google
@@ -7802,7 +7802,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Gigaset
@@ -7838,7 +7838,7 @@
     name: Chrome
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: Ginzzu
@@ -7856,7 +7856,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Ginzzu
@@ -7874,7 +7874,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Ginzzu
@@ -7892,7 +7892,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Ginzzu
@@ -7910,7 +7910,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Ginzzu
@@ -7928,7 +7928,7 @@
     name: Chrome Webview
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Ginzzu
@@ -7982,7 +7982,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Ginzzu
@@ -8000,7 +8000,7 @@
     name: Yandex Browser
     version: "7.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Ginzzu
@@ -8018,7 +8018,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Ginzzu
@@ -8036,7 +8036,7 @@
     name: Chrome
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: Ginzzu
@@ -8072,7 +8072,7 @@
     name: Chrome Mobile
     version: "74.0.3729.169"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.169"
   device:
     type: tablet
     brand: Ginzzu
@@ -8090,7 +8090,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Haier
@@ -8108,7 +8108,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Haier
@@ -8126,7 +8126,7 @@
     name: Chrome
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: HannSpree
@@ -8144,7 +8144,7 @@
     name: Chrome
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: tablet
     brand: HannSpree
@@ -8216,7 +8216,7 @@
     name: Chrome
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: tablet
     brand: HannSpree
@@ -8288,7 +8288,7 @@
     name: Opera
     version: "18.0.1290.66961"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.57"
   device:
     type: tablet
     brand: Hisense
@@ -8414,7 +8414,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Hyundai
@@ -8432,7 +8432,7 @@
     name: Chrome
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: HP
@@ -8484,7 +8484,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: HP
@@ -8502,7 +8502,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: HP
@@ -8574,7 +8574,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: HP
@@ -8592,7 +8592,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: HP
@@ -8610,7 +8610,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: HP
@@ -8628,7 +8628,7 @@
     name: Chrome
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: HP
@@ -8646,7 +8646,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: HP
@@ -8682,7 +8682,7 @@
     name: Chrome
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: HP
@@ -8718,7 +8718,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: HP
@@ -8878,7 +8878,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: tablet
     brand: Huawei
@@ -8896,7 +8896,7 @@
     name: Chrome
     version: "83.0.4103.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: tablet
     brand: Huawei
@@ -8914,7 +8914,7 @@
     name: Chrome
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Huawei
@@ -8932,7 +8932,7 @@
     name: Chrome
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Huawei
@@ -8950,7 +8950,7 @@
     name: Chrome Webview
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: Huawei
@@ -8968,7 +8968,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Huawei
@@ -9358,7 +9358,7 @@
     name: Chrome
     version: 36.0.1985.135
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: tablet
     brand: Samsung
@@ -9412,7 +9412,7 @@
     name: Chrome
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: tablet
     brand: Samsung
@@ -9430,7 +9430,7 @@
     name: Chrome
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: tablet
     brand: Samsung
@@ -9538,7 +9538,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Samsung
@@ -9574,7 +9574,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Samsung
@@ -9592,7 +9592,7 @@
     name: Chrome
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: tablet
     brand: Samsung
@@ -9610,7 +9610,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Samsung
@@ -9628,7 +9628,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Samsung
@@ -9646,7 +9646,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Samsung
@@ -9700,7 +9700,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Samsung
@@ -9736,7 +9736,7 @@
     name: Chrome
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: Samsung
@@ -9754,7 +9754,7 @@
     name: Chrome
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: Samsung
@@ -9772,7 +9772,7 @@
     name: Chrome
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: Samsung
@@ -9790,7 +9790,7 @@
     name: Chrome
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: Samsung
@@ -9862,7 +9862,7 @@
     name: Chrome
     version: 52.0.2743.98
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Samsung
@@ -9934,7 +9934,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Samsung
@@ -9952,7 +9952,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Samsung
@@ -9970,7 +9970,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Samsung
@@ -9988,7 +9988,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Samsung
@@ -10038,7 +10038,7 @@
     name: Chrome
     version: 50.0.2661.89
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: tablet
     brand: Samsung
@@ -10056,7 +10056,7 @@
     name: Chrome
     version: 50.0.2661.89
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: tablet
     brand: Samsung
@@ -10128,7 +10128,7 @@
     name: Chrome
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: tablet
     brand: Samsung
@@ -10146,7 +10146,7 @@
     name: Chrome
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: tablet
     brand: Samsung
@@ -10356,7 +10356,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Polaroid

--- a/Tests/fixtures/tablet-2.yml
+++ b/Tests/fixtures/tablet-2.yml
@@ -10,7 +10,7 @@
     name: Chrome
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Huawei
@@ -28,7 +28,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Huawei
@@ -64,7 +64,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Huawei
@@ -82,7 +82,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Huawei
@@ -118,7 +118,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Huawei
@@ -136,7 +136,7 @@
     name: Chrome
     version: "80.0.3987.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: tablet
     brand: Huawei
@@ -172,7 +172,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Huawei
@@ -190,7 +190,7 @@
     name: Chrome Webview
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: tablet
     brand: Huawei
@@ -208,7 +208,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Huawei
@@ -244,7 +244,7 @@
     name: Chrome
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: Huawei
@@ -316,7 +316,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Huawei
@@ -334,7 +334,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Huawei
@@ -370,7 +370,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Huawei
@@ -406,7 +406,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: tablet
     brand: Huawei
@@ -424,7 +424,7 @@
     name: Chrome Mobile
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: tablet
     brand: Huawei
@@ -442,7 +442,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Huawei
@@ -460,7 +460,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Huawei
@@ -478,7 +478,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Huawei
@@ -496,7 +496,7 @@
     name: Chrome Mobile
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Huawei
@@ -514,7 +514,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Huawei
@@ -532,7 +532,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Huawei
@@ -550,7 +550,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Huawei
@@ -568,7 +568,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Huawei
@@ -586,7 +586,7 @@
     name: Chrome
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Huawei
@@ -604,7 +604,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Huawei
@@ -622,7 +622,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Huawei
@@ -640,7 +640,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Huawei
@@ -676,7 +676,7 @@
     name: Chrome Webview
     version: "70.0.3538.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: tablet
     brand: Huawei
@@ -694,7 +694,7 @@
     name: Yandex Browser
     version: "19.7.6.137.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Huawei
@@ -712,7 +712,7 @@
     name: Yandex Browser
     version: "19.7.7.115.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Huawei
@@ -730,7 +730,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Huawei
@@ -748,7 +748,7 @@
     name: Chrome Mobile
     version: "75.0.3770.67"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: tablet
     brand: Huawei
@@ -766,7 +766,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Huawei
@@ -784,7 +784,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Huawei
@@ -802,7 +802,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Huawei
@@ -820,7 +820,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Huawei
@@ -838,7 +838,7 @@
     name: Chrome
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tablet
     brand: Huawei
@@ -856,7 +856,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Huawei
@@ -874,7 +874,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Huawei
@@ -892,7 +892,7 @@
     name: Huawei Browser Mobile
     version: "10.0.1.333"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.64"
   device:
     type: tablet
     brand: Huawei
@@ -910,7 +910,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Huawei
@@ -928,7 +928,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Huawei
@@ -946,7 +946,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Huawei
@@ -964,7 +964,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: Huawei
@@ -982,7 +982,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Huawei
@@ -1000,7 +1000,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Huawei
@@ -1018,7 +1018,7 @@
     name: Chrome
     version: "80.0.3970.3"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3970.3"
   device:
     type: tablet
     brand: Huawei
@@ -1036,7 +1036,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Huawei
@@ -1054,7 +1054,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: tablet
     brand: Huawei
@@ -1090,7 +1090,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Huawei
@@ -1108,7 +1108,7 @@
     name: Chrome
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Huawei
@@ -1126,7 +1126,7 @@
     name: Chrome Webview
     version: "63.0.3239.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.83"
   device:
     type: tablet
     brand: Huawei
@@ -1144,7 +1144,7 @@
     name: Chrome
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Huawei
@@ -1162,7 +1162,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Huawei
@@ -1198,7 +1198,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: Huawei
@@ -1216,7 +1216,7 @@
     name: Chrome Mobile
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: tablet
     brand: Huawei
@@ -1234,7 +1234,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Huawei
@@ -1252,7 +1252,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Huawei
@@ -1270,7 +1270,7 @@
     name: Chrome
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Huawei
@@ -1288,7 +1288,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Huawei
@@ -1306,7 +1306,7 @@
     name: Chrome Mobile
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Huawei
@@ -1324,7 +1324,7 @@
     name: Chrome Mobile
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Huawei
@@ -1342,7 +1342,7 @@
     name: Chrome Mobile
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: tablet
     brand: Huawei
@@ -1378,7 +1378,7 @@
     name: Chrome
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: tablet
     brand: Huawei
@@ -1396,7 +1396,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Huawei
@@ -1432,7 +1432,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Huawei
@@ -1450,7 +1450,7 @@
     name: Chrome
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: tablet
     brand: Huawei
@@ -1468,7 +1468,7 @@
     name: Chrome
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Huawei
@@ -1486,7 +1486,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Huawei
@@ -1504,7 +1504,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Huawei
@@ -1522,7 +1522,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Huawei
@@ -1558,7 +1558,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: How
@@ -1612,7 +1612,7 @@
     name: Chrome Webview
     version: "44.0.2403.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: tablet
     brand: Hoozo
@@ -1630,7 +1630,7 @@
     name: Opera
     version: "44.1.2254.142553"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Hoozo
@@ -1648,7 +1648,7 @@
     name: Chrome Webview
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Hoozo
@@ -1666,7 +1666,7 @@
     name: Chrome Webview
     version: "51.0.2704.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.91"
   device:
     type: tablet
     brand: Hoozo
@@ -1720,7 +1720,7 @@
     name: Chrome Mobile
     version: "29.0.1547.72"
     engine: Blink
-    engine_version: ""
+    engine_version: "29.0.1547.72"
   device:
     type: tablet
     brand: IconBIT
@@ -1738,7 +1738,7 @@
     name: Chrome Mobile
     version: "48.0.2564.95"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.95"
   device:
     type: tablet
     brand: IconBIT
@@ -1756,7 +1756,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: IconBIT
@@ -1810,7 +1810,7 @@
     name: Chrome
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: IconBIT
@@ -1828,7 +1828,7 @@
     name: Chrome
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: IconBIT
@@ -1882,7 +1882,7 @@
     name: Chrome
     version: "40.0.2214.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: tablet
     brand: IconBIT
@@ -1900,7 +1900,7 @@
     name: Chrome
     version: "30.0.1599.82"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.82"
   device:
     type: tablet
     brand: IconBIT
@@ -1972,7 +1972,7 @@
     name: Chrome
     version: "30.0.1599.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.92"
   device:
     type: tablet
     brand: IconBIT
@@ -1990,7 +1990,7 @@
     name: Yandex Browser
     version: "14.12.2125.9740.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.122"
   device:
     type: tablet
     brand: Impression
@@ -2008,7 +2008,7 @@
     name: Chrome
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: tablet
     brand: Impression
@@ -2026,7 +2026,7 @@
     name: Chrome Mobile
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: tablet
     brand: Impression
@@ -2062,7 +2062,7 @@
     name: Chrome
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Impression
@@ -2080,7 +2080,7 @@
     name: Chrome
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Impression
@@ -2206,7 +2206,7 @@
     name: Chrome
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: tablet
     brand: Impression
@@ -2224,7 +2224,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: Impression
@@ -2242,7 +2242,7 @@
     name: Chrome Mobile
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: Impression
@@ -2260,7 +2260,7 @@
     name: Chrome
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: Impression
@@ -2278,7 +2278,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Impression
@@ -2296,7 +2296,7 @@
     name: Yandex Browser
     version: "15.6.2311.5718.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.152"
   device:
     type: tablet
     brand: Impression
@@ -2314,7 +2314,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Impression
@@ -2332,7 +2332,7 @@
     name: Chrome
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: tablet
     brand: Impression
@@ -2440,7 +2440,7 @@
     name: Chrome Webview
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Impression
@@ -2458,7 +2458,7 @@
     name: Chrome
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Impression
@@ -2476,7 +2476,7 @@
     name: Chrome
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Irbis
@@ -2494,7 +2494,7 @@
     name: Opera
     version: "47.0.2249.129167"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tablet
     brand: Irbis
@@ -2512,7 +2512,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Irbis
@@ -2530,7 +2530,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Irbis
@@ -2566,7 +2566,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Irbis
@@ -2584,7 +2584,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Irbis
@@ -2602,7 +2602,7 @@
     name: Yandex Browser
     version: "20.2.2.127.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.117"
   device:
     type: tablet
     brand: Irbis
@@ -2620,7 +2620,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Irbis
@@ -2638,7 +2638,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Irbis
@@ -2656,7 +2656,7 @@
     name: Chrome
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: Irbis
@@ -2674,7 +2674,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: Irbis
@@ -2692,7 +2692,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Irbis
@@ -2710,7 +2710,7 @@
     name: Chrome Mobile
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Irbis
@@ -2728,7 +2728,7 @@
     name: Opera Mobile
     version: "52.3.2517.140547"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Irbis
@@ -2746,7 +2746,7 @@
     name: Yandex Browser
     version: "19.12.1.121.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.97"
   device:
     type: tablet
     brand: Irbis
@@ -2764,7 +2764,7 @@
     name: Chrome
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: Irbis
@@ -2782,7 +2782,7 @@
     name: Chrome Webview
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tablet
     brand: Irbis
@@ -2800,7 +2800,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Irbis
@@ -2818,7 +2818,7 @@
     name: Chrome
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Irbis
@@ -2836,7 +2836,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Irbis
@@ -2854,7 +2854,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Irbis
@@ -2872,7 +2872,7 @@
     name: Opera Mobile
     version: "43.3.2254.142003"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Irbis
@@ -2890,7 +2890,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Irbis
@@ -2908,7 +2908,7 @@
     name: Opera
     version: "44.0.2254.141977"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Irbis
@@ -2926,7 +2926,7 @@
     name: Chrome
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Irbis
@@ -2944,7 +2944,7 @@
     name: Chrome
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tablet
     brand: Irbis
@@ -2962,7 +2962,7 @@
     name: Yandex Browser
     version: "19.7.6.137.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Irbis
@@ -2980,7 +2980,7 @@
     name: Chrome
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Irbis
@@ -2998,7 +2998,7 @@
     name: Chrome Webview
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Irbis
@@ -3016,7 +3016,7 @@
     name: Chrome
     version: "71.0.3578.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: tablet
     brand: Irbis
@@ -3034,7 +3034,7 @@
     name: Chrome
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: Irbis
@@ -3052,7 +3052,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Irbis
@@ -3070,7 +3070,7 @@
     name: Opera
     version: "53.0.2569.141117"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Irbis
@@ -3088,7 +3088,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Irbis
@@ -3106,7 +3106,7 @@
     name: Yandex Browser
     version: "19.7.2.90.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Irbis
@@ -3124,7 +3124,7 @@
     name: Chrome
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: tablet
     brand: Irbis
@@ -3142,7 +3142,7 @@
     name: Opera
     version: "44.1.2254.143214"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Irbis
@@ -3160,7 +3160,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Irbis
@@ -3178,7 +3178,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Irbis
@@ -3196,7 +3196,7 @@
     name: Opera
     version: "44.1.2254.143214"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Irbis
@@ -3214,7 +3214,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Irbis
@@ -3232,7 +3232,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Irbis
@@ -3250,7 +3250,7 @@
     name: Opera Mobile
     version: "55.1.2719.50626"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Irbis
@@ -3268,7 +3268,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Irbis
@@ -3286,7 +3286,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Irbis
@@ -3304,7 +3304,7 @@
     name: Chrome Mobile
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Irbis
@@ -3340,7 +3340,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Irbis
@@ -3358,7 +3358,7 @@
     name: Chrome
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: tablet
     brand: Irbis
@@ -3376,7 +3376,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Irbis
@@ -3394,7 +3394,7 @@
     name: Chrome
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: tablet
     brand: Irbis
@@ -3412,7 +3412,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Irbis
@@ -3430,7 +3430,7 @@
     name: Chrome
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Irbis
@@ -3448,7 +3448,7 @@
     name: Chrome
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Irbis
@@ -3466,7 +3466,7 @@
     name: Yandex Browser
     version: "15.6.2311.5718.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.152"
   device:
     type: tablet
     brand: Irbis
@@ -3484,7 +3484,7 @@
     name: Chrome Webview
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Irbis
@@ -3502,7 +3502,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Irbis
@@ -3520,7 +3520,7 @@
     name: Chrome Mobile
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Irbis
@@ -3538,7 +3538,7 @@
     name: Chrome
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Irbis
@@ -3556,7 +3556,7 @@
     name: Yandex Browser
     version: "20.2.0.215.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.117"
   device:
     type: tablet
     brand: Irbis
@@ -3574,7 +3574,7 @@
     name: Chrome Webview
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Irbis
@@ -3592,7 +3592,7 @@
     name: Chrome
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Irbis
@@ -3610,7 +3610,7 @@
     name: Chrome
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Irbis
@@ -3628,7 +3628,7 @@
     name: Chrome
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: tablet
     brand: Irbis
@@ -3646,7 +3646,7 @@
     name: Chrome
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Irbis
@@ -3664,7 +3664,7 @@
     name: Chrome
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Irbis
@@ -3682,7 +3682,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Irbis
@@ -3700,7 +3700,7 @@
     name: Chrome
     version: "74.0.3729.112"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: tablet
     brand: Irbis
@@ -3718,7 +3718,7 @@
     name: Chrome
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Irbis
@@ -3736,7 +3736,7 @@
     name: Opera
     version: "44.1.2254.142088"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Irbis
@@ -3754,7 +3754,7 @@
     name: Chrome
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: Irbis
@@ -3772,7 +3772,7 @@
     name: Chrome
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Irbis
@@ -3790,7 +3790,7 @@
     name: Chrome
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: tablet
     brand: Irbis
@@ -3808,7 +3808,7 @@
     name: Yandex Browser
     version: "19.9.6.88.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Irbis
@@ -3826,7 +3826,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Irbis
@@ -3862,7 +3862,7 @@
     name: Chrome
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: Irbis
@@ -3880,7 +3880,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Irbis
@@ -3898,7 +3898,7 @@
     name: Chrome
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Irbis
@@ -3916,7 +3916,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Irbis
@@ -3934,7 +3934,7 @@
     name: Opera
     version: "38.0.2254.134507"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Irbis
@@ -3952,7 +3952,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Irbis
@@ -3970,7 +3970,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Irbis
@@ -3988,7 +3988,7 @@
     name: Opera
     version: "44.1.2254.142088"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Irbis
@@ -4006,7 +4006,7 @@
     name: Yandex Browser
     version: "18.11.2.730.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: tablet
     brand: Irbis
@@ -4024,7 +4024,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Irbis
@@ -4042,7 +4042,7 @@
     name: Chrome Webview
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: tablet
     brand: Irbis
@@ -4060,7 +4060,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: iZotron
@@ -4078,7 +4078,7 @@
     name: Chrome
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: tablet
     brand: iZotron
@@ -4114,7 +4114,7 @@
     name: Chrome Mobile
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: iBall
@@ -4132,7 +4132,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: iView
@@ -4150,7 +4150,7 @@
     name: Chrome
     version: "80.0.3987.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: tablet
     brand: iGet
@@ -4168,7 +4168,7 @@
     name: Chrome
     version: "80.0.3987.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: tablet
     brand: iGet
@@ -4186,7 +4186,7 @@
     name: Chrome Mobile
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: tablet
     brand: iGet
@@ -4204,7 +4204,7 @@
     name: Chrome
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: iGet
@@ -4222,7 +4222,7 @@
     name: Chrome
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: iGet
@@ -4276,7 +4276,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: i-Joy
@@ -4456,7 +4456,7 @@
     name: Opera Mobile
     version: "22.0.2254.112936"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: iRola
@@ -4474,7 +4474,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: iRola
@@ -4492,7 +4492,7 @@
     name: Chrome
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: tablet
     brand: Insignia
@@ -4510,7 +4510,7 @@
     name: Chrome
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: tablet
     brand: Insignia
@@ -4528,7 +4528,7 @@
     name: Chrome
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Insignia
@@ -4546,7 +4546,7 @@
     name: Chrome
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Insignia
@@ -4564,7 +4564,7 @@
     name: Chrome
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Insignia
@@ -4582,7 +4582,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Insignia
@@ -4600,7 +4600,7 @@
     name: Chrome
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Insignia
@@ -4618,7 +4618,7 @@
     name: Chrome
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Insignia
@@ -4636,7 +4636,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: iRulu
@@ -4654,7 +4654,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: iRulu
@@ -4672,7 +4672,7 @@
     name: Chrome
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: tablet
     brand: iRulu
@@ -4708,7 +4708,7 @@
     name: Chrome
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: JAY-Tech
@@ -4726,7 +4726,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: JAY-Tech
@@ -4744,7 +4744,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: JAY-Tech
@@ -4762,7 +4762,7 @@
     name: Chrome Webview
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: JAY-Tech
@@ -4780,7 +4780,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: JAY-Tech
@@ -4798,7 +4798,7 @@
     name: Chrome Webview
     version: "72.0.3626.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: tablet
     brand: JAY-Tech
@@ -4816,7 +4816,7 @@
     name: Chrome Webview
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: JAY-Tech
@@ -4834,7 +4834,7 @@
     name: Chrome Webview
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: JAY-Tech
@@ -4852,7 +4852,7 @@
     name: Chrome Webview
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: JAY-Tech
@@ -4870,7 +4870,7 @@
     name: Chrome
     version: "74.0.3729.112"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: tablet
     brand: JAY-Tech
@@ -4888,7 +4888,7 @@
     name: Chrome
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: JAY-Tech
@@ -4906,7 +4906,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Cavion
@@ -4924,7 +4924,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Cavion
@@ -4942,7 +4942,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Cavion
@@ -4996,7 +4996,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Kiano
@@ -5050,7 +5050,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Kiano
@@ -5068,7 +5068,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Kiano
@@ -5104,7 +5104,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Kiano
@@ -5122,7 +5122,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Kiano
@@ -5140,7 +5140,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Kanji
@@ -5248,7 +5248,7 @@
     name: Chrome
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: tablet
     brand: Kocaso
@@ -5354,7 +5354,7 @@
     name: Chrome
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: Kocaso
@@ -5426,7 +5426,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Kocaso
@@ -5462,7 +5462,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Kocaso
@@ -5480,7 +5480,7 @@
     name: Chrome Mobile
     version: "28.0.1500.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.64"
   device:
     type: tablet
     brand: Kocaso
@@ -5498,7 +5498,7 @@
     name: Chrome Webview
     version: "51.0.2704.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.91"
   device:
     type: tablet
     brand: Kocaso
@@ -5516,7 +5516,7 @@
     name: Chrome Mobile
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: tablet
     brand: Kocaso
@@ -5534,7 +5534,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: tablet
     brand: Kocaso
@@ -5552,7 +5552,7 @@
     name: Chrome
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: tablet
     brand: Kocaso
@@ -5588,7 +5588,7 @@
     name: Chrome
     version: "30.0.1599.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.92"
   device:
     type: tablet
     brand: Kocaso
@@ -5640,7 +5640,7 @@
     name: Chrome
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: tablet
     brand: Kocaso
@@ -5658,7 +5658,7 @@
     name: Chrome
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: 'Krüger&Matz'
@@ -5676,7 +5676,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: 'Krüger&Matz'
@@ -5694,7 +5694,7 @@
     name: Chrome
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tablet
     brand: 'Krüger&Matz'
@@ -5712,7 +5712,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: 'Krüger&Matz'
@@ -5730,7 +5730,7 @@
     name: Chrome Webview
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: 'Krüger&Matz'
@@ -5748,7 +5748,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Kodak
@@ -5766,7 +5766,7 @@
     name: Chrome
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: Kodak
@@ -5784,7 +5784,7 @@
     name: Mobile Silk
     version: "49.2.1"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: tablet
     brand: Amazon
@@ -5802,7 +5802,7 @@
     name: Mobile Silk
     version: "80.4.14"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: tablet
     brand: Amazon
@@ -5820,7 +5820,7 @@
     name: Chrome
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Amazon
@@ -5856,7 +5856,7 @@
     name: Chrome
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Amazon
@@ -5874,7 +5874,7 @@
     name: Mobile Silk
     version: "3.45"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2026.117"
   device:
     type: tablet
     brand: Amazon
@@ -5892,7 +5892,7 @@
     name: Mobile Silk
     version: "3.37"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.137"
   device:
     type: tablet
     brand: Amazon
@@ -5910,7 +5910,7 @@
     name: Mobile Silk
     version: "50.2.1"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: tablet
     brand: Amazon
@@ -5928,7 +5928,7 @@
     name: Opera
     version: "37.0.2192.105088"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.94"
   device:
     type: tablet
     brand: Amazon
@@ -5946,7 +5946,7 @@
     name: Chrome
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Amazon
@@ -5964,7 +5964,7 @@
     name: Mobile Silk
     version: "69.4.17"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: Amazon
@@ -5982,7 +5982,7 @@
     name: Chrome Webview
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Amazon
@@ -6000,7 +6000,7 @@
     name: Mobile Silk
     version: "3.46"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2026.117"
   device:
     type: tablet
     brand: Amazon
@@ -6018,7 +6018,7 @@
     name: Mobile Silk
     version: "3.41"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2026.117"
   device:
     type: tablet
     brand: Amazon
@@ -6108,7 +6108,7 @@
     name: Chrome
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: Amazon
@@ -6216,7 +6216,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Amazon
@@ -6234,7 +6234,7 @@
     name: Chrome
     version: "31.0.1650.42"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.42"
   device:
     type: tablet
     brand: Amazon
@@ -6252,7 +6252,7 @@
     name: Chrome
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: Amazon
@@ -6288,7 +6288,7 @@
     name: Chrome
     version: "40.0.2214.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: tablet
     brand: Amazon
@@ -6342,7 +6342,7 @@
     name: Chrome
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: tablet
     brand: Amazon
@@ -6378,7 +6378,7 @@
     name: Chrome
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: tablet
     brand: Leagoo
@@ -6396,7 +6396,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lanix
@@ -6486,7 +6486,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Lenovo
@@ -6504,7 +6504,7 @@
     name: Chrome Mobile
     version: "61.0.2912.171"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.2912.171"
   device:
     type: tablet
     brand: Lenovo
@@ -6522,7 +6522,7 @@
     name: Chrome Webview
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: Lenovo
@@ -6576,7 +6576,7 @@
     name: Chrome
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: tablet
     brand: Lenovo
@@ -6594,7 +6594,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -6643,7 +6643,7 @@
     name: Chrome
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: Lenovo
@@ -6661,7 +6661,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -6679,7 +6679,7 @@
     name: Chrome
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: Lenovo
@@ -6697,7 +6697,7 @@
     name: Chrome
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: tablet
     brand: Lenovo
@@ -6715,7 +6715,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -6733,7 +6733,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -6751,7 +6751,7 @@
     name: Chrome
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: tablet
     brand: Lenovo
@@ -6769,7 +6769,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -6805,7 +6805,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -6823,7 +6823,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -6841,7 +6841,7 @@
     name: Chrome
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: tablet
     brand: Lenovo
@@ -6859,7 +6859,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -6877,7 +6877,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Lenovo
@@ -6895,7 +6895,7 @@
     name: Chrome
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Lenovo
@@ -6913,7 +6913,7 @@
     name: Chrome
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: Lenovo
@@ -6931,7 +6931,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -6949,7 +6949,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -6967,7 +6967,7 @@
     name: Chrome
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Lenovo
@@ -6985,7 +6985,7 @@
     name: Chrome
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: tablet
     brand: Lenovo
@@ -7003,7 +7003,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -7021,7 +7021,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -7039,7 +7039,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -7057,7 +7057,7 @@
     name: Chrome
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: tablet
     brand: Lenovo
@@ -7075,7 +7075,7 @@
     name: Chrome
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: tablet
     brand: Lenovo
@@ -7093,7 +7093,7 @@
     name: Chrome
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: Lenovo
@@ -7111,7 +7111,7 @@
     name: Chrome
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Lenovo
@@ -7129,7 +7129,7 @@
     name: Chrome Webview
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tablet
     brand: Lenovo
@@ -7147,7 +7147,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Lenovo
@@ -7165,7 +7165,7 @@
     name: Chrome
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: tablet
     brand: Lenovo
@@ -7183,7 +7183,7 @@
     name: Chrome Mobile
     version: "63.0.3239.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.84"
   device:
     type: tablet
     brand: Lenovo
@@ -7201,7 +7201,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Lenovo
@@ -7219,7 +7219,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -7237,7 +7237,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -7255,7 +7255,7 @@
     name: Chrome Mobile
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Lenovo
@@ -7273,7 +7273,7 @@
     name: Chrome
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: tablet
     brand: Lenovo
@@ -7291,7 +7291,7 @@
     name: Chrome
     version: "83.0.4103.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: tablet
     brand: Lenovo
@@ -7309,7 +7309,7 @@
     name: Chrome Webview
     version: "64.0.3282.123"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: tablet
     brand: Lenovo
@@ -7327,7 +7327,7 @@
     name: Chrome
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: Lenovo
@@ -7345,7 +7345,7 @@
     name: Yandex Browser
     version: "17.7.0.1173.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Lenovo
@@ -7363,7 +7363,7 @@
     name: Chrome
     version: "69.0.3497.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.86"
   device:
     type: tablet
     brand: Lenovo
@@ -7381,7 +7381,7 @@
     name: Chrome
     version: "83.0.4103.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: tablet
     brand: Lenovo
@@ -7399,7 +7399,7 @@
     name: Chrome Webview
     version: "85.0.4183.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Lenovo
@@ -7417,7 +7417,7 @@
     name: Chrome
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: tablet
     brand: Lenovo
@@ -7471,7 +7471,7 @@
     name: Chrome
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: tablet
     brand: Lenovo
@@ -7489,7 +7489,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -7507,7 +7507,7 @@
     name: Chrome
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Lenovo
@@ -7525,7 +7525,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -7543,7 +7543,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -7561,7 +7561,7 @@
     name: Chrome Mobile
     version: "63.0.3239.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.84"
   device:
     type: tablet
     brand: Lenovo
@@ -7579,7 +7579,7 @@
     name: Chrome
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: tablet
     brand: Lenovo
@@ -7597,7 +7597,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -7615,7 +7615,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Lenovo
@@ -7687,7 +7687,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Lenovo
@@ -7705,7 +7705,7 @@
     name: Chrome
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Lenovo
@@ -7723,7 +7723,7 @@
     name: Chrome
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: Lenovo
@@ -7741,7 +7741,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Lenovo
@@ -7759,7 +7759,7 @@
     name: Chrome
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: Lenovo
@@ -7777,7 +7777,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Lenovo
@@ -7795,7 +7795,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Lenovo
@@ -7813,7 +7813,7 @@
     name: Chrome
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: tablet
     brand: Lenovo
@@ -7831,7 +7831,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Lenovo
@@ -7849,7 +7849,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Lenovo
@@ -7885,7 +7885,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: LG
@@ -7903,7 +7903,7 @@
     name: Chrome
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: tablet
     brand: LG
@@ -7921,7 +7921,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: LG
@@ -7939,7 +7939,7 @@
     name: Chrome
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: tablet
     brand: LG
@@ -7957,7 +7957,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: LG
@@ -7975,7 +7975,7 @@
     name: Chrome
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: tablet
     brand: LG
@@ -7993,7 +7993,7 @@
     name: Chrome
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: LG
@@ -8029,7 +8029,7 @@
     name: Opera
     version: "16.0.1212.63780"
     engine: Blink
-    engine_version: ""
+    engine_version: "29.0.1547.72"
   device:
     type: tablet
     brand: LG
@@ -8065,7 +8065,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Lark
@@ -8083,7 +8083,7 @@
     name: Chrome
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: tablet
     brand: Lark
@@ -8101,7 +8101,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: Lark
@@ -8155,7 +8155,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Lark
@@ -8209,7 +8209,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Lark
@@ -8227,7 +8227,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Lark
@@ -8245,7 +8245,7 @@
     name: Chrome
     version: "72.0.3626.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: tablet
     brand: Lark
@@ -8263,7 +8263,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: Lark
@@ -8281,7 +8281,7 @@
     name: Chrome
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: tablet
     brand: Lark
@@ -8299,7 +8299,7 @@
     name: Chrome
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: tablet
     brand: Lark
@@ -8317,7 +8317,7 @@
     name: Chrome Webview
     version: "51.0.2704.81"
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: tablet
     brand: Lark
@@ -8335,7 +8335,7 @@
     name: Chrome Webview
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: tablet
     brand: Lark
@@ -8353,7 +8353,7 @@
     name: Chrome Webview
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: tablet
     brand: Logicom
@@ -8443,7 +8443,7 @@
     name: Chrome Mobile
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Logicom
@@ -8461,7 +8461,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Logicom
@@ -8479,7 +8479,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Logicom
@@ -8497,7 +8497,7 @@
     name: Chrome
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Logicom
@@ -8515,7 +8515,7 @@
     name: Chrome
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Logicom
@@ -8533,7 +8533,7 @@
     name: Chrome
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tablet
     brand: Logicom
@@ -8569,7 +8569,7 @@
     name: Chrome Webview
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Logicom
@@ -8587,7 +8587,7 @@
     name: Chrome Webview
     version: "48.0.2564.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.106"
   device:
     type: smartphone
     brand: Logicom
@@ -8605,7 +8605,7 @@
     name: Chrome
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: tablet
     brand: Logicom
@@ -8623,7 +8623,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Logicom
@@ -8641,7 +8641,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Logicom
@@ -8659,7 +8659,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Logicom
@@ -8677,7 +8677,7 @@
     name: Chrome
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: Logicom
@@ -8695,7 +8695,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: tablet
     brand: Logicom
@@ -8713,7 +8713,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: Logicom
@@ -8731,7 +8731,7 @@
     name: Chrome
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: Logicom
@@ -8749,7 +8749,7 @@
     name: Chrome
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: Logicom
@@ -8767,7 +8767,7 @@
     name: Chrome Mobile
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: tablet
     brand: Logicom
@@ -8893,7 +8893,7 @@
     name: Opera
     version: "21.0.1437.74904"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.116"
   device:
     type: tablet
     brand: Lenco
@@ -9001,7 +9001,7 @@
     name: Chrome
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Cavion
@@ -9037,7 +9037,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Cavion
@@ -9055,7 +9055,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Cavion
@@ -9091,7 +9091,7 @@
     name: Chrome
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: tablet
     brand: Alcatel

--- a/Tests/fixtures/tablet-3.yml
+++ b/Tests/fixtures/tablet-3.yml
@@ -118,7 +118,7 @@
     name: Chrome
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: tablet
     brand: Le Pan
@@ -172,7 +172,7 @@
     name: Chrome
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: MLS
@@ -190,7 +190,7 @@
     name: Chrome
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: MLS
@@ -208,7 +208,7 @@
     name: Chrome
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: MLS
@@ -244,7 +244,7 @@
     name: Chrome
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: tablet
     brand: MLS
@@ -262,7 +262,7 @@
     name: Chrome
     version: "49.0.2623.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: tablet
     brand: MLS
@@ -280,7 +280,7 @@
     name: Chrome
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: MLS
@@ -298,7 +298,7 @@
     name: Chrome
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: MLS
@@ -316,7 +316,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: MLS
@@ -334,7 +334,7 @@
     name: Chrome
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: MLS
@@ -352,7 +352,7 @@
     name: Chrome
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: tablet
     brand: MLS
@@ -388,7 +388,7 @@
     name: Chrome
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tablet
     brand: MLS
@@ -424,7 +424,7 @@
     name: Chrome Webview
     version: "60.0.3112"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112"
   device:
     type: tablet
     brand: MLS
@@ -442,7 +442,7 @@
     name: Chrome
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: MLS
@@ -460,7 +460,7 @@
     name: Chrome
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: MLS
@@ -478,7 +478,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: MLS
@@ -496,7 +496,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Leotec
@@ -514,7 +514,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Leotec
@@ -532,7 +532,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Leotec
@@ -820,7 +820,7 @@
     name: Chrome Mobile
     version: "30.0.1599.82"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.82"
   device:
     type: tablet
     brand: Lexibook
@@ -838,7 +838,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Lexibook
@@ -982,7 +982,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Mecer
@@ -1054,7 +1054,7 @@
     name: Chrome
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: tablet
     brand: Modecom
@@ -1108,7 +1108,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Miray
@@ -1126,7 +1126,7 @@
     name: Chrome
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: tablet
     brand: Myria
@@ -1144,7 +1144,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Myria
@@ -1162,7 +1162,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: MTC
@@ -1198,7 +1198,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Manta Multimedia
@@ -1216,7 +1216,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Manta Multimedia
@@ -1288,7 +1288,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Manta Multimedia
@@ -1306,7 +1306,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Manta Multimedia
@@ -1342,7 +1342,7 @@
     name: Chrome
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Mediacom
@@ -1360,7 +1360,7 @@
     name: Chrome
     version: "43.0.2357.78"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.78"
   device:
     type: tablet
     brand: Mediacom
@@ -1378,7 +1378,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Mediacom
@@ -1396,7 +1396,7 @@
     name: Chrome
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: Mediacom
@@ -1414,7 +1414,7 @@
     name: Chrome
     version: "43.0.2357.78"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.78"
   device:
     type: tablet
     brand: Mediacom
@@ -1450,7 +1450,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Mediacom
@@ -1468,7 +1468,7 @@
     name: Chrome
     version: "43.0.2357.78"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.78"
   device:
     type: tablet
     brand: Mediacom
@@ -1486,7 +1486,7 @@
     name: Chrome
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: tablet
     brand: Mediacom
@@ -1522,7 +1522,7 @@
     name: Chrome
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: tablet
     brand: Mediacom
@@ -1540,7 +1540,7 @@
     name: Chrome
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: tablet
     brand: Mediacom
@@ -1558,7 +1558,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Mediacom
@@ -1666,7 +1666,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Mediacom
@@ -1684,7 +1684,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Mediacom
@@ -1738,7 +1738,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Mediacom
@@ -1756,7 +1756,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Mediacom
@@ -1774,7 +1774,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Mediacom
@@ -1792,7 +1792,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Mediacom
@@ -1810,7 +1810,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Mediacom
@@ -1828,7 +1828,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Mediacom
@@ -1846,7 +1846,7 @@
     name: Opera
     version: "29.0.1809.92117"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.107"
   device:
     type: tablet
     brand: Mediacom
@@ -1900,7 +1900,7 @@
     name: Chrome
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: Mediacom
@@ -1918,7 +1918,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Mediacom
@@ -1990,7 +1990,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Mediacom
@@ -2008,7 +2008,7 @@
     name: Opera
     version: "21.0.1437.74904"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.116"
   device:
     type: tablet
     brand: Mediacom
@@ -2062,7 +2062,7 @@
     name: Chrome
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: tablet
     brand: Mediacom
@@ -2134,7 +2134,7 @@
     name: Chrome Webview
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Mediacom
@@ -2152,7 +2152,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Medion
@@ -2170,7 +2170,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Medion
@@ -2188,7 +2188,7 @@
     name: Chrome
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: tablet
     brand: Medion
@@ -2258,7 +2258,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Medion
@@ -2276,7 +2276,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Medion
@@ -2328,7 +2328,7 @@
     name: Chrome
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: tablet
     brand: Medion
@@ -2346,7 +2346,7 @@
     name: Chrome
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: Medion
@@ -2382,7 +2382,7 @@
     name: Chrome
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: Medion
@@ -2436,7 +2436,7 @@
     name: Chrome
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: tablet
     brand: Medion
@@ -2508,7 +2508,7 @@
     name: Chrome
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: tablet
     brand: MicroMax
@@ -2562,7 +2562,7 @@
     name: Chrome
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: Majestic
@@ -2580,7 +2580,7 @@
     name: Chrome
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Majestic
@@ -2616,7 +2616,7 @@
     name: Chrome
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: tablet
     brand: Mpman
@@ -2832,7 +2832,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Mpman
@@ -2850,7 +2850,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Mpman
@@ -2904,7 +2904,7 @@
     name: Opera
     version: "21.0.1437.74904"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.116"
   device:
     type: tablet
     brand: Mpman
@@ -3012,7 +3012,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Mpman
@@ -3118,7 +3118,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Mpman
@@ -3136,7 +3136,7 @@
     name: Chrome
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Mpman
@@ -3172,7 +3172,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Mpman
@@ -3226,7 +3226,7 @@
     name: Chrome Mobile
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: MegaFon
@@ -3244,7 +3244,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: MegaFon
@@ -3352,7 +3352,7 @@
     name: Opera
     version: "18.0.1290.67495"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.57"
   device:
     type: tablet
     brand: Motorola
@@ -3478,7 +3478,7 @@
     name: Chrome
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: Motorola
@@ -3514,7 +3514,7 @@
     name: Chrome
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: tablet
     brand: Motorola
@@ -3710,7 +3710,7 @@
     name: Opera
     version: "21.0.1437.74904"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.116"
   device:
     type: tablet
     brand: Memup
@@ -3728,7 +3728,7 @@
     name: Opera Mobile
     version: "21.0.1437.74904"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.116"
   device:
     type: tablet
     brand: Memup
@@ -3926,7 +3926,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: MyPhone
@@ -3944,7 +3944,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: MyPhone
@@ -3962,7 +3962,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: MyPhone
@@ -3998,7 +3998,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: MSI
@@ -4034,7 +4034,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: MTN
@@ -4052,7 +4052,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: NEC
@@ -4070,7 +4070,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Nomi
@@ -4088,7 +4088,7 @@
     name: Chrome
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Nomi
@@ -4106,7 +4106,7 @@
     name: Chrome
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Nomi
@@ -4124,7 +4124,7 @@
     name: Chrome
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Nomi
@@ -4142,7 +4142,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Nomi
@@ -4160,7 +4160,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Nomi
@@ -4178,7 +4178,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Nomi
@@ -4196,7 +4196,7 @@
     name: Chrome
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Nomi
@@ -4214,7 +4214,7 @@
     name: Chrome
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: Nomi
@@ -4232,7 +4232,7 @@
     name: Chrome
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: Nomi
@@ -4250,7 +4250,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Nomi
@@ -4268,7 +4268,7 @@
     name: Chrome
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: Nomi
@@ -4304,7 +4304,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: NextBook
@@ -4322,7 +4322,7 @@
     name: Opera
     version: "37.0.2254.130605"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: NextBook
@@ -4500,7 +4500,7 @@
     name: Chrome Mobile
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: tablet
     brand: Nvidia
@@ -4518,7 +4518,7 @@
     name: Chrome
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Nvidia
@@ -4536,7 +4536,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Nvidia
@@ -4590,7 +4590,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Odys
@@ -4608,7 +4608,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Odys
@@ -4644,7 +4644,7 @@
     name: Chrome
     version: "67.0.3396.68"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.68"
   device:
     type: tablet
     brand: Odys
@@ -4680,7 +4680,7 @@
     name: Chrome Webview
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: tablet
     brand: Odys
@@ -4698,7 +4698,7 @@
     name: Chrome
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: Odys
@@ -4716,7 +4716,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Odys
@@ -4734,7 +4734,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Odys
@@ -4752,7 +4752,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Odys
@@ -4770,7 +4770,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Odys
@@ -4788,7 +4788,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Odys
@@ -4806,7 +4806,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Odys
@@ -4878,7 +4878,7 @@
     name: Chrome
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Odys
@@ -4896,7 +4896,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Odys
@@ -4914,7 +4914,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Odys
@@ -4932,7 +4932,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Odys
@@ -4968,7 +4968,7 @@
     name: Chrome
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Odys
@@ -4986,7 +4986,7 @@
     name: Chrome
     version: "60.0.3112.78"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.78"
   device:
     type: tablet
     brand: Odys
@@ -5004,7 +5004,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Odys
@@ -5022,7 +5022,7 @@
     name: Chrome Webview
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: tablet
     brand: Odys
@@ -5040,7 +5040,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Odys
@@ -5076,7 +5076,7 @@
     name: Chrome
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: Odys
@@ -5112,7 +5112,7 @@
     name: Chrome
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: Odys
@@ -5130,7 +5130,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Odys
@@ -5148,7 +5148,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: Odys
@@ -5166,7 +5166,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: ONN
@@ -5202,7 +5202,7 @@
     name: Chrome
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Oyyu
@@ -5238,7 +5238,7 @@
     name: Chrome
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Onda
@@ -5256,7 +5256,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Onda
@@ -5274,7 +5274,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Onda
@@ -5292,7 +5292,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Onda
@@ -5310,7 +5310,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Onda
@@ -5328,7 +5328,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Onda
@@ -5346,7 +5346,7 @@
     name: Chrome
     version: "48.0.2564.8"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.8"
   device:
     type: tablet
     brand: Onda
@@ -5364,7 +5364,7 @@
     name: Chrome
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Onda
@@ -5382,7 +5382,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Onda
@@ -5400,7 +5400,7 @@
     name: Chrome
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Onda
@@ -5418,7 +5418,7 @@
     name: Chrome
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Onda
@@ -5436,7 +5436,7 @@
     name: Opera
     version: "54.0.2651.48970"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Onda
@@ -5454,7 +5454,7 @@
     name: Chrome
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tablet
     brand: Onda
@@ -5490,7 +5490,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Orange
@@ -5634,7 +5634,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Overmax
@@ -5652,7 +5652,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Overmax
@@ -5670,7 +5670,7 @@
     name: Chrome
     version: "80.0.3987.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: Overmax
@@ -5706,7 +5706,7 @@
     name: Chrome
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Oysters
@@ -5724,7 +5724,7 @@
     name: Chrome
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tablet
     brand: Oysters
@@ -5742,7 +5742,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Oysters
@@ -5760,7 +5760,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Oysters
@@ -5778,7 +5778,7 @@
     name: Yandex Browser
     version: "15.4.2272.3608.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.118"
   device:
     type: tablet
     brand: Oysters
@@ -5796,7 +5796,7 @@
     name: Opera
     version: "54.3.2672.50220"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Oysters
@@ -5814,7 +5814,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Oysters
@@ -5832,7 +5832,7 @@
     name: Chrome
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Oysters
@@ -5850,7 +5850,7 @@
     name: Opera
     version: "19.0.1340.69721"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.72"
   device:
     type: tablet
     brand: Oysters
@@ -5886,7 +5886,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Oysters
@@ -5904,7 +5904,7 @@
     name: Chrome Webview
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Oysters
@@ -5922,7 +5922,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Oysters
@@ -5940,7 +5940,7 @@
     name: Chrome
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Oysters
@@ -5958,7 +5958,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Oysters
@@ -5976,7 +5976,7 @@
     name: Chrome
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Oysters
@@ -5994,7 +5994,7 @@
     name: Chrome
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: tablet
     brand: Oysters
@@ -6012,7 +6012,7 @@
     name: Chrome
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Oysters
@@ -6030,7 +6030,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Oysters
@@ -6066,7 +6066,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Oysters
@@ -6084,7 +6084,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Oysters
@@ -6102,7 +6102,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Oysters
@@ -6120,7 +6120,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Oysters
@@ -6228,7 +6228,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Polytron
@@ -6246,7 +6246,7 @@
     name: Chrome Webview
     version: "37.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: tablet
     brand: Proline
@@ -6264,7 +6264,7 @@
     name: Chrome
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: PocketBook
@@ -6300,7 +6300,7 @@
     name: Chrome
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: tablet
     brand: Primepad
@@ -6318,7 +6318,7 @@
     name: Chrome
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: tablet
     brand: Primepad
@@ -6354,7 +6354,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Panasonic
@@ -6372,7 +6372,7 @@
     name: Chrome Webview
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: PCBOX
@@ -6390,7 +6390,7 @@
     name: Chrome
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: PCBOX
@@ -6426,7 +6426,7 @@
     name: Opera
     version: "25.0.1619.84037"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: tablet
     brand: Pentagram
@@ -6516,7 +6516,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Philips
@@ -6534,7 +6534,7 @@
     name: Chrome
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Philips
@@ -6552,7 +6552,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Pioneer
@@ -6892,7 +6892,7 @@
     name: Chrome
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: tablet
     brand: Polaroid
@@ -6946,7 +6946,7 @@
     name: Chrome Mobile
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Polaroid
@@ -7036,7 +7036,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: tablet
     brand: Polaroid
@@ -7054,7 +7054,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Panacom
@@ -7108,7 +7108,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Prestigio
@@ -7126,7 +7126,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Prestigio
@@ -7144,7 +7144,7 @@
     name: Yandex Browser
     version: "7.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: Prestigio
@@ -7162,7 +7162,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Prestigio
@@ -7180,7 +7180,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Prestigio
@@ -7198,7 +7198,7 @@
     name: Opera
     version: "55.0.2719.50560"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Prestigio
@@ -7342,7 +7342,7 @@
     name: Chrome
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: Prestigio
@@ -7504,7 +7504,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Prestigio
@@ -7540,7 +7540,7 @@
     name: Chrome Mobile
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: Prestigio
@@ -7558,7 +7558,7 @@
     name: Chrome Mobile
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Prestigio
@@ -7576,7 +7576,7 @@
     name: Chrome Mobile
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: tablet
     brand: Prestigio
@@ -7646,7 +7646,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Point of View
@@ -7808,7 +7808,7 @@
     name: Chrome Webview
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Pixus
@@ -7844,7 +7844,7 @@
     name: Chrome
     version: "63.0.3239.71"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.71"
   device:
     type: tablet
     brand: Pixus
@@ -7862,7 +7862,7 @@
     name: Chrome
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: tablet
     brand: Pixus
@@ -7898,7 +7898,7 @@
     name: Chrome Webview
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: Pixus
@@ -7916,7 +7916,7 @@
     name: Opera
     version: "49.2.2361.134358"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Pixus
@@ -7934,7 +7934,7 @@
     name: Chrome
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: Pixus
@@ -7970,7 +7970,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: Ployer
@@ -8006,7 +8006,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Ployer
@@ -8024,7 +8024,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Ployer
@@ -8042,7 +8042,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Qilive
@@ -8060,7 +8060,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Qilive
@@ -8078,7 +8078,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Qilive
@@ -8096,7 +8096,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Qilive
@@ -8114,7 +8114,7 @@
     name: Chrome
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Qilive
@@ -8132,7 +8132,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Qilive
@@ -8204,7 +8204,7 @@
     name: Chrome
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Qumo
@@ -8222,7 +8222,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Qumo
@@ -8258,7 +8258,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Qumo
@@ -8276,7 +8276,7 @@
     name: Chrome
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: Qumo
@@ -8312,7 +8312,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Qumo
@@ -8330,7 +8330,7 @@
     name: Chrome
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Qumo
@@ -8366,7 +8366,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Qumo
@@ -8384,7 +8384,7 @@
     name: Chrome
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: SQOOL
@@ -8402,7 +8402,7 @@
     name: Chrome
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: SQOOL
@@ -8420,7 +8420,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Casper
@@ -8438,7 +8438,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Casper
@@ -8456,7 +8456,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Casper
@@ -8474,7 +8474,7 @@
     name: Chrome
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Casper
@@ -8492,7 +8492,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Casper
@@ -8510,7 +8510,7 @@
     name: Chrome
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: tablet
     brand: Casper
@@ -8528,7 +8528,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Casper
@@ -8546,7 +8546,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Casper
@@ -8564,7 +8564,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Casper
@@ -8582,7 +8582,7 @@
     name: Chrome
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: tablet
     brand: Casper
@@ -8600,7 +8600,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Casper
@@ -8618,7 +8618,7 @@
     name: Chrome
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Casper
@@ -8636,7 +8636,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Casper
@@ -8690,7 +8690,7 @@
     name: Yandex Browser
     version: "19.9.6.88.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: RoverPad
@@ -8708,7 +8708,7 @@
     name: Chrome
     version: "35.0.1916.122"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.122"
   device:
     type: tablet
     brand: RoverPad
@@ -8798,7 +8798,7 @@
     name: Opera
     version: "50.3.2426.136976"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: RoverPad
@@ -8834,7 +8834,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: RoverPad
@@ -8852,7 +8852,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: RoverPad
@@ -9008,7 +9008,7 @@
     name: Chrome Mobile
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Tecno Mobile
@@ -9026,7 +9026,7 @@
     name: Chrome
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: tablet
     brand: Vonino
@@ -9044,7 +9044,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: Kocaso
@@ -9062,7 +9062,7 @@
     name: Chrome Webview
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Topelotek
@@ -9093,7 +9093,7 @@
     name: Chrome Webview
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: tablet
     brand: Alcatel
@@ -9111,7 +9111,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Alcatel
@@ -9129,7 +9129,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Alcatel
@@ -9147,7 +9147,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Alcatel
@@ -9165,7 +9165,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: TCL
@@ -9183,7 +9183,7 @@
     name: Chrome
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: Gateway
@@ -9201,7 +9201,7 @@
     name: Opera
     version: 58.4.2878.56737
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Verizon
@@ -9219,7 +9219,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Ghost
@@ -9237,7 +9237,7 @@
     name: Microsoft Edge
     version: 96.0.1054.41
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.55"
   device:
     type: tablet
     brand: Microsoft
@@ -9255,7 +9255,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Microsoft
@@ -9273,7 +9273,7 @@
     name: Aloha Browser
     version: 3.10.2
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: tablet
     brand: RCA Tablets
@@ -9291,7 +9291,7 @@
     name: Chrome
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: tablet
     brand: ONN
@@ -9309,7 +9309,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: SPC
@@ -9327,7 +9327,7 @@
     name: Opera Mobile
     version: 64.2.3282.60128
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: tablet
     brand: X-TIGI
@@ -9345,7 +9345,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Vastking
@@ -9363,7 +9363,7 @@
     name: Opera
     version: 60.0.2254.59405
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: X-TIGI
@@ -9381,7 +9381,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Venturer
@@ -9399,7 +9399,7 @@
     name: Chrome
     version: 43.0.2357.93
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: tablet
     brand: Selecline
@@ -9417,7 +9417,7 @@
     name: Opera
     version: 46.1.2254.55193
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Haier
@@ -9451,7 +9451,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Turkcell
@@ -9469,7 +9469,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: tablet
     brand: Majestic
@@ -9487,7 +9487,7 @@
     name: Chrome
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: NOGA
@@ -9505,7 +9505,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Allview
@@ -9775,7 +9775,7 @@
     name: Opera
     version: 51.3.2461.138727
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: tablet
     brand: PocketBook
@@ -9793,7 +9793,7 @@
     name: Chrome
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: PocketBook

--- a/Tests/fixtures/tablet-4.yml
+++ b/Tests/fixtures/tablet-4.yml
@@ -60,7 +60,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: RCA Tablets
@@ -78,7 +78,7 @@
     name: Chrome
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: tablet
     brand: RCA Tablets
@@ -168,7 +168,7 @@
     name: Opera
     version: "50.3.2426.136976"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Ritmix
@@ -186,7 +186,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Ritmix
@@ -204,7 +204,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Ritmix
@@ -258,7 +258,7 @@
     name: Chrome
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tablet
     brand: Ritmix
@@ -294,7 +294,7 @@
     name: Chrome Mobile
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Ritmix
@@ -330,7 +330,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Ritmix
@@ -420,7 +420,7 @@
     name: Opera Mobile
     version: "16.0.1212.65583"
     engine: Blink
-    engine_version: ""
+    engine_version: "29.0.1547.72"
   device:
     type: tablet
     brand: Sencor
@@ -546,7 +546,7 @@
     name: Yandex Browser
     version: "14.5.1847.18432.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.131"
   device:
     type: tablet
     brand: Supra
@@ -582,7 +582,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Supra
@@ -618,7 +618,7 @@
     name: Opera
     version: "53.1.2569.142848"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Supra
@@ -672,7 +672,7 @@
     name: Chrome
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: tablet
     brand: Samsung
@@ -690,7 +690,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Samsung
@@ -708,7 +708,7 @@
     name: Chrome
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: tablet
     brand: Samsung
@@ -744,7 +744,7 @@
     name: Chrome
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: tablet
     brand: Samsung
@@ -904,7 +904,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Samsung
@@ -922,7 +922,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Samsung
@@ -940,7 +940,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Samsung
@@ -1246,7 +1246,7 @@
     name: Chrome
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: tablet
     brand: Samsung
@@ -1390,7 +1390,7 @@
     name: Chrome
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: Samsung
@@ -1498,7 +1498,7 @@
     name: Opera
     version: "20.0.1396.73172"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: tablet
     brand: Samsung
@@ -1606,7 +1606,7 @@
     name: Chrome
     version: "33.0.1750.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.132"
   device:
     type: tablet
     brand: Samsung
@@ -1660,7 +1660,7 @@
     name: Chrome
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: tablet
     brand: Samsung
@@ -1768,7 +1768,7 @@
     name: Chrome
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: tablet
     brand: Samsung
@@ -1786,7 +1786,7 @@
     name: Chrome
     version: "30.0.1599.82"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.82"
   device:
     type: tablet
     brand: Samsung
@@ -1822,7 +1822,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Samsung
@@ -1946,7 +1946,7 @@
     name: Chrome
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: tablet
     brand: Samsung
@@ -1964,7 +1964,7 @@
     name: Chrome
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: tablet
     brand: Samsung
@@ -1982,7 +1982,7 @@
     name: Chrome
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: tablet
     brand: Samsung
@@ -2000,7 +2000,7 @@
     name: Chrome
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: tablet
     brand: Samsung
@@ -2018,7 +2018,7 @@
     name: Chrome
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: tablet
     brand: Samsung
@@ -2036,7 +2036,7 @@
     name: Chrome
     version: "68.0.3440.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.85"
   device:
     type: tablet
     brand: Samsung
@@ -2054,7 +2054,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Samsung
@@ -2090,7 +2090,7 @@
     name: Chrome
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: tablet
     brand: Samsung
@@ -2108,7 +2108,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Samsung
@@ -2126,7 +2126,7 @@
     name: Chrome
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Samsung
@@ -2144,7 +2144,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Samsung
@@ -2162,7 +2162,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Samsung
@@ -2180,7 +2180,7 @@
     name: Chrome
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: tablet
     brand: Samsung
@@ -2198,7 +2198,7 @@
     name: Chrome
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Samsung
@@ -2252,7 +2252,7 @@
     name: Chrome Mobile
     version: "38.0.2125.102"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: tablet
     brand: Samsung
@@ -2270,7 +2270,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Samsung
@@ -2288,7 +2288,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Samsung
@@ -2306,7 +2306,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Samsung
@@ -2342,7 +2342,7 @@
     name: Chrome
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Samsung
@@ -2360,7 +2360,7 @@
     name: Chrome
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Samsung
@@ -2396,7 +2396,7 @@
     name: Chrome
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Samsung
@@ -2504,7 +2504,7 @@
     name: Chrome
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: Samsung
@@ -2540,7 +2540,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Samsung
@@ -2558,7 +2558,7 @@
     name: Chrome
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: Samsung
@@ -2576,7 +2576,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Samsung
@@ -2594,7 +2594,7 @@
     name: Chrome
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: Samsung
@@ -2648,7 +2648,7 @@
     name: Chrome
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Samsung
@@ -2666,7 +2666,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Samsung
@@ -2684,7 +2684,7 @@
     name: Chrome
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Samsung
@@ -2702,7 +2702,7 @@
     name: Chrome
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: tablet
     brand: Samsung
@@ -2720,7 +2720,7 @@
     name: Chrome
     version: "68.0.3440.70"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.70"
   device:
     type: tablet
     brand: Samsung
@@ -2738,7 +2738,7 @@
     name: Chrome
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Samsung
@@ -2756,7 +2756,7 @@
     name: Chrome
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Samsung
@@ -2774,7 +2774,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Samsung
@@ -2792,7 +2792,7 @@
     name: Chrome
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: tablet
     brand: Samsung
@@ -2828,7 +2828,7 @@
     name: Chrome
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Samsung
@@ -2918,7 +2918,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Samsung
@@ -2936,7 +2936,7 @@
     name: Chrome
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Samsung
@@ -2972,7 +2972,7 @@
     name: Chrome
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: Samsung
@@ -2990,7 +2990,7 @@
     name: Chrome
     version: "49.0.2623.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: tablet
     brand: Samsung
@@ -3008,7 +3008,7 @@
     name: Chrome
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Samsung
@@ -3026,7 +3026,7 @@
     name: Chrome
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: Samsung
@@ -3044,7 +3044,7 @@
     name: Chrome
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: tablet
     brand: Samsung
@@ -3080,7 +3080,7 @@
     name: Chrome
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: tablet
     brand: Samsung
@@ -3098,7 +3098,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Samsung
@@ -3116,7 +3116,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Samsung
@@ -3134,7 +3134,7 @@
     name: Chrome
     version: "81.0.4044.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Samsung
@@ -3152,7 +3152,7 @@
     name: Chrome
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: tablet
     brand: Samsung
@@ -3170,7 +3170,7 @@
     name: Chrome
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: tablet
     brand: Samsung
@@ -3188,7 +3188,7 @@
     name: Chrome
     version: "71.0.3578.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: tablet
     brand: Samsung
@@ -3206,7 +3206,7 @@
     name: Chrome
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Samsung
@@ -3224,7 +3224,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Samsung
@@ -3260,7 +3260,7 @@
     name: Chrome
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Samsung
@@ -3278,7 +3278,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Samsung
@@ -3296,7 +3296,7 @@
     name: Chrome
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: tablet
     brand: Samsung
@@ -3314,7 +3314,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Samsung
@@ -3332,7 +3332,7 @@
     name: Chrome
     version: "81.0.4044.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: Samsung
@@ -3350,7 +3350,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Samsung
@@ -3368,7 +3368,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Samsung
@@ -3386,7 +3386,7 @@
     name: Chrome
     version: "80.0.3987.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: Samsung
@@ -3420,7 +3420,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Samsung
@@ -3438,7 +3438,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Samsung
@@ -3456,7 +3456,7 @@
     name: Chrome
     version: "81.0.4044.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: Samsung
@@ -3474,7 +3474,7 @@
     name: Opera
     version: "43.2.2254.140293"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Samsung
@@ -3564,7 +3564,7 @@
     name: Chrome
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Samsung
@@ -3618,7 +3618,7 @@
     name: Chrome
     version: "53.0.2785.124"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: tablet
     brand: Samsung
@@ -3636,7 +3636,7 @@
     name: Chrome
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Samsung
@@ -3654,7 +3654,7 @@
     name: Chrome
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Samsung
@@ -3672,7 +3672,7 @@
     name: Chrome
     version: "81.0.4044.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: tablet
     brand: Samsung
@@ -3690,7 +3690,7 @@
     name: Opera
     version: "37.1.2254.132401"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Samsung
@@ -3708,7 +3708,7 @@
     name: Opera
     version: "43.1.2254.140112"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: tablet
     brand: Samsung
@@ -3834,7 +3834,7 @@
     name: Chrome
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: Samsung
@@ -3852,7 +3852,7 @@
     name: Chrome
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Samsung
@@ -3870,7 +3870,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Samsung
@@ -3888,7 +3888,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Samsung
@@ -3906,7 +3906,7 @@
     name: Opera
     version: "43.1.2254.140112"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Samsung
@@ -3978,7 +3978,7 @@
     name: Chrome Webview
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Samsung
@@ -4014,7 +4014,7 @@
     name: Chrome
     version: "74.0.3729.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: Samsung
@@ -4032,7 +4032,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Samsung
@@ -4050,7 +4050,7 @@
     name: Chrome
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Samsung
@@ -4068,7 +4068,7 @@
     name: Chrome
     version: "83.0.4103.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: tablet
     brand: Samsung
@@ -4086,7 +4086,7 @@
     name: Opera
     version: "43.2.2254.140293"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Samsung
@@ -4104,7 +4104,7 @@
     name: Chrome
     version: "83.0.4103.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: tablet
     brand: Samsung
@@ -4122,7 +4122,7 @@
     name: Chrome
     version: "83.0.4103.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: tablet
     brand: Samsung
@@ -4140,7 +4140,7 @@
     name: Chrome
     version: "83.0.4103.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: tablet
     brand: Samsung
@@ -4194,7 +4194,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Samsung
@@ -4212,7 +4212,7 @@
     name: Chrome
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Samsung
@@ -4248,7 +4248,7 @@
     name: Chrome
     version: "35.0.1916.141"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.141"
   device:
     type: tablet
     brand: Samsung
@@ -4266,7 +4266,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Samsung
@@ -4284,7 +4284,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Samsung
@@ -4302,7 +4302,7 @@
     name: Chrome Webview
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Samsung
@@ -4320,7 +4320,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Samsung
@@ -4338,7 +4338,7 @@
     name: Chrome
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: tablet
     brand: Samsung
@@ -4356,7 +4356,7 @@
     name: Chrome
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Samsung
@@ -4374,7 +4374,7 @@
     name: Chrome
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Samsung
@@ -4392,7 +4392,7 @@
     name: Chrome
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Samsung
@@ -4680,7 +4680,7 @@
     name: Chrome
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: tablet
     brand: Sony
@@ -4752,7 +4752,7 @@
     name: Chrome
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: Sony
@@ -4806,7 +4806,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Sony
@@ -4878,7 +4878,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Sony
@@ -4896,7 +4896,7 @@
     name: Opera
     version: "19.0.1340.69721"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.72"
   device:
     type: tablet
     brand: Sony
@@ -4914,7 +4914,7 @@
     name: Chrome
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: tablet
     brand: Sony
@@ -4932,7 +4932,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Sony
@@ -4950,7 +4950,7 @@
     name: Chrome
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: tablet
     brand: Sony
@@ -4968,7 +4968,7 @@
     name: Chrome
     version: "37.0.2062.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.117"
   device:
     type: tablet
     brand: Sony
@@ -4986,7 +4986,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Sony
@@ -5004,7 +5004,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Sony
@@ -5022,7 +5022,7 @@
     name: Chrome
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Sony
@@ -5040,7 +5040,7 @@
     name: Chrome
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Sony
@@ -5058,7 +5058,7 @@
     name: Chrome
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Sony
@@ -5076,7 +5076,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Sony
@@ -5094,7 +5094,7 @@
     name: Chrome
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: Sony
@@ -5112,7 +5112,7 @@
     name: Opera
     version: "21.0.1437.74904"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.116"
   device:
     type: tablet
     brand: Storex
@@ -5164,7 +5164,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Storex
@@ -5182,7 +5182,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Storex
@@ -5322,7 +5322,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Storex
@@ -5358,7 +5358,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Storex
@@ -5376,7 +5376,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Storex
@@ -5394,7 +5394,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Storex
@@ -5464,7 +5464,7 @@
     name: Chrome
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: tablet
     brand: Storex
@@ -5482,7 +5482,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Storex
@@ -5570,7 +5570,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Storex
@@ -5732,7 +5732,7 @@
     name: Chrome
     version: "30.0.1599.82"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.82"
   device:
     type: tablet
     brand: Sumvision
@@ -5750,7 +5750,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Tolino
@@ -5768,7 +5768,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Tolino
@@ -5822,7 +5822,7 @@
     name: Chrome
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: tablet
     brand: Trevi
@@ -5840,7 +5840,7 @@
     name: Chrome
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: tablet
     brand: Trevi
@@ -5876,7 +5876,7 @@
     name: Opera
     version: "18.0.1290.67495"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.57"
   device:
     type: tablet
     brand: TB Touch
@@ -5894,7 +5894,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: TrekStor
@@ -5966,7 +5966,7 @@
     name: Chrome
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: TrekStor
@@ -5984,7 +5984,7 @@
     name: Chrome
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: TrekStor
@@ -6002,7 +6002,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: tablet
     brand: TrekStor
@@ -6020,7 +6020,7 @@
     name: Chrome
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: tablet
     brand: TrekStor
@@ -6056,7 +6056,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: TrekStor
@@ -6074,7 +6074,7 @@
     name: Chrome
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: tablet
     brand: TrekStor
@@ -6092,7 +6092,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: TrekStor
@@ -6146,7 +6146,7 @@
     name: Chrome
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: tablet
     brand: TrekStor
@@ -6164,7 +6164,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Teclast
@@ -6182,7 +6182,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Teclast
@@ -6200,7 +6200,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Teclast
@@ -6218,7 +6218,7 @@
     name: Chrome
     version: "80.0.3987.119"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: tablet
     brand: Teclast
@@ -6236,7 +6236,7 @@
     name: Chrome
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: Teclast
@@ -6254,7 +6254,7 @@
     name: Chrome
     version: "81.0.4044.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: tablet
     brand: Teclast
@@ -6272,7 +6272,7 @@
     name: Opera
     version: "43"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Teclast
@@ -6290,7 +6290,7 @@
     name: Chrome
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Teclast
@@ -6308,7 +6308,7 @@
     name: Chrome
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Teclast
@@ -6326,7 +6326,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Teclast
@@ -6344,7 +6344,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Teclast
@@ -6362,7 +6362,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Teclast
@@ -6380,7 +6380,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Teclast
@@ -6452,7 +6452,7 @@
     name: Chrome
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tablet
     brand: Touchmate
@@ -6488,7 +6488,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Touchmate
@@ -6524,7 +6524,7 @@
     name: Chrome
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: Touchmate
@@ -6542,7 +6542,7 @@
     name: Chrome Mobile
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: Top House
@@ -6560,7 +6560,7 @@
     name: Chrome
     version: "47.0.2526.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: tablet
     brand: Top House
@@ -6578,7 +6578,7 @@
     name: Chrome
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Tecno Mobile
@@ -6596,7 +6596,7 @@
     name: Opera
     version: "28.0.2254.119213"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: Tecno Mobile
@@ -6632,7 +6632,7 @@
     name: Chrome
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Tecno Mobile
@@ -6650,7 +6650,7 @@
     name: Chrome Webview
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tablet
     brand: Tecno Mobile
@@ -6668,7 +6668,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Tesco
@@ -6686,7 +6686,7 @@
     name: Chrome
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: tablet
     brand: Tesco
@@ -6704,7 +6704,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Tesco
@@ -6722,7 +6722,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Takara
@@ -6740,7 +6740,7 @@
     name: Chrome
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: tablet
     brand: Telefunken
@@ -6758,7 +6758,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Telefunken
@@ -6794,7 +6794,7 @@
     name: Chrome
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: tablet
     brand: Telefunken
@@ -6830,7 +6830,7 @@
     name: Chrome
     version: "28.0.1500.64"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.64"
   device:
     type: tablet
     brand: Telefunken
@@ -6918,7 +6918,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Thomson
@@ -6936,7 +6936,7 @@
     name: Chrome Webview
     version: "60.0.3112.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: tablet
     brand: TechPad
@@ -6988,7 +6988,7 @@
     name: Chrome Mobile
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: tablet
     brand: TechPad
@@ -7024,7 +7024,7 @@
     name: Opera
     version: "24.0.1565.82529"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.117"
   device:
     type: tablet
     brand: TechPad
@@ -7060,7 +7060,7 @@
     name: Chrome
     version: "48.0.2564.95"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.95"
   device:
     type: tablet
     brand: TechPad
@@ -7078,7 +7078,7 @@
     name: Chrome
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Turbo-X
@@ -7150,7 +7150,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Toshiba
@@ -7168,7 +7168,7 @@
     name: Chrome
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: tablet
     brand: Toshiba
@@ -7186,7 +7186,7 @@
     name: Chrome
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Toshiba
@@ -7204,7 +7204,7 @@
     name: Chrome
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Toshiba
@@ -7276,7 +7276,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Toshiba
@@ -7294,7 +7294,7 @@
     name: Chrome
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: tablet
     brand: Toshiba
@@ -7348,7 +7348,7 @@
     name: Chrome
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: tablet
     brand: Toshiba
@@ -7438,7 +7438,7 @@
     name: Chrome
     version: "30.0.1599.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.92"
   device:
     type: tablet
     brand: Toshiba
@@ -7474,7 +7474,7 @@
     name: Chrome
     version: "40.0.2214.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.89"
   device:
     type: tablet
     brand: Toshiba
@@ -7525,7 +7525,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: teXet
@@ -7561,7 +7561,7 @@
     name: Chrome
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: tablet
     brand: teXet
@@ -7597,7 +7597,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: teXet
@@ -7633,7 +7633,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: teXet
@@ -7669,7 +7669,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: teXet
@@ -7687,7 +7687,7 @@
     name: Chrome
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: teXet
@@ -7741,7 +7741,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: teXet
@@ -7777,7 +7777,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: teXet
@@ -7795,7 +7795,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: teXet
@@ -7865,7 +7865,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: teXet
@@ -7883,7 +7883,7 @@
     name: Chrome
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: teXet
@@ -7937,7 +7937,7 @@
     name: Chrome Webview
     version: "48.0.2564.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.106"
   device:
     type: tablet
     brand: teXet
@@ -7955,7 +7955,7 @@
     name: Chrome
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: teXet
@@ -8009,7 +8009,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: teXet
@@ -8063,7 +8063,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: teXet
@@ -8081,7 +8081,7 @@
     name: Opera
     version: "50.3.2426.136976"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: teXet
@@ -8117,7 +8117,7 @@
     name: Chrome
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: tablet
     brand: teXet
@@ -8171,7 +8171,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: teXet
@@ -8207,7 +8207,7 @@
     name: Chrome
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: tablet
     brand: teXet
@@ -8225,7 +8225,7 @@
     name: Chrome
     version: "69.0.3497.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: tablet
     brand: teXet
@@ -8261,7 +8261,7 @@
     name: Chrome
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: teXet
@@ -8279,7 +8279,7 @@
     name: Chrome
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: teXet
@@ -8297,7 +8297,7 @@
     name: Opera
     version: "54.1.2672.49808"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: teXet
@@ -8315,7 +8315,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: teXet
@@ -8333,7 +8333,7 @@
     name: Chrome
     version: "73.0.3683.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: teXet
@@ -8351,7 +8351,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: teXet
@@ -8369,7 +8369,7 @@
     name: Chrome
     version: "66.0.3359.126"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: tablet
     brand: teXet
@@ -8387,7 +8387,7 @@
     name: Chrome
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: teXet
@@ -8405,7 +8405,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: teXet
@@ -8423,7 +8423,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: teXet
@@ -8441,7 +8441,7 @@
     name: Opera
     version: "30.0.1856.93524"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.78"
   device:
     type: tablet
     brand: teXet
@@ -8459,7 +8459,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: teXet
@@ -8477,7 +8477,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: teXet
@@ -8495,7 +8495,7 @@
     name: Chrome
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: teXet
@@ -8513,7 +8513,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: teXet
@@ -8531,7 +8531,7 @@
     name: Chrome
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: teXet
@@ -8549,7 +8549,7 @@
     name: Chrome
     version: "68.0.3440.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: teXet
@@ -8567,7 +8567,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: teXet
@@ -8585,7 +8585,7 @@
     name: Chrome
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tablet
     brand: teXet
@@ -8603,7 +8603,7 @@
     name: Opera
     version: "47.3.2249.130976"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tablet
     brand: teXet
@@ -8621,7 +8621,7 @@
     name: Chrome
     version: "69.0.3497.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: tablet
     brand: teXet
@@ -8639,7 +8639,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: teXet
@@ -8657,7 +8657,7 @@
     name: Opera
     version: "56.0.2780.51441"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: teXet
@@ -8675,7 +8675,7 @@
     name: Chrome
     version: "62.0.3202.84"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: tablet
     brand: Umax
@@ -8693,7 +8693,7 @@
     name: Chrome
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Umax
@@ -8711,7 +8711,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Umax
@@ -8729,7 +8729,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Umax
@@ -8747,7 +8747,7 @@
     name: Chrome
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Umax
@@ -8765,7 +8765,7 @@
     name: Chrome Webview
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Umax
@@ -8783,7 +8783,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Umax
@@ -8801,7 +8801,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Umax
@@ -8819,7 +8819,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Umax
@@ -8837,7 +8837,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Umax
@@ -8855,7 +8855,7 @@
     name: Chrome Webview
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Umax
@@ -8873,7 +8873,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Unowhy
@@ -8891,7 +8891,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Vonino
@@ -8909,7 +8909,7 @@
     name: Chrome Webview
     version: "43.0.2357.121"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: tablet
     brand: Vonino
@@ -8927,7 +8927,7 @@
     name: Chrome
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: tablet
     brand: Vonino
@@ -8945,7 +8945,7 @@
     name: Chrome
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: tablet
     brand: Vonino
@@ -8963,7 +8963,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Vonino
@@ -8981,7 +8981,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Brondi
@@ -8999,7 +8999,7 @@
     name: Chrome
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Alba
@@ -9017,7 +9017,7 @@
     name: Chrome
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: EXO
@@ -9035,7 +9035,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Wink
@@ -9053,7 +9053,7 @@
     name: Chrome
     version: 75.0.3770.67
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: tablet
     brand: Wink

--- a/Tests/fixtures/tablet-5.yml
+++ b/Tests/fixtures/tablet-5.yml
@@ -28,7 +28,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Vonino
@@ -46,7 +46,7 @@
     name: Chrome
     version: 53.0.2785.124
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: tablet
     brand: Vonino
@@ -64,7 +64,7 @@
     name: Chrome
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: Vonino
@@ -100,7 +100,7 @@
     name: Chrome
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: Vonino
@@ -118,7 +118,7 @@
     name: Chrome
     version: 43.0.2357.93
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: tablet
     brand: Vonino
@@ -136,7 +136,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Verizon
@@ -154,7 +154,7 @@
     name: Chrome Webview
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: Verizon
@@ -172,7 +172,7 @@
     name: Chrome
     version: 39.0.2171.93
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: tablet
     brand: Verizon
@@ -190,7 +190,7 @@
     name: Chrome
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: Verizon
@@ -208,7 +208,7 @@
     name: Chrome
     version: 64.0.3282.123
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: tablet
     brand: Verizon
@@ -226,7 +226,7 @@
     name: Chrome
     version: 74.0.3729.112
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: tablet
     brand: Verizon
@@ -244,7 +244,7 @@
     name: Chrome
     version: 53.0.2785.124
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: tablet
     brand: Verizon
@@ -280,7 +280,7 @@
     name: Chrome
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: Vastking
@@ -388,7 +388,7 @@
     name: Opera
     version: 29.0.1809.92697
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.107"
   device:
     type: tablet
     brand: Vodafone
@@ -424,7 +424,7 @@
     name: Chrome
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Vodafone
@@ -442,7 +442,7 @@
     name: Chrome
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Vodafone
@@ -460,7 +460,7 @@
     name: Chrome Webview
     version: 33.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: Vodafone
@@ -478,7 +478,7 @@
     name: Opera
     version: 28.0.1764.89981
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.74"
   device:
     type: tablet
     brand: Vodafone
@@ -532,7 +532,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Vodafone
@@ -604,7 +604,7 @@
     name: Chrome Webview
     version: 59.0.3071.125
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Vodafone
@@ -622,7 +622,7 @@
     name: Chrome
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: Vodafone
@@ -640,7 +640,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Vodafone
@@ -658,7 +658,7 @@
     name: Chrome
     version: 57.0.2987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: tablet
     brand: Vodafone
@@ -676,7 +676,7 @@
     name: Chrome
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: Vodafone
@@ -694,7 +694,7 @@
     name: Chrome
     version: 51.0.2704.81
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: tablet
     brand: Vodacom
@@ -784,7 +784,7 @@
     name: Chrome
     version: 48.0.2564.95
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.95"
   device:
     type: tablet
     brand: Vestel
@@ -802,7 +802,7 @@
     name: Chrome Mobile
     version: 60.0.3112.116
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: tablet
     brand: Vestel
@@ -820,7 +820,7 @@
     name: Chrome
     version: 54.0.2840.85
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: tablet
     brand: Vestel
@@ -838,7 +838,7 @@
     name: Chrome
     version: 50.0.2661.89
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: tablet
     brand: Vestel
@@ -856,7 +856,7 @@
     name: Chrome
     version: 44.0.2403.133
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.133"
   device:
     type: tablet
     brand: Vestel
@@ -892,7 +892,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Voyo
@@ -964,7 +964,7 @@
     name: Chrome
     version: 35.0.1916.122
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.122"
   device:
     type: tablet
     brand: Walton
@@ -982,7 +982,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tablet
     brand: Wolder
@@ -1090,7 +1090,7 @@
     name: Chrome
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Wolder
@@ -1108,7 +1108,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tablet
     brand: Wortmann
@@ -1126,7 +1126,7 @@
     name: Chrome
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: Woxter
@@ -1180,7 +1180,7 @@
     name: Opera Mobile
     version: 16.0.1212.65583
     engine: Blink
-    engine_version: ""
+    engine_version: "29.0.1547.72"
   device:
     type: tablet
     brand: Woxter
@@ -1270,7 +1270,7 @@
     name: Yandex Browser
     version: 14.12.2125.9740.01
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.122"
   device:
     type: tablet
     brand: Wexler
@@ -1324,7 +1324,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Wexler
@@ -1360,7 +1360,7 @@
     name: Chrome
     version: 53.0.2785.124
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: tablet
     brand: Xiaomi
@@ -1378,7 +1378,7 @@
     name: Chrome
     version: 59.0.3071.125
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Xiaomi
@@ -1396,7 +1396,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Xiaomi
@@ -1414,7 +1414,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Xoro
@@ -1432,7 +1432,7 @@
     name: Chrome Webview
     version: 33.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: Xoro
@@ -1450,7 +1450,7 @@
     name: Chrome Webview
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Xoro
@@ -1486,7 +1486,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Xoro
@@ -1504,7 +1504,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: X-TIGI
@@ -1522,7 +1522,7 @@
     name: Chrome Webview
     version: 61.0.3163.81
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.81"
   device:
     type: tablet
     brand: X-TIGI
@@ -1540,7 +1540,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tablet
     brand: X-TIGI
@@ -1702,7 +1702,7 @@
     name: Chrome
     version: 32.0.1700.99
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: tablet
     brand: Yarvik
@@ -1918,7 +1918,7 @@
     name: Chrome Webview
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: Zfiner
@@ -2080,7 +2080,7 @@
     name: Chrome Mobile
     version: 38.0.2125.114
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.114"
   device:
     type: tablet
     brand: Zync
@@ -2098,7 +2098,7 @@
     name: Chrome
     version: 40.0.2214.109
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: tablet
     brand: Zync
@@ -2260,7 +2260,7 @@
     name: Chrome
     version: 54.0.2840.85
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: tablet
     brand: Simbans
@@ -2296,7 +2296,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Simbans
@@ -2314,7 +2314,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Simbans
@@ -2332,7 +2332,7 @@
     name: Chrome
     version: 48.0.2564.95
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.95"
   device:
     type: tablet
     brand: Simbans
@@ -2350,7 +2350,7 @@
     name: Chrome
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Simbans
@@ -2368,7 +2368,7 @@
     name: Chrome
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Alcor
@@ -2386,7 +2386,7 @@
     name: Chrome
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Asus
@@ -2404,7 +2404,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Leotec
@@ -2422,7 +2422,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Ditecma
@@ -2440,7 +2440,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Ditecma
@@ -2458,7 +2458,7 @@
     name: Chrome
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: tablet
     brand: Ditecma
@@ -2476,7 +2476,7 @@
     name: Chrome
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: tablet
     brand: Ditecma
@@ -2494,7 +2494,7 @@
     name: Chrome
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tablet
     brand: Ditecma
@@ -2512,7 +2512,7 @@
     name: Chrome
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: Odys
@@ -2530,7 +2530,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Datamini
@@ -2548,7 +2548,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Maxwest
@@ -2566,7 +2566,7 @@
     name: Chrome
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: tablet
     brand: Navon
@@ -2584,7 +2584,7 @@
     name: Chrome
     version: 77.0.3865.73
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: tablet
     brand: IT
@@ -2602,7 +2602,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: IT
@@ -2620,7 +2620,7 @@
     name: Chrome
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: tablet
     brand: IT
@@ -2638,7 +2638,7 @@
     name: Chrome
     version: 57.0.2987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: tablet
     brand: iTel
@@ -2656,7 +2656,7 @@
     name: Chrome
     version: 58.0.3029.83
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: iTel
@@ -2674,7 +2674,7 @@
     name: Chrome
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tablet
     brand: iTel
@@ -2692,7 +2692,7 @@
     name: Chrome
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: tablet
     brand: Jeka
@@ -2710,7 +2710,7 @@
     name: Chrome
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: Jeka
@@ -2728,7 +2728,7 @@
     name: Chrome
     version: 50.0.2661.89
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: tablet
     brand: Kzen
@@ -2746,7 +2746,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: Maximus
@@ -2764,7 +2764,7 @@
     name: Chrome
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: Navitel
@@ -2782,7 +2782,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Navitel
@@ -2800,7 +2800,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Navitel
@@ -2818,7 +2818,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Navitel
@@ -2836,7 +2836,7 @@
     name: Chrome
     version: 72.0.3626.96
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: tablet
     brand: Navitel
@@ -2854,7 +2854,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Navitel
@@ -2872,7 +2872,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Navitel
@@ -2890,7 +2890,7 @@
     name: Chrome
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: Navitel
@@ -2908,7 +2908,7 @@
     name: Chrome
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Navitel
@@ -2926,7 +2926,7 @@
     name: Chrome
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tablet
     brand: Leagoo
@@ -2944,7 +2944,7 @@
     name: Chrome
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: Smartab
@@ -2962,7 +2962,7 @@
     name: Chrome
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: TrekStor
@@ -2980,7 +2980,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: SuperTab
@@ -2998,7 +2998,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: SuperTab
@@ -3016,7 +3016,7 @@
     name: Chrome
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: SuperTab
@@ -3034,7 +3034,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Suzuki
@@ -3052,7 +3052,7 @@
     name: Chrome
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Suzuki
@@ -3070,7 +3070,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: Suzuki
@@ -3088,7 +3088,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Ghia
@@ -3106,7 +3106,7 @@
     name: Chrome Mobile
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Lark
@@ -3124,7 +3124,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: FaRao Pro
@@ -3142,7 +3142,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Nabi
@@ -3160,7 +3160,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: Nabi
@@ -3178,7 +3178,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Nabi
@@ -3196,7 +3196,7 @@
     name: Chrome
     version: 47.0.2526.83
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: tablet
     brand: Nabi
@@ -3214,7 +3214,7 @@
     name: Chrome
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: tablet
     brand: Nabi
@@ -3232,7 +3232,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Nabi
@@ -3250,7 +3250,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: Nabi
@@ -3286,7 +3286,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: SPC
@@ -3304,7 +3304,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Digiland
@@ -3340,7 +3340,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Digiland
@@ -3358,7 +3358,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Digiland
@@ -3394,7 +3394,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: PiPO
@@ -3412,7 +3412,7 @@
     name: Chrome
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: PiPO
@@ -3574,7 +3574,7 @@
     name: Chrome
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: ProScan
@@ -3592,7 +3592,7 @@
     name: Chrome
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: ProScan
@@ -3610,7 +3610,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: ProScan
@@ -3628,7 +3628,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Philco
@@ -3646,7 +3646,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: iBall
@@ -3664,7 +3664,7 @@
     name: Chrome
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: tablet
     brand: Qilive
@@ -3754,7 +3754,7 @@
     name: Chrome
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: MSI
@@ -3772,7 +3772,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: MSI
@@ -3790,7 +3790,7 @@
     name: Chrome
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tablet
     brand: MSI
@@ -3808,7 +3808,7 @@
     name: Chrome
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: Casper
@@ -3826,7 +3826,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Casper
@@ -3844,7 +3844,7 @@
     name: Yandex Browser
     version: 21.22.1
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: tablet
     brand: Huawei
@@ -3862,7 +3862,7 @@
     name: Chrome
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: tablet
     brand: General Mobile
@@ -3880,7 +3880,7 @@
     name: Yandex Browser
     version: 21.22.0
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: tablet
     brand: Huawei
@@ -3898,7 +3898,7 @@
     name: Yandex Browser
     version: 20.125.1
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: tablet
     brand: Teclast
@@ -3916,7 +3916,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Digma
@@ -3934,7 +3934,7 @@
     name: Chrome
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: tablet
     brand: Irbis
@@ -3952,7 +3952,7 @@
     name: Chrome
     version: 89.0.4389.86
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.86"
   device:
     type: tablet
     brand: Hyundai
@@ -3970,7 +3970,7 @@
     name: Chrome
     version: 89.0.4389.90
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.90"
   device:
     type: tablet
     brand: Huawei
@@ -3988,7 +3988,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Dell
@@ -4006,7 +4006,7 @@
     name: Chrome
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: tablet
     brand: Ghia
@@ -4024,7 +4024,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: AllDocube
@@ -4078,7 +4078,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Chuwi
@@ -4114,7 +4114,7 @@
     name: Chrome
     version: 89.0.4389.90
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.90"
   device:
     type: tablet
     brand: Digma
@@ -4132,7 +4132,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Digma
@@ -4150,7 +4150,7 @@
     name: Yandex Browser
     version: "7.52"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: bq
@@ -4168,7 +4168,7 @@
     name: Chrome
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: Touchmate
@@ -4186,7 +4186,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: iBall
@@ -4204,7 +4204,7 @@
     name: Chrome Webview
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: tablet
     brand: Touchmate
@@ -4222,7 +4222,7 @@
     name: Chrome
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: Lava
@@ -4240,7 +4240,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: tablet
     brand: ZTE
@@ -4258,7 +4258,7 @@
     name: Chrome
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Samsung
@@ -4276,7 +4276,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Kyowon
@@ -4294,7 +4294,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: LG
@@ -4312,7 +4312,7 @@
     name: Chrome
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: tablet
     brand: Alcatel
@@ -4346,7 +4346,7 @@
     name: Chrome Webview
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: Alcatel
@@ -4364,7 +4364,7 @@
     name: Opera
     version: 24.0.1565.82529
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.117"
   device:
     type: tablet
     brand: Supra
@@ -4382,7 +4382,7 @@
     name: Chrome
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tablet
     brand: iBall
@@ -4400,7 +4400,7 @@
     name: Chrome Webview
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: tablet
     brand: Alcatel
@@ -4418,7 +4418,7 @@
     name: Opera
     version: 62.3.3146.57763
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: tablet
     brand: ONYX BOOX
@@ -4436,7 +4436,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: Medion
@@ -4454,7 +4454,7 @@
     name: Chrome
     version: 88.0.4324.152
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.152"
   device:
     type: tablet
     brand: Medion
@@ -4472,7 +4472,7 @@
     name: Chrome Mobile
     version: 54.0.2840.85
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: tablet
     brand: Advan
@@ -4490,7 +4490,7 @@
     name: Chrome
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: tablet
     brand: Contixo
@@ -4508,7 +4508,7 @@
     name: Chrome
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: tablet
     brand: Digma
@@ -4526,7 +4526,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Alba
@@ -4544,7 +4544,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Alba
@@ -4562,7 +4562,7 @@
     name: Chrome
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: tablet
     brand: Alba
@@ -4580,7 +4580,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Alba
@@ -4598,7 +4598,7 @@
     name: Chrome
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: tablet
     brand: iBall
@@ -4616,7 +4616,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: Condor
@@ -4634,7 +4634,7 @@
     name: Chrome
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tablet
     brand: AURIS
@@ -4652,7 +4652,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: Condor
@@ -4670,7 +4670,7 @@
     name: Yandex Browser
     version: 21.31.1
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.128"
   device:
     type: tablet
     brand: DEXP
@@ -4688,7 +4688,7 @@
     name: Chrome Webview
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: MiXzo
@@ -4706,7 +4706,7 @@
     name: Chrome
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Zaith
@@ -4724,7 +4724,7 @@
     name: Chrome
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: tablet
     brand: Ghia
@@ -4742,7 +4742,7 @@
     name: Chrome
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Vega
@@ -4760,7 +4760,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Bleck
@@ -4778,7 +4778,7 @@
     name: Chrome
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: tablet
     brand: AllDocube
@@ -4796,7 +4796,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: Teclast
@@ -4814,7 +4814,7 @@
     name: Yandex Browser
     version: 20.8.1.71.01
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: tablet
     brand: DEXP
@@ -4832,7 +4832,7 @@
     name: Yandex Browser
     version: 21.2.0.223.01
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: tablet
     brand: DEXP
@@ -4850,7 +4850,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: DEXP
@@ -4868,7 +4868,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: DEXP
@@ -4886,7 +4886,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: DEXP
@@ -4904,7 +4904,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: TurboPad
@@ -4922,7 +4922,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: TurboPad
@@ -4940,7 +4940,7 @@
     name: Yandex Browser
     version: 14.8.1985.12003.01
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.125"
   device:
     type: tablet
     brand: TurboPad
@@ -4958,7 +4958,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: TurboPad
@@ -4976,7 +4976,7 @@
     name: Chrome
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: TurboPad
@@ -4994,7 +4994,7 @@
     name: Chrome
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: TurboPad
@@ -5012,7 +5012,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: TurboKids
@@ -5030,7 +5030,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: TurboPad
@@ -5048,7 +5048,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: TurboPad
@@ -5066,7 +5066,7 @@
     name: Yandex Browser
     version: 19.10.1.100.00
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: TurboPad
@@ -5084,7 +5084,7 @@
     name: Yandex Browser
     version: 19.10.2.116.01
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: tablet
     brand: TurboPad
@@ -5102,7 +5102,7 @@
     name: Chrome Webview
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: E-Boda
@@ -5120,7 +5120,7 @@
     name: Chrome
     version: 74.0.3729.61
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.61"
   device:
     type: tablet
     brand: Navon
@@ -5138,7 +5138,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Ramos
@@ -5156,7 +5156,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Ramos
@@ -5174,7 +5174,7 @@
     name: Chrome
     version: 72.0.3626.73
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.73"
   device:
     type: tablet
     brand: Ramos
@@ -5192,7 +5192,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Quantum
@@ -5210,7 +5210,7 @@
     name: Chrome
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: Quantum
@@ -5228,7 +5228,7 @@
     name: Chrome
     version: 68.0.3440.85
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.85"
   device:
     type: tablet
     brand: Quantum
@@ -5246,7 +5246,7 @@
     name: Chrome
     version: 80.0.3987.117
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: tablet
     brand: RoverPad
@@ -5264,7 +5264,7 @@
     name: Chrome
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: tablet
     brand: RoverPad
@@ -5282,7 +5282,7 @@
     name: Chrome Mobile
     version: 73.0.3683.75
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.75"
   device:
     type: tablet
     brand: Axioo
@@ -5300,7 +5300,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: IconBIT
@@ -5318,7 +5318,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Bitmore
@@ -5336,7 +5336,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Bitmore
@@ -5354,7 +5354,7 @@
     name: Chrome Webview
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Bitmore
@@ -5372,7 +5372,7 @@
     name: Chrome Webview
     version: 50.0.2661.86
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: tablet
     brand: Bitmore
@@ -5390,7 +5390,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Bitmore
@@ -5408,7 +5408,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Danew
@@ -5426,7 +5426,7 @@
     name: Chrome
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Danew
@@ -5462,7 +5462,7 @@
     name: Chrome
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Danew
@@ -5480,7 +5480,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Danew
@@ -5498,7 +5498,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: Mpman
@@ -5516,7 +5516,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Mpman
@@ -5534,7 +5534,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Mpman
@@ -5552,7 +5552,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Mpman
@@ -5570,7 +5570,7 @@
     name: Chrome
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: EXO
@@ -5588,7 +5588,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: EXO
@@ -5606,7 +5606,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Walton
@@ -5624,7 +5624,7 @@
     name: Chrome Mobile
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Walton
@@ -5642,7 +5642,7 @@
     name: Chrome
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: Walton
@@ -5660,7 +5660,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Walton
@@ -5678,7 +5678,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: EvroMedia
@@ -5696,7 +5696,7 @@
     name: Chrome
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: Celkon
@@ -5714,7 +5714,7 @@
     name: Chrome Mobile
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: tablet
     brand: Mito
@@ -5732,7 +5732,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Mito
@@ -5750,7 +5750,7 @@
     name: Chrome
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: Mito
@@ -5768,7 +5768,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Mito
@@ -5786,7 +5786,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Verico
@@ -5804,7 +5804,7 @@
     name: Chrome Mobile
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Jeka
@@ -5822,7 +5822,7 @@
     name: Chrome Mobile
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Jeka
@@ -5840,7 +5840,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Jeka
@@ -5858,7 +5858,7 @@
     name: Opera
     version: 50.3.2426.136976
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Jeka
@@ -5876,7 +5876,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Jeka
@@ -5894,7 +5894,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: KREZ
@@ -5912,7 +5912,7 @@
     name: Chrome
     version: 49.0.2623.105
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: tablet
     brand: KREZ
@@ -5930,7 +5930,7 @@
     name: Chrome
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: BB Mobile
@@ -5948,7 +5948,7 @@
     name: Chrome
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: Kurio
@@ -5984,7 +5984,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Inch
@@ -6002,7 +6002,7 @@
     name: Chrome
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: Inch
@@ -6020,7 +6020,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Inch
@@ -6038,7 +6038,7 @@
     name: Chrome
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Inco
@@ -6056,7 +6056,7 @@
     name: Opera
     version: 56.1.2780.51589
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Irbis
@@ -6074,7 +6074,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Irbis
@@ -6092,7 +6092,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Irbis
@@ -6110,7 +6110,7 @@
     name: Opera
     version: 58.4.2878.56737
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Irbis
@@ -6128,7 +6128,7 @@
     name: Opera
     version: 58.2.2878.53403
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Irbis
@@ -6146,7 +6146,7 @@
     name: Chrome
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Irbis
@@ -6164,7 +6164,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Irbis
@@ -6182,7 +6182,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Irbis
@@ -6200,7 +6200,7 @@
     name: Opera
     version: 58.4.2878.56737
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Irbis
@@ -6218,7 +6218,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Irbis
@@ -6236,7 +6236,7 @@
     name: Chrome
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: tablet
     brand: Irbis
@@ -6254,7 +6254,7 @@
     name: Opera
     version: 58.0.2878.53230
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Irbis
@@ -6272,7 +6272,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Maxwest
@@ -6290,7 +6290,7 @@
     name: Chrome
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: tablet
     brand: Asus
@@ -6308,7 +6308,7 @@
     name: Chrome
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Woxter
@@ -6326,7 +6326,7 @@
     name: Chrome
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Woxter
@@ -6344,7 +6344,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Woxter
@@ -6362,7 +6362,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Woxter
@@ -6380,7 +6380,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Woxter
@@ -6398,7 +6398,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Woxter
@@ -6416,7 +6416,7 @@
     name: Chrome
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: tablet
     brand: Woxter
@@ -6434,7 +6434,7 @@
     name: Chrome
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Woxter
@@ -6452,7 +6452,7 @@
     name: Chrome
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Woxter
@@ -6470,7 +6470,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Woxter
@@ -6488,7 +6488,7 @@
     name: Chrome
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: Woxter
@@ -6506,7 +6506,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Woxter
@@ -6524,7 +6524,7 @@
     name: Chrome
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Woxter
@@ -6542,7 +6542,7 @@
     name: Chrome
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Woxter
@@ -6560,7 +6560,7 @@
     name: Chrome
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Woxter
@@ -6578,7 +6578,7 @@
     name: Chrome
     version: 73.0.3683.75
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.75"
   device:
     type: tablet
     brand: Woxter
@@ -6596,7 +6596,7 @@
     name: Chrome
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Woxter
@@ -6614,7 +6614,7 @@
     name: Chrome
     version: 74.0.3729.112
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: tablet
     brand: Woxter
@@ -6632,7 +6632,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Woxter
@@ -6650,7 +6650,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Woxter
@@ -6668,7 +6668,7 @@
     name: Chrome
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Woxter
@@ -6686,7 +6686,7 @@
     name: Chrome
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Woxter
@@ -6704,7 +6704,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Woxter
@@ -6722,7 +6722,7 @@
     name: Chrome
     version: 77.0.3865.73
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: tablet
     brand: Cobalt
@@ -6740,7 +6740,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: Cobalt
@@ -6758,7 +6758,7 @@
     name: Chrome
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: tablet
     brand: Cobalt
@@ -6776,7 +6776,7 @@
     name: Chrome
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Cobalt
@@ -6794,7 +6794,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Cobalt
@@ -6812,7 +6812,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: Hometech
@@ -6830,7 +6830,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: Hometech
@@ -6848,7 +6848,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: AOYODKG
@@ -6866,7 +6866,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: Turbo-X
@@ -6884,7 +6884,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: Vastking
@@ -6902,7 +6902,7 @@
     name: Chrome
     version: 90.0.4430.66
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.66"
   device:
     type: tablet
     brand: Vastking
@@ -6920,7 +6920,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: Vonino
@@ -6938,7 +6938,7 @@
     name: Chrome
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: Swipe
@@ -6956,7 +6956,7 @@
     name: Chrome
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tablet
     brand: Alcatel
@@ -6974,7 +6974,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Asus
@@ -6992,7 +6992,7 @@
     name: Chrome
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: tablet
     brand: Huawei
@@ -7010,7 +7010,7 @@
     name: Chrome Mobile
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: tablet
     brand: IKU Mobile
@@ -7028,7 +7028,7 @@
     name: Chrome
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: tablet
     brand: IKU Mobile
@@ -7046,7 +7046,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: IKU Mobile
@@ -7064,7 +7064,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: IKU Mobile
@@ -7082,7 +7082,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Dell
@@ -7100,7 +7100,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Dell
@@ -7118,7 +7118,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Dell
@@ -7136,7 +7136,7 @@
     name: Chrome
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: Dell
@@ -7154,7 +7154,7 @@
     name: Opera
     version: 54.0.2672.49578
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: DEXP
@@ -7172,7 +7172,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: DEXP
@@ -7190,7 +7190,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Umax
@@ -7244,7 +7244,7 @@
     name: Chrome Mobile
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: tablet
     brand: Verykool
@@ -7262,7 +7262,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: Chuwi
@@ -7280,7 +7280,7 @@
     name: Chrome Mobile
     version: 72.0.3626.96
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: tablet
     brand: Alcatel
@@ -7298,7 +7298,7 @@
     name: Yandex Browser
     version: 19.3.3.288.01
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.119"
   device:
     type: tablet
     brand: BB Mobile
@@ -7316,7 +7316,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Supra
@@ -7334,7 +7334,7 @@
     name: Opera
     version: 18.0.1290.67495
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.57"
   device:
     type: tablet
     brand: Explay
@@ -7352,7 +7352,7 @@
     name: Chrome
     version: 66.0.3359.126
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: tablet
     brand: LG
@@ -7402,7 +7402,7 @@
     name: Chrome
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tablet
     brand: Medion
@@ -7420,7 +7420,7 @@
     name: Chrome
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Chuwi
@@ -7438,7 +7438,7 @@
     name: Chrome
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Lenovo
@@ -7456,7 +7456,7 @@
     name: Chrome
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: tablet
     brand: Philips
@@ -7474,7 +7474,7 @@
     name: Chrome Webview
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: tablet
     brand: QMobile
@@ -7492,7 +7492,7 @@
     name: Chrome
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: tablet
     brand: Teclast
@@ -7510,7 +7510,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Blow
@@ -7528,7 +7528,7 @@
     name: Chrome
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Nomi
@@ -7546,7 +7546,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: FNF
@@ -7564,7 +7564,7 @@
     name: Yandex Browser
     version: 18.11.1.1011.01
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: tablet
     brand: FNF
@@ -7582,7 +7582,7 @@
     name: Yandex Browser
     version: 18.1.2.70.01
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.132"
   device:
     type: tablet
     brand: FNF
@@ -7600,7 +7600,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: FNF
@@ -7618,7 +7618,7 @@
     name: Opera
     version: 50.0.2254.149180
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tablet
     brand: Digma
@@ -7636,7 +7636,7 @@
     name: Chrome
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: tablet
     brand: Digma
@@ -7654,7 +7654,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: Digma
@@ -7672,7 +7672,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Nvidia
@@ -7690,7 +7690,7 @@
     name: Chrome
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: AVH
@@ -7708,7 +7708,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: Alba
@@ -7726,7 +7726,7 @@
     name: Chrome Mobile
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: Vizio
@@ -7744,7 +7744,7 @@
     name: Chrome Mobile
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: Vizio
@@ -7762,7 +7762,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Asus
@@ -7780,7 +7780,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Prestigio
@@ -7798,7 +7798,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Pixus
@@ -7816,7 +7816,7 @@
     name: Chrome
     version: 47.0.2526.83
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.83"
   device:
     type: tablet
     brand: Navon
@@ -7852,7 +7852,7 @@
     name: Chrome
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: GOCLEVER
@@ -7870,7 +7870,7 @@
     name: Chrome
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: tablet
     brand: LG
@@ -7888,7 +7888,7 @@
     name: Chrome
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: tablet
     brand: Samsung
@@ -7922,7 +7922,7 @@
     name: Chrome
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: tablet
     brand: Dragon Touch
@@ -7940,7 +7940,7 @@
     name: Chrome
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Ghia
@@ -7974,7 +7974,7 @@
     name: Chrome
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tablet
     brand: Ghia
@@ -7992,7 +7992,7 @@
     name: Yandex Browser
     version: 20.4.0.237.01
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: tablet
     brand: MiXzo
@@ -8010,7 +8010,7 @@
     name: Opera Mobile
     version: 51.0.2254.150679
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: tablet
     brand: Tecno Mobile
@@ -8028,7 +8028,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Lenovo
@@ -8046,7 +8046,7 @@
     name: Chrome
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: tablet
     brand: Lenovo
@@ -8064,7 +8064,7 @@
     name: Microsoft Edge
     version: 45.11.2.5116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Onda
@@ -8082,7 +8082,7 @@
     name: Mobile Silk
     version: 67.6.1
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: Amazon
@@ -8118,7 +8118,7 @@
     name: Chrome
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: tablet
     brand: Multilaser
@@ -8136,7 +8136,7 @@
     name: Chrome
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: tablet
     brand: FNF
@@ -8154,7 +8154,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: FNF
@@ -8172,7 +8172,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Leotec
@@ -8208,7 +8208,7 @@
     name: Chrome
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: tablet
     brand: Nomi
@@ -8226,7 +8226,7 @@
     name: Yandex Browser Lite
     version: 19.6.0.158
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: Lenovo
@@ -8244,7 +8244,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Lenovo
@@ -8262,7 +8262,7 @@
     name: Chrome Webview
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: Lenovo
@@ -8280,7 +8280,7 @@
     name: Chrome
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Asus
@@ -8298,7 +8298,7 @@
     name: Chrome
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Asus
@@ -8316,7 +8316,7 @@
     name: Chrome
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Explay
@@ -8334,7 +8334,7 @@
     name: Chrome
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: tablet
     brand: LG
@@ -8368,7 +8368,7 @@
     name: Chrome
     version: 45.0.2454.84
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.84"
   device:
     type: tablet
     brand: LG
@@ -8386,7 +8386,7 @@
     name: Chrome
     version: 45.0.2454.94
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.94"
   device:
     type: tablet
     brand: LG
@@ -8404,7 +8404,7 @@
     name: Chrome
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: LG
@@ -8422,7 +8422,7 @@
     name: Chrome
     version: 54.0.2840.68
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.68"
   device:
     type: tablet
     brand: LG
@@ -8456,7 +8456,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Thomson
@@ -8474,7 +8474,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: tablet
     brand: Nomi
@@ -8492,7 +8492,7 @@
     name: Chrome Webview
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: Nomi
@@ -8510,7 +8510,7 @@
     name: Chrome Webview
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: tablet
     brand: Nomi
@@ -8528,7 +8528,7 @@
     name: Yandex Browser
     version: "10.61"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: Prestigio
@@ -8546,7 +8546,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: Nomi
@@ -8564,7 +8564,7 @@
     name: Chrome Webview
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Supra
@@ -8582,7 +8582,7 @@
     name: Chrome
     version: 43.0.2357.93
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: tablet
     brand: FLYCAT
@@ -8600,7 +8600,7 @@
     name: Yandex Browser
     version: 16.7.0.2777.01
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.106"
   device:
     type: tablet
     brand: FLYCAT
@@ -8618,7 +8618,7 @@
     name: Chrome
     version: 49.0.2623.91
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: tablet
     brand: FLYCAT
@@ -8636,7 +8636,7 @@
     name: Chrome
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: tablet
     brand: Nomi
@@ -8654,7 +8654,7 @@
     name: Chrome
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Prestigio
@@ -8672,7 +8672,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: DEXP
@@ -8690,7 +8690,7 @@
     name: Chrome
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Supra
@@ -8708,7 +8708,7 @@
     name: Chrome
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: DEXP
@@ -8726,7 +8726,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: DEXP
@@ -8760,7 +8760,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tablet
     brand: 3GO
@@ -8778,7 +8778,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: 3GO
@@ -8812,7 +8812,7 @@
     name: Chrome
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: tablet
     brand: Lenovo
@@ -8830,7 +8830,7 @@
     name: Chrome
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Lenovo
@@ -8848,7 +8848,7 @@
     name: Chrome
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tablet
     brand: JVC
@@ -8866,7 +8866,7 @@
     name: Chrome
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: tablet
     brand: Pixus
@@ -8884,7 +8884,7 @@
     name: Chrome Mobile
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: tablet
     brand: Tecno Mobile
@@ -8902,7 +8902,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tablet
     brand: Pixus
@@ -8920,7 +8920,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: iLife
@@ -8938,7 +8938,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: iLife
@@ -8956,7 +8956,7 @@
     name: Chrome
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: Explay
@@ -8974,7 +8974,7 @@
     name: Chrome
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: tablet
     brand: Explay
@@ -8992,7 +8992,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: Overmax
@@ -9010,7 +9010,7 @@
     name: Yandex Browser
     version: 21.5.6.56.01
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: tablet
     brand: Lenovo
@@ -9028,7 +9028,7 @@
     name: Yandex Browser
     version: 21.6.1.101.01 beta
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: tablet
     brand: Lenovo
@@ -9046,7 +9046,7 @@
     name: Yandex Browser
     version: 21.50.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: tablet
     brand: Lenovo
@@ -9064,7 +9064,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Alcatel
@@ -9082,7 +9082,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Alcatel
@@ -9100,7 +9100,7 @@
     name: Chrome
     version: 85.0.4183.120
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: tablet
     brand: Alcatel
@@ -9118,7 +9118,7 @@
     name: Chrome
     version: 85.0.4183.120
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.120"
   device:
     type: tablet
     brand: Alcatel
@@ -9136,7 +9136,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Teclast
@@ -9154,7 +9154,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Teclast
@@ -9172,7 +9172,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: AllDocube
@@ -9190,7 +9190,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: AllDocube
@@ -9208,7 +9208,7 @@
     name: Chrome Webview
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: Zentality
@@ -9226,7 +9226,7 @@
     name: Chrome Webview
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Diva
@@ -9244,7 +9244,7 @@
     name: Chrome
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: Diva
@@ -9262,7 +9262,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Diva
@@ -9280,7 +9280,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Diva
@@ -9298,7 +9298,7 @@
     name: Chrome Webview
     version: 50.0.2661.86
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: tablet
     brand: Diva
@@ -9316,7 +9316,7 @@
     name: Opera
     version: 50.6.2426.201126
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: DNS
@@ -9334,7 +9334,7 @@
     name: Chrome
     version: 45.0.2454.94
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.94"
   device:
     type: tablet
     brand: DNS

--- a/Tests/fixtures/tablet-6.yml
+++ b/Tests/fixtures/tablet-6.yml
@@ -10,7 +10,7 @@
     name: Chrome
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: Teclast
@@ -28,7 +28,7 @@
     name: Chrome
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tablet
     brand: Umax
@@ -46,7 +46,7 @@
     name: Chrome
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: tablet
     brand: Sencor
@@ -173,7 +173,7 @@
     name: Chrome Mobile
     version: 52.0.2758.92
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2758.92"
   device:
     type: tablet
     brand: bq
@@ -191,7 +191,7 @@
     name: Chrome
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: tablet
     brand: Nomi
@@ -209,7 +209,7 @@
     name: Chrome Webview
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: Prestigio
@@ -227,7 +227,7 @@
     name: Chrome
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tablet
     brand: Prestigio
@@ -245,7 +245,7 @@
     name: Chrome
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: tablet
     brand: Prestigio
@@ -263,7 +263,7 @@
     name: Chrome
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: tablet
     brand: Prestigio
@@ -281,7 +281,7 @@
     name: Opera
     version: 65.0.3310.60026
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: tablet
     brand: Prestigio
@@ -299,7 +299,7 @@
     name: Opera Mobile
     version: 55.1.2254.56965
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: tablet
     brand: Lenovo
@@ -317,7 +317,7 @@
     name: Yandex Browser
     version: 21.50.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: tablet
     brand: Lenovo
@@ -335,7 +335,7 @@
     name: Opera
     version: 57.0.2254.58007
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: tablet
     brand: Digma
@@ -353,7 +353,7 @@
     name: Chrome
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: tablet
     brand: DEXP
@@ -371,7 +371,7 @@
     name: Chrome
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: tablet
     brand: TrekStor
@@ -389,7 +389,7 @@
     name: Chrome
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: tablet
     brand: Teclast
@@ -407,7 +407,7 @@
     name: Opera
     version: 55.1.2254.56965
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: Xiaomi
@@ -425,7 +425,7 @@
     name: Yandex Browser
     version: 21.50.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: tablet
     brand: DEXP
@@ -443,7 +443,7 @@
     name: Yandex Browser
     version: 21.50.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: tablet
     brand: DEXP
@@ -461,7 +461,7 @@
     name: Yandex Browser
     version: 21.50.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: tablet
     brand: Lenovo
@@ -479,7 +479,7 @@
     name: Yandex Browser
     version: 21.5.0.350.01
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: tablet
     brand: Lenovo
@@ -497,7 +497,7 @@
     name: Chrome
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: tablet
     brand: Lenovo
@@ -515,7 +515,7 @@
     name: Opera Mobile
     version: 56.1.2254.57583
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: tablet
     brand: Nomi
@@ -533,7 +533,7 @@
     name: Opera
     version: 55.1.2254.56965
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: Nomi
@@ -551,7 +551,7 @@
     name: Opera Mobile
     version: 57.0.2254.57835
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: tablet
     brand: Nomi
@@ -569,7 +569,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: tablet
     brand: Nomi
@@ -587,7 +587,7 @@
     name: Chrome Mobile
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: tablet
     brand: Nomi
@@ -605,7 +605,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: tablet
     brand: Nomi
@@ -623,7 +623,7 @@
     name: Chrome
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tablet
     brand: Teclast
@@ -659,7 +659,7 @@
     name: Chrome
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: AllDocube
@@ -677,7 +677,7 @@
     name: Chrome
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: tablet
     brand: Asus
@@ -695,7 +695,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: Adronix
@@ -713,7 +713,7 @@
     name: Chrome Webview
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: tablet
     brand: Adronix
@@ -731,7 +731,7 @@
     name: Chrome
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: tablet
     brand: Adronix
@@ -749,7 +749,7 @@
     name: Chrome
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: tablet
     brand: Hoozo
@@ -767,7 +767,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: tablet
     brand: AllDocube
@@ -785,7 +785,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tablet
     brand: 'Krüger&Matz'
@@ -803,7 +803,7 @@
     name: Chrome
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: tablet
     brand: Lenovo
@@ -821,7 +821,7 @@
     name: Chrome
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: tablet
     brand: Lenovo
@@ -839,7 +839,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tablet
     brand: Lenovo
@@ -857,7 +857,7 @@
     name: Chrome
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tablet
     brand: Lenovo
@@ -875,7 +875,7 @@
     name: Chrome Mobile
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tablet
     brand: ONN
@@ -893,7 +893,7 @@
     name: Chrome
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: tablet
     brand: ONN
@@ -911,7 +911,7 @@
     name: Opera
     version: 56.1.2254.57583
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tablet
     brand: Teclast
@@ -929,7 +929,7 @@
     name: Yandex Browser
     version: 21.65.1
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: tablet
     brand: Digma
@@ -947,7 +947,7 @@
     name: Yandex Browser
     version: 21.6.5.64.01 alpha
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: tablet
     brand: Digma
@@ -965,7 +965,7 @@
     name: Yandex Browser
     version: 21.65.1
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: tablet
     brand: Digma
@@ -983,7 +983,7 @@
     name: Opera Mobile
     version: 58.0.2254.58441
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Digma
@@ -1001,7 +1001,7 @@
     name: Chrome
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: tablet
     brand: Bravis
@@ -1019,7 +1019,7 @@
     name: Chrome
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: tablet
     brand: Bravis
@@ -1037,7 +1037,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: smartphone
     brand: Dialog
@@ -1055,7 +1055,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: smartphone
     brand: Dialog
@@ -1073,7 +1073,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: tablet
     brand: Digma
@@ -1091,7 +1091,7 @@
     name: Chrome
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: tablet
     brand: Digma
@@ -1109,7 +1109,7 @@
     name: Chrome
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: tablet
     brand: Digma
@@ -1127,7 +1127,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: tablet
     brand: Digma
@@ -1145,7 +1145,7 @@
     name: Chrome
     version: 92.0.4515.105
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: tablet
     brand: Matrix
@@ -1163,7 +1163,7 @@
     name: Chrome
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: tablet
     brand: Prestigio
@@ -1181,7 +1181,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: tablet
     brand: Prestigio
@@ -1199,7 +1199,7 @@
     name: Chrome
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tablet
     brand: Prestigio
@@ -1217,7 +1217,7 @@
     name: Chrome
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: tablet
     brand: Prestigio
@@ -1235,7 +1235,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: tablet
     brand: bq
@@ -1253,7 +1253,7 @@
     name: Chrome
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: tablet
     brand: Digiland
@@ -1271,7 +1271,7 @@
     name: Yandex Browser
     version: 21.51.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: tablet
     brand: Prestigio
@@ -1289,7 +1289,7 @@
     name: Chrome
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: tablet
     brand: Teclast
@@ -1307,7 +1307,7 @@
     name: Chrome
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: tablet
     brand: Teclast
@@ -1325,7 +1325,7 @@
     name: Chrome
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: tablet
     brand: Samsung
@@ -1343,7 +1343,7 @@
     name: Chrome
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: tablet
     brand: Samsung
@@ -1361,7 +1361,7 @@
     name: Chrome
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tablet
     brand: Medion
@@ -1379,7 +1379,7 @@
     name: Chrome Mobile
     version: 91.0.4472.164
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: tablet
     brand: Alcatel
@@ -1397,7 +1397,7 @@
     name: Chrome Mobile
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: tablet
     brand: Alcatel
@@ -1415,7 +1415,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: tablet
     brand: Alcatel
@@ -1433,7 +1433,7 @@
     name: Chrome Mobile
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: tablet
     brand: Alcatel
@@ -1451,7 +1451,7 @@
     name: Yandex Browser
     version: 21.54.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.216"
   device:
     type: tablet
     brand: DEXP
@@ -1469,7 +1469,7 @@
     name: Yandex Browser
     version: 21.50.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: tablet
     brand: Irbis
@@ -1487,7 +1487,7 @@
     name: Yandex Browser
     version: 21.50.1
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.93"
   device:
     type: tablet
     brand: Lenovo
@@ -1505,7 +1505,7 @@
     name: Chrome Webview
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Lenovo
@@ -1523,7 +1523,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: tablet
     brand: Prestigio
@@ -1541,7 +1541,7 @@
     name: Chrome
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tablet
     brand: Prestigio
@@ -1559,7 +1559,7 @@
     name: Chrome
     version: 91.0.4472.77
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.77"
   device:
     type: tablet
     brand: Prestigio
@@ -1577,7 +1577,7 @@
     name: Chrome
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tablet
     brand: Prestigio
@@ -1595,7 +1595,7 @@
     name: Chrome
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tablet
     brand: Prestigio
@@ -1613,7 +1613,7 @@
     name: Chrome Mobile
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: tablet
     brand: Sigma
@@ -1631,7 +1631,7 @@
     name: Chrome
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: tablet
     brand: Sigma
@@ -1649,7 +1649,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Acer
@@ -1719,7 +1719,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Mobicel
@@ -1737,7 +1737,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: Sunny
@@ -1755,7 +1755,7 @@
     name: Chrome
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tablet
     brand: Sunny
@@ -1773,7 +1773,7 @@
     name: Chrome
     version: 73.0.3683.75
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.75"
   device:
     type: tablet
     brand: SmartBook
@@ -1791,7 +1791,7 @@
     name: Chrome
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: SmartBook
@@ -1809,7 +1809,7 @@
     name: Chrome
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Primux
@@ -1827,7 +1827,7 @@
     name: Chrome
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tablet
     brand: Sky
@@ -1845,7 +1845,7 @@
     name: Chrome
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: Vestel
@@ -1863,7 +1863,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: iView
@@ -1881,7 +1881,7 @@
     name: Chrome Mobile
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: iView
@@ -1899,7 +1899,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: iView
@@ -1917,7 +1917,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Ainol
@@ -1935,7 +1935,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Ainol
@@ -1953,7 +1953,7 @@
     name: Chrome
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: tablet
     brand: Sprint
@@ -1971,7 +1971,7 @@
     name: Chrome
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: tablet
     brand: Sprint
@@ -1989,7 +1989,7 @@
     name: Chrome
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: Sprint
@@ -2007,7 +2007,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Google
@@ -2025,7 +2025,7 @@
     name: Chrome Mobile
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: Bundy
@@ -2043,7 +2043,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Digiland
@@ -2061,7 +2061,7 @@
     name: Chrome
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: tablet
     brand: GOCLEVER
@@ -2079,7 +2079,7 @@
     name: Chrome
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: GOCLEVER
@@ -2097,7 +2097,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: GOCLEVER
@@ -2115,7 +2115,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Haier
@@ -2133,7 +2133,7 @@
     name: Chrome
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Kanji
@@ -2151,7 +2151,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Kanji
@@ -2169,7 +2169,7 @@
     name: Chrome
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: Kanji
@@ -2187,7 +2187,7 @@
     name: Chrome
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: NextBook
@@ -2205,7 +2205,7 @@
     name: Chrome
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: Leotec
@@ -2223,7 +2223,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: TrekStor
@@ -2241,7 +2241,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Carrefour
@@ -2259,7 +2259,7 @@
     name: Mobile Silk
     version: 90.2.49
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: Amazon
@@ -2277,7 +2277,7 @@
     name: Mobile Silk
     version: 84.3.5
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tablet
     brand: Amazon
@@ -2295,7 +2295,7 @@
     name: Chrome Mobile
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Sico
@@ -2313,7 +2313,7 @@
     name: Chrome
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Vexia
@@ -2331,7 +2331,7 @@
     name: Chrome
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: Odys
@@ -2349,7 +2349,7 @@
     name: Chrome
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: tablet
     brand: Amazon
@@ -2367,7 +2367,7 @@
     name: Chrome
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: tablet
     brand: NEC
@@ -2385,7 +2385,7 @@
     name: Chrome
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: tablet
     brand: Amazon
@@ -2403,7 +2403,7 @@
     name: Chrome
     version: 85.0.4183.78
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.78"
   device:
     type: tablet
     brand: Sony
@@ -2421,7 +2421,7 @@
     name: Chrome Webview
     version: 53.0.2785.124
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.124"
   device:
     type: tablet
     brand: AIRON
@@ -2439,7 +2439,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Mito
@@ -2457,7 +2457,7 @@
     name: Chrome
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Mito
@@ -2475,7 +2475,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Mito
@@ -2493,7 +2493,7 @@
     name: Chrome
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Mito
@@ -2511,7 +2511,7 @@
     name: Chrome
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: tablet
     brand: Mito
@@ -2529,7 +2529,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: Mymaga
@@ -2547,7 +2547,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Lark
@@ -2565,7 +2565,7 @@
     name: Chrome
     version: 81.0.4044.96
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.96"
   device:
     type: tablet
     brand: Lark
@@ -2583,7 +2583,7 @@
     name: Chrome
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: tablet
     brand: Odys
@@ -2601,7 +2601,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tablet
     brand: Odys
@@ -2619,7 +2619,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Odys
@@ -2637,7 +2637,7 @@
     name: Chrome
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: Packard Bell
@@ -2655,7 +2655,7 @@
     name: Chrome
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: Packard Bell
@@ -2673,7 +2673,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Packard Bell
@@ -2691,7 +2691,7 @@
     name: Chrome
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: Packard Bell
@@ -2709,7 +2709,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Packard Bell
@@ -2727,7 +2727,7 @@
     name: Yandex Browser
     version: 21.80.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: tablet
     brand: Samsung
@@ -2745,7 +2745,7 @@
     name: Yandex Browser
     version: 21.66.1
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.164"
   device:
     type: tablet
     brand: Samsung
@@ -2763,7 +2763,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Xiaomi
@@ -2781,7 +2781,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Lenovo
@@ -2799,7 +2799,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: AllDocube
@@ -2817,7 +2817,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: Samsung
@@ -2835,7 +2835,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: Samsung
@@ -2853,7 +2853,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: tablet
     brand: Vertex
@@ -2871,7 +2871,7 @@
     name: Chrome Mobile
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: tablet
     brand: Mecer
@@ -2889,7 +2889,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: 'Krüger&Matz'
@@ -2907,7 +2907,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Teclast
@@ -2925,7 +2925,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: Teclast
@@ -2943,7 +2943,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Chuwi
@@ -2961,7 +2961,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Pixus
@@ -2979,7 +2979,7 @@
     name: Opera Mobile
     version: 59.0.2254.59153
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: Telefunken
@@ -2997,7 +2997,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: Navitel
@@ -3015,7 +3015,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: Winnovo
@@ -3033,7 +3033,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: DEXP
@@ -3051,7 +3051,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: DEXP
@@ -3069,7 +3069,7 @@
     name: Chrome
     version: 94.0.4606.50
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.50"
   device:
     type: tablet
     brand: Lenovo
@@ -3087,7 +3087,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Digiland
@@ -3105,7 +3105,7 @@
     name: Microsoft Edge
     version: 93.0.961.44
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.63"
   device:
     type: tablet
     brand: Huawei
@@ -3123,7 +3123,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: BMAX
@@ -3141,7 +3141,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: Inoi
@@ -3159,7 +3159,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Inoi
@@ -3177,7 +3177,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: Sigma
@@ -3195,7 +3195,7 @@
     name: Chrome
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: tablet
     brand: Mobicel
@@ -3213,7 +3213,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Teclast
@@ -3231,7 +3231,7 @@
     name: Opera
     version: 64.3.3282.60839
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: tablet
     brand: Teclast
@@ -3249,7 +3249,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: Nomi
@@ -3267,7 +3267,7 @@
     name: Chrome
     version: 93.0.4572.0
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4572.0"
   device:
     type: tablet
     brand: Nomi
@@ -3285,7 +3285,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: Nomi
@@ -3303,7 +3303,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Nomi
@@ -3321,7 +3321,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: Nomi
@@ -3339,7 +3339,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: LG
@@ -3357,7 +3357,7 @@
     name: Chrome Webview
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: DEXP
@@ -3375,7 +3375,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: DEXP
@@ -3393,7 +3393,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Acer
@@ -3411,7 +3411,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Lenovo
@@ -3429,7 +3429,7 @@
     name: Chrome Webview
     version: 51.0.2704.91
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.91"
   device:
     type: tablet
     brand: Contixo
@@ -3447,7 +3447,7 @@
     name: Chrome Webview
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: bq
@@ -3465,7 +3465,7 @@
     name: Chrome
     version: 85.0.4178.0
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4178.0"
   device:
     type: tablet
     brand: ONYX BOOX
@@ -3483,7 +3483,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: Mecer
@@ -3501,7 +3501,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Lenovo
@@ -3519,7 +3519,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: RCA Tablets
@@ -3537,7 +3537,7 @@
     name: Chrome
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: tablet
     brand: Fly
@@ -3555,7 +3555,7 @@
     name: Chrome
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: tablet
     brand: Xiaomi
@@ -3573,7 +3573,7 @@
     name: Chrome
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: Samsung
@@ -3591,7 +3591,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Samsung
@@ -3609,7 +3609,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Huawei
@@ -3627,7 +3627,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Huawei
@@ -3645,7 +3645,7 @@
     name: Huawei Browser Mobile
     version: 11.1.4.301
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Huawei
@@ -3663,7 +3663,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Huawei
@@ -3681,7 +3681,7 @@
     name: Huawei Browser Mobile
     version: 11.0.6.305
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Huawei
@@ -3699,7 +3699,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Huawei
@@ -3717,7 +3717,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Huawei
@@ -3735,7 +3735,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Huawei
@@ -3753,7 +3753,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.301
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Huawei
@@ -3771,7 +3771,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Huawei
@@ -3789,7 +3789,7 @@
     name: Huawei Browser Mobile
     version: 11.1.4.301
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Huawei
@@ -3807,7 +3807,7 @@
     name: Chrome
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tablet
     brand: iBall
@@ -3825,7 +3825,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Vonino
@@ -3843,7 +3843,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Runbo
@@ -3861,7 +3861,7 @@
     name: Chrome
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: tablet
     brand: Digma
@@ -3879,7 +3879,7 @@
     name: Chrome
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: tablet
     brand: Digma
@@ -3897,7 +3897,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Digma
@@ -3915,7 +3915,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: Digma
@@ -3933,7 +3933,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Digma
@@ -3951,7 +3951,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Digma
@@ -3969,7 +3969,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Digma
@@ -3987,7 +3987,7 @@
     name: Chrome
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: tablet
     brand: Digma
@@ -4005,7 +4005,7 @@
     name: Chrome Webview
     version: 62.0.3202.84
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.84"
   device:
     type: tablet
     brand: Digma
@@ -4023,7 +4023,7 @@
     name: Chrome
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: tablet
     brand: Digma
@@ -4041,7 +4041,7 @@
     name: Chrome
     version: 71.0.3578.83
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: tablet
     brand: Digma
@@ -4059,7 +4059,7 @@
     name: Chrome
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: tablet
     brand: Digma
@@ -4077,7 +4077,7 @@
     name: Opera
     version: 64.3.3282.60839
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: tablet
     brand: Digma
@@ -4095,7 +4095,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: Digma
@@ -4113,7 +4113,7 @@
     name: Chrome
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: tablet
     brand: Digma
@@ -4131,7 +4131,7 @@
     name: Chrome
     version: 89.0.4389.105
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: tablet
     brand: Digma
@@ -4149,7 +4149,7 @@
     name: Opera
     version: 64.3.3282.60839
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: tablet
     brand: Digma
@@ -4167,7 +4167,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Digma
@@ -4185,7 +4185,7 @@
     name: Chrome
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: tablet
     brand: Digma
@@ -4203,7 +4203,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Digma
@@ -4221,7 +4221,7 @@
     name: Chrome
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: tablet
     brand: Digma
@@ -4239,7 +4239,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Digma
@@ -4257,7 +4257,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Digma
@@ -4275,7 +4275,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Digma
@@ -4293,7 +4293,7 @@
     name: Chrome Mobile
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Digma
@@ -4311,7 +4311,7 @@
     name: Chrome
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tablet
     brand: Digma
@@ -4329,7 +4329,7 @@
     name: Chrome
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: tablet
     brand: Prestigio
@@ -4347,7 +4347,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Prestigio
@@ -4383,7 +4383,7 @@
     name: Chrome
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Prestigio
@@ -4401,7 +4401,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Prestigio
@@ -4419,7 +4419,7 @@
     name: Chrome
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: tablet
     brand: Prestigio
@@ -4437,7 +4437,7 @@
     name: Chrome
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: tablet
     brand: Prestigio
@@ -4455,7 +4455,7 @@
     name: Chrome
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: tablet
     brand: Prestigio
@@ -4473,7 +4473,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: tablet
     brand: Prestigio
@@ -4491,7 +4491,7 @@
     name: Chrome Mobile
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: tablet
     brand: Prestigio
@@ -4509,7 +4509,7 @@
     name: Chrome Mobile
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: tablet
     brand: LG
@@ -4527,7 +4527,7 @@
     name: Chrome
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: tablet
     brand: DEXP
@@ -4545,7 +4545,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: DEXP
@@ -4563,7 +4563,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Teclast
@@ -4597,7 +4597,7 @@
     name: Yandex Browser
     version: 20.11.3.88.01
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4600.1"
   device:
     type: tablet
     brand: Cube
@@ -4615,7 +4615,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Lenovo
@@ -4633,7 +4633,7 @@
     name: Chrome
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: tablet
     brand: Beeline
@@ -4651,7 +4651,7 @@
     name: Opera
     version: 65.1.3381.61266
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: tablet
     brand: 4Good
@@ -4669,7 +4669,7 @@
     name: Chrome
     version: 86.0.4240.99
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.99"
   device:
     type: tablet
     brand: 4Good
@@ -4687,7 +4687,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Teclast
@@ -4705,7 +4705,7 @@
     name: Chrome
     version: 94.0.4606.56
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.56"
   device:
     type: tablet
     brand: Teclast
@@ -4723,7 +4723,7 @@
     name: Chrome
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: tablet
     brand: AllDocube
@@ -4741,7 +4741,7 @@
     name: Chrome
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: tablet
     brand: ONN
@@ -4759,7 +4759,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: ONN
@@ -4777,7 +4777,7 @@
     name: Chrome
     version: 92.0.4492.0
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4492.0"
   device:
     type: tablet
     brand: ONN
@@ -4795,7 +4795,7 @@
     name: Chrome
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: tablet
     brand: TechPad
@@ -4813,7 +4813,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Teclast
@@ -4831,7 +4831,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: SUNWIND
@@ -4849,7 +4849,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: SUNWIND
@@ -4867,7 +4867,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Qumo
@@ -4885,7 +4885,7 @@
     name: Yandex Browser
     version: 21.82.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: tablet
     brand: Huawei
@@ -4903,7 +4903,7 @@
     name: Yandex Browser
     version: 21.85.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: tablet
     brand: OKSI
@@ -4921,7 +4921,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Proline
@@ -4939,7 +4939,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Mobicel
@@ -4957,7 +4957,7 @@
     name: Yandex Browser
     version: "11.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Supra
@@ -4975,7 +4975,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Archos
@@ -4993,7 +4993,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Supra
@@ -5011,7 +5011,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Supra
@@ -5029,7 +5029,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Lenovo
@@ -5047,7 +5047,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Proline
@@ -5065,7 +5065,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Packard Bell
@@ -5083,7 +5083,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Digma
@@ -5101,7 +5101,7 @@
     name: Opera Mobile
     version: 62.3.3146.57763
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4583.0"
   device:
     type: tablet
     brand: Digma
@@ -5119,7 +5119,7 @@
     name: Opera
     version: 64.2.3282.60128
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: tablet
     brand: Digma
@@ -5137,7 +5137,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Digma
@@ -5155,7 +5155,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Digma
@@ -5173,7 +5173,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Connex
@@ -5191,7 +5191,7 @@
     name: Huawei Browser Mobile
     version: 11.1.1.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Huawei
@@ -5209,7 +5209,7 @@
     name: Huawei Browser Mobile
     version: 11.1.3.300
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Huawei
@@ -5227,7 +5227,7 @@
     name: Huawei Browser Mobile
     version: 11.1.2.301
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Huawei
@@ -5245,7 +5245,7 @@
     name: Huawei Browser Mobile
     version: 11.1.4.301
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Huawei
@@ -5263,7 +5263,7 @@
     name: Huawei Browser Mobile
     version: 11.1.4.301
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Huawei
@@ -5281,7 +5281,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Huawei
@@ -5315,7 +5315,7 @@
     name: Chrome Webview
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: tablet
     brand: Ginzzu
@@ -5333,7 +5333,7 @@
     name: Opera
     version: 50.4.2426.146257
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4591.0"
   device:
     type: tablet
     brand: Samsung
@@ -5351,7 +5351,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Samsung
@@ -5369,7 +5369,7 @@
     name: Chrome Webview
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tablet
     brand: Telefunken
@@ -5387,7 +5387,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: BDF
@@ -5405,7 +5405,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Irbis
@@ -5423,7 +5423,7 @@
     name: Chrome
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: tablet
     brand: Qilive
@@ -5441,7 +5441,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: DEXP
@@ -5459,7 +5459,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Huawei
@@ -5477,7 +5477,7 @@
     name: Huawei Browser Mobile
     version: 11.1.4.301
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Huawei
@@ -5495,7 +5495,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Medion
@@ -5513,7 +5513,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Lenovo
@@ -5531,7 +5531,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: NEC
@@ -5549,7 +5549,7 @@
     name: Chrome
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: tablet
     brand: DEXP
@@ -5567,7 +5567,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: DEXP
@@ -5585,7 +5585,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Alcatel
@@ -5603,7 +5603,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Alcatel
@@ -5621,7 +5621,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Alcatel
@@ -5639,7 +5639,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: DEXP
@@ -5657,7 +5657,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: DEXP
@@ -5675,7 +5675,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: DEXP
@@ -5693,7 +5693,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: DEXP
@@ -5711,7 +5711,7 @@
     name: Yandex Browser
     version: 21.110.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: DEXP
@@ -5729,7 +5729,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Neon IQ
@@ -5747,7 +5747,7 @@
     name: Chrome
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Neon IQ
@@ -5783,7 +5783,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: Neon IQ
@@ -5801,7 +5801,7 @@
     name: Chrome Mobile
     version: 85.0.4183.127
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.127"
   device:
     type: tablet
     brand: Telefunken
@@ -5819,7 +5819,7 @@
     name: Chrome
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: tablet
     brand: Stylo
@@ -5837,7 +5837,7 @@
     name: Yandex Browser
     version: 20.8.3.71.01
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4597.1"
   device:
     type: tablet
     brand: DEXP
@@ -5855,7 +5855,7 @@
     name: Chrome
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: tablet
     brand: Umax
@@ -5873,7 +5873,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: ONN
@@ -5891,7 +5891,7 @@
     name: Chrome
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: tablet
     brand: iGet
@@ -5909,7 +5909,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: iGet
@@ -5927,7 +5927,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Archos
@@ -5945,7 +5945,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Prestigio
@@ -5963,7 +5963,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Prestigio
@@ -5981,7 +5981,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Prestigio
@@ -5999,7 +5999,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Prestigio
@@ -6017,7 +6017,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Prestigio
@@ -6035,7 +6035,7 @@
     name: Chrome
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: tablet
     brand: RCA Tablets
@@ -6053,7 +6053,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Awow
@@ -6071,7 +6071,7 @@
     name: Yandex Browser
     version: "7.52"
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Inoi
@@ -6089,7 +6089,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: AllDocube
@@ -6107,7 +6107,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Nokia
@@ -6125,7 +6125,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Teclast
@@ -6143,7 +6143,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Prestigio
@@ -6161,7 +6161,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Samsung
@@ -6179,7 +6179,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: DEXP
@@ -6197,7 +6197,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: RoyQueen
@@ -6233,7 +6233,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: AllDocube
@@ -6251,7 +6251,7 @@
     name: Chrome
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: tablet
     brand: Teclast
@@ -6269,7 +6269,7 @@
     name: Chrome
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: tablet
     brand: Lenovo
@@ -6287,7 +6287,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Ramos
@@ -6305,7 +6305,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: DEXP
@@ -6323,7 +6323,7 @@
     name: Chrome
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: tablet
     brand: SPC
@@ -6395,7 +6395,7 @@
     name: Chrome
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: tablet
     brand: GEOFOX
@@ -6413,7 +6413,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Acer
@@ -6431,7 +6431,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Crosscall
@@ -6449,7 +6449,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Bubblegum
@@ -6467,7 +6467,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Archos
@@ -6485,7 +6485,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Lenovo
@@ -6503,7 +6503,7 @@
     name: Yandex Browser
     version: "7.52"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: DEXP
@@ -6521,7 +6521,7 @@
     name: Yandex Browser
     version: 20.85.1
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.135"
   device:
     type: tablet
     brand: bq
@@ -6539,7 +6539,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Teclast
@@ -6557,7 +6557,7 @@
     name: Chrome
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: tablet
     brand: Ghia
@@ -6575,7 +6575,7 @@
     name: Chrome
     version: 79.0.3945.45
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.45"
   device:
     type: tablet
     brand: Google
@@ -6593,7 +6593,7 @@
     name: Chrome Webview
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Cloud
@@ -6611,7 +6611,7 @@
     name: Chrome Mobile
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: AllDocube
@@ -6629,7 +6629,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: MyPhone
@@ -6647,7 +6647,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: MyPhone
@@ -6665,7 +6665,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: MyPhone
@@ -6683,7 +6683,7 @@
     name: Chrome
     version: 43.0.2357.93
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: tablet
     brand: Archos
@@ -6701,7 +6701,7 @@
     name: Chrome
     version: 92.0.4515.166
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: tablet
     brand: Smartab
@@ -6719,7 +6719,7 @@
     name: Opera
     version: 64.3.3282.60839
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: tablet
     brand: Navitel
@@ -6737,7 +6737,7 @@
     name: Yandex Browser
     version: 21.85.1
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: tablet
     brand: Samsung
@@ -6755,7 +6755,7 @@
     name: Yandex Browser
     version: 21.113.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Prestigio
@@ -6773,7 +6773,7 @@
     name: Yandex Browser
     version: 21.112.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Prestigio
@@ -6791,7 +6791,7 @@
     name: Yandex Browser
     version: 21.112.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Prestigio
@@ -6809,7 +6809,7 @@
     name: Yandex Browser
     version: 21.110.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Digma
@@ -6827,7 +6827,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Archos
@@ -6845,7 +6845,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: Archos
@@ -6863,7 +6863,7 @@
     name: Chrome
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: tablet
     brand: Archos
@@ -6881,7 +6881,7 @@
     name: Chrome
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: tablet
     brand: Archos
@@ -6899,7 +6899,7 @@
     name: Chrome
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: tablet
     brand: Lenovo
@@ -6917,7 +6917,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: Atvio
@@ -6935,7 +6935,7 @@
     name: Chrome Webview
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: Hyundai
@@ -6953,7 +6953,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Hyundai
@@ -6971,7 +6971,7 @@
     name: Opera Mobile
     version: 66.0.3445.62158
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Irbis
@@ -6989,7 +6989,7 @@
     name: Chrome Webview
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Irbis
@@ -7007,7 +7007,7 @@
     name: Chrome Webview
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Irbis
@@ -7025,7 +7025,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Realme
@@ -7043,7 +7043,7 @@
     name: Chrome
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: tablet
     brand: Ulefone
@@ -7061,7 +7061,7 @@
     name: Opera
     version: 65.2.3381.61420
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: tablet
     brand: Teclast
@@ -7079,7 +7079,7 @@
     name: Chrome Webview
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: SuperSonic
@@ -7097,7 +7097,7 @@
     name: Yandex Browser
     version: 21.115.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: SUNWIND
@@ -7169,7 +7169,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Smarty
@@ -7187,7 +7187,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Smarty
@@ -7205,7 +7205,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: NavRoad
@@ -7223,7 +7223,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: NavRoad
@@ -7241,7 +7241,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Vankyo
@@ -7259,7 +7259,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Vankyo
@@ -7277,7 +7277,7 @@
     name: Chrome Mobile
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: Vankyo
@@ -7295,7 +7295,7 @@
     name: Chrome
     version: 38.0.2125.102
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: tablet
     brand: NavRoad
@@ -7349,7 +7349,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: DF
@@ -7385,7 +7385,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: DF
@@ -7403,7 +7403,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: FEONAL
@@ -7421,7 +7421,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: NEC
@@ -7439,7 +7439,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: NEC
@@ -7457,7 +7457,7 @@
     name: Chrome Mobile
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: tablet
     brand: NEC
@@ -7475,7 +7475,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: Lenovo
@@ -7493,7 +7493,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: Lenovo
@@ -7511,7 +7511,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Asus
@@ -7529,7 +7529,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: NEC
@@ -7547,7 +7547,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: NEC
@@ -7565,7 +7565,7 @@
     name: Chrome
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: tablet
     brand: Lenovo
@@ -7583,7 +7583,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: Polaroid
@@ -7601,7 +7601,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: Ematic
@@ -7619,7 +7619,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: TrekStor
@@ -7637,7 +7637,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: Odys
@@ -7655,7 +7655,7 @@
     name: Chrome
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tablet
     brand: BDQ
@@ -7673,7 +7673,7 @@
     name: Chrome
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: tablet
     brand: Prestigio
@@ -7691,7 +7691,7 @@
     name: Chrome Mobile
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Prestigio
@@ -7709,7 +7709,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Prestigio
@@ -7727,7 +7727,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: tablet
     brand: Prestigio
@@ -7745,7 +7745,7 @@
     name: Opera Mobile
     version: 65.2.3381.61420
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: tablet
     brand: Prestigio
@@ -7763,7 +7763,7 @@
     name: Chrome
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: tablet
     brand: Prestigio
@@ -7781,7 +7781,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Prestigio
@@ -7799,7 +7799,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Prestigio
@@ -7817,7 +7817,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Prestigio
@@ -7835,7 +7835,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Prestigio
@@ -7853,7 +7853,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: Prestigio
@@ -7871,7 +7871,7 @@
     name: Sputnik Browser
     version: 1.3.3.166
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Prestigio
@@ -7889,7 +7889,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Prestigio
@@ -7907,7 +7907,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: Prestigio
@@ -7925,7 +7925,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: Prestigio
@@ -7943,7 +7943,7 @@
     name: Opera Mobile
     version: 66.2.3445.62346
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Prestigio
@@ -7961,7 +7961,7 @@
     name: Chrome
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: tablet
     brand: Prestigio
@@ -7979,7 +7979,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: Prestigio
@@ -7997,7 +7997,7 @@
     name: Chrome Mobile
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tablet
     brand: GLONYX
@@ -8015,7 +8015,7 @@
     name: Opera
     version: 58.1.2878.53288
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Matrix
@@ -8033,7 +8033,7 @@
     name: Chrome Webview
     version: 37.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.0.0"
   device:
     type: tablet
     brand: Adronix
@@ -8051,7 +8051,7 @@
     name: Chrome
     version: 92.0.4515.115
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.115"
   device:
     type: tablet
     brand: Adronix
@@ -8069,7 +8069,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tablet
     brand: Onix
@@ -8105,7 +8105,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: Ghia
@@ -8141,7 +8141,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: Samsung
@@ -8159,7 +8159,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tablet
     brand: AGM
@@ -8177,7 +8177,7 @@
     name: Chrome
     version: 40.0.2214.109
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: tablet
     brand: AGM
@@ -8195,7 +8195,7 @@
     name: Chrome
     version: 88.0.4324.152
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.152"
   device:
     type: tablet
     brand: TAG Tech
@@ -8213,7 +8213,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: TAG Tech
@@ -8231,7 +8231,7 @@
     name: Chrome
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: AllDocube
@@ -8249,7 +8249,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Senkatel
@@ -8267,7 +8267,7 @@
     name: Chrome
     version: 97.0.4692.70
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.70"
   device:
     type: smartphone
     brand: Beyond
@@ -8285,7 +8285,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: DUNNS Mobile
@@ -8303,7 +8303,7 @@
     name: Chrome
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: tablet
     brand: DUNNS Mobile
@@ -8321,7 +8321,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: Vertex
@@ -8339,7 +8339,7 @@
     name: Chrome
     version: 67.0.3396.81
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.81"
   device:
     type: tablet
     brand: Selecline
@@ -8357,7 +8357,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Qilive
@@ -8375,7 +8375,7 @@
     name: Chrome
     version: 44.0.2403.133
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.133"
   device:
     type: tablet
     brand: Qilive
@@ -8393,7 +8393,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: Qilive
@@ -8411,7 +8411,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Coby Kyros
@@ -8429,7 +8429,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Cherry Mobile
@@ -8447,7 +8447,7 @@
     name: Chrome
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tablet
     brand: Cherry Mobile
@@ -8465,7 +8465,7 @@
     name: Chrome Mobile
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tablet
     brand: Cherry Mobile
@@ -8483,7 +8483,7 @@
     name: Chrome
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: tablet
     brand: Cherry Mobile
@@ -8501,7 +8501,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Acer
@@ -8519,7 +8519,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Acer
@@ -8537,7 +8537,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Coolpad
@@ -8555,7 +8555,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: EXO
@@ -8573,7 +8573,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Simbans
@@ -8591,7 +8591,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Masstel
@@ -8609,7 +8609,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Reeder
@@ -8627,7 +8627,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Multilaser
@@ -8645,7 +8645,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: smartphone
     brand: Vivax
@@ -8663,7 +8663,7 @@
     name: Chrome Mobile
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Multilaser
@@ -8681,7 +8681,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Haier
@@ -8699,7 +8699,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Klipad
@@ -8717,7 +8717,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Philco
@@ -8735,7 +8735,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: AOC
@@ -8753,7 +8753,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Vankyo
@@ -8771,7 +8771,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Positivo
@@ -8789,7 +8789,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Advance
@@ -8807,7 +8807,7 @@
     name: Chrome Webview
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: tablet
     brand: Advance
@@ -8825,7 +8825,7 @@
     name: Chrome
     version: 90.0.4430.210
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.210"
   device:
     type: tablet
     brand: Advance
@@ -8843,7 +8843,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Fusion5
@@ -8861,7 +8861,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Fusion5
@@ -8879,7 +8879,7 @@
     name: Chrome
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: tablet
     brand: AIDATA
@@ -8897,7 +8897,7 @@
     name: Chrome
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: tablet
     brand: iKon
@@ -8915,7 +8915,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: iKon
@@ -8933,7 +8933,7 @@
     name: Chrome Webview
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: iKon
@@ -8967,7 +8967,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: iKon
@@ -8985,7 +8985,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Huawei
@@ -9003,7 +9003,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: IRA
@@ -9021,7 +9021,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: LG
@@ -9039,7 +9039,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: MLS
@@ -9057,7 +9057,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Lenovo
@@ -9075,7 +9075,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Lenovo
@@ -9093,7 +9093,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Lenovo
@@ -9111,7 +9111,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Lenovo
@@ -9129,7 +9129,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Lenovo
@@ -9147,7 +9147,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Lenovo
@@ -9165,7 +9165,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Vastking
@@ -9183,7 +9183,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Microtech
@@ -9201,7 +9201,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Vonino
@@ -9219,7 +9219,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Cherry Mobile
@@ -9237,7 +9237,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Eurocase
@@ -9255,7 +9255,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: RCA Tablets
@@ -9273,7 +9273,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: RCA Tablets
@@ -9291,7 +9291,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: RCA Tablets
@@ -9309,7 +9309,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Huawei
@@ -9327,7 +9327,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Blow
@@ -9345,7 +9345,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Blow
@@ -9363,7 +9363,7 @@
     name: Chrome Mobile
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Allview
@@ -9399,7 +9399,7 @@
     name: Chrome
     version: 51.0.2704.81
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.81"
   device:
     type: tablet
     brand: 'Ross&Moor'
@@ -9417,7 +9417,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: AIDATA
@@ -9435,7 +9435,7 @@
     name: Chrome
     version: 97.0.4692.70
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.70"
   device:
     type: tablet
     brand: Xiaomi
@@ -9453,7 +9453,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: UMIDIGI
@@ -9471,7 +9471,7 @@
     name: Chrome
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: tablet
     brand: Chuwi
@@ -9489,7 +9489,7 @@
     name: Chrome
     version: 97.0.4692.70
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.70"
   device:
     type: tablet
     brand: Chuwi
@@ -9507,7 +9507,7 @@
     name: Chrome
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: tablet
     brand: Lenovo
@@ -9525,7 +9525,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: Lenovo
@@ -9543,7 +9543,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: Lenovo
@@ -9561,7 +9561,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: Lenovo
@@ -9579,7 +9579,7 @@
     name: Chrome
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: tablet
     brand: Lenovo
@@ -9597,7 +9597,7 @@
     name: Chrome
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: tablet
     brand: Realme
@@ -9615,7 +9615,7 @@
     name: Chrome
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: tablet
     brand: Oukitel
@@ -9649,7 +9649,7 @@
     name: Chrome
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: tablet
     brand: AIDATA
@@ -9667,7 +9667,7 @@
     name: Chrome
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: tablet
     brand: AIDATA
@@ -9685,7 +9685,7 @@
     name: Chrome
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: tablet
     brand: Positivo
@@ -9703,7 +9703,7 @@
     name: Chrome Webview
     version: 88.0.4324.181
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.181"
   device:
     type: tablet
     brand: Sky
@@ -9721,7 +9721,7 @@
     name: Chrome
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: tablet
     brand: Samsung
@@ -9739,7 +9739,7 @@
     name: Chrome
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: tablet
     brand: Samsung
@@ -9757,7 +9757,7 @@
     name: Chrome
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: tablet
     brand: Samsung
@@ -9775,7 +9775,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: tablet
     brand: Samsung
@@ -9793,7 +9793,7 @@
     name: Huawei Browser Mobile
     version: 12.0.0.303
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: tablet
     brand: Huawei
@@ -9811,7 +9811,7 @@
     name: Huawei Browser Mobile
     version: 12.0.0.303
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: tablet
     brand: Huawei
@@ -9829,7 +9829,7 @@
     name: Huawei Browser Mobile
     version: 11.0.2.301
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Huawei
@@ -9847,7 +9847,7 @@
     name: Huawei Browser Mobile
     version: 12.0.0.303
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: tablet
     brand: Huawei
@@ -9865,7 +9865,7 @@
     name: Chrome
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: tablet
     brand: BMAX
@@ -9883,7 +9883,7 @@
     name: Chrome Mobile
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: tablet
     brand: Acer
@@ -9901,7 +9901,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Contixo
@@ -9919,7 +9919,7 @@
     name: Chrome
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: tablet
     brand: Hoozo
@@ -9937,7 +9937,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tablet
     brand: Mediacom
@@ -9955,7 +9955,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Mediacom
@@ -9973,7 +9973,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Walton
@@ -9991,7 +9991,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Redfox

--- a/Tests/fixtures/tablet-7.yml
+++ b/Tests/fixtures/tablet-7.yml
@@ -10,7 +10,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Vestel
@@ -28,7 +28,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Beista
@@ -46,7 +46,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: YOTOPT
@@ -64,7 +64,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: ONN
@@ -82,7 +82,7 @@
     name: Chrome
     version: 95.0.4638.90
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.90"
   device:
     type: tablet
     brand: Xiaomi
@@ -100,7 +100,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tablet
     brand: Wortmann
@@ -118,7 +118,7 @@
     name: Chrome
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: tablet
     brand: TOSCIDO
@@ -136,7 +136,7 @@
     name: Chrome
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: tablet
     brand: TOSCIDO
@@ -154,7 +154,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: DEXP
@@ -172,7 +172,7 @@
     name: Chrome
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: tablet
     brand: DEXP
@@ -190,7 +190,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: Medion
@@ -208,7 +208,7 @@
     name: Chrome
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: tablet
     brand: Casper
@@ -226,7 +226,7 @@
     name: Chrome
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: tablet
     brand: Mediacom
@@ -244,7 +244,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Sigma
@@ -262,7 +262,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tablet
     brand: Koslam
@@ -280,7 +280,7 @@
     name: Yandex Browser
     version: "8.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Koslam
@@ -298,7 +298,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Verssed
@@ -316,7 +316,7 @@
     name: Opera
     version: 50.6.2426.201126
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Orion
@@ -334,7 +334,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: S2Tel
@@ -352,7 +352,7 @@
     name: Chrome
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: tablet
     brand: Technopc
@@ -370,7 +370,7 @@
     name: Chrome
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: tablet
     brand: Casper
@@ -388,7 +388,7 @@
     name: Chrome
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: tablet
     brand: Danew
@@ -406,7 +406,7 @@
     name: Chrome
     version: 97.0.4692.70
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.70"
   device:
     type: tablet
     brand: Samsung
@@ -424,7 +424,7 @@
     name: Chrome Webview
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: tablet
     brand: Sunny
@@ -442,7 +442,7 @@
     name: Opera
     version: 50.6.2426.201126
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Nexa
@@ -460,7 +460,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: Ryte
@@ -478,7 +478,7 @@
     name: Chrome
     version: 96.0.4664.27
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.27"
   device:
     type: tablet
     brand: Lenovo
@@ -496,7 +496,7 @@
     name: Huawei Browser Mobile
     version: 12.0.2.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: tablet
     brand: Huawei
@@ -514,7 +514,7 @@
     name: Huawei Browser Mobile
     version: 12.0.0.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: tablet
     brand: Huawei
@@ -532,7 +532,7 @@
     name: Huawei Browser Mobile
     version: 12.0.3.310
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: tablet
     brand: Huawei
@@ -550,7 +550,7 @@
     name: Huawei Browser Mobile
     version: 12.0.0.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: tablet
     brand: Huawei
@@ -568,7 +568,7 @@
     name: Huawei Browser Mobile
     version: 11.1.5.310
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Huawei
@@ -586,7 +586,7 @@
     name: Chrome Webview
     version: 43.0.2357.121
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.121"
   device:
     type: tablet
     brand: Jumper
@@ -604,7 +604,7 @@
     name: Chrome Mobile
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tablet
     brand: Jumper
@@ -622,7 +622,7 @@
     name: Chrome
     version: 39.0.2171.93
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: tablet
     brand: Jumper
@@ -640,7 +640,7 @@
     name: Chrome Webview
     version: 74.0.3729.186
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.186"
   device:
     type: tablet
     brand: Royole
@@ -658,7 +658,7 @@
     name: Chrome Webview
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tablet
     brand: Royole
@@ -676,7 +676,7 @@
     name: Chrome
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: tablet
     brand: Teclast
@@ -694,7 +694,7 @@
     name: Chrome
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: tablet
     brand: Teclast
@@ -712,7 +712,7 @@
     name: Chrome Webview
     version: 74.0.3729.186
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.186"
   device:
     type: tablet
     brand: Teclast
@@ -730,7 +730,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tablet
     brand: Readboy
@@ -748,7 +748,7 @@
     name: Chrome Webview
     version: 88.0.4324.93
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.93"
   device:
     type: tablet
     brand: Huawei
@@ -766,7 +766,7 @@
     name: Huawei Browser Mobile
     version: 12.0.2.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: tablet
     brand: Huawei
@@ -784,7 +784,7 @@
     name: Huawei Browser Mobile
     version: 11.0.8.303
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Huawei
@@ -802,7 +802,7 @@
     name: Chrome Webview
     version: 83.0.4103.106
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Huawei
@@ -820,7 +820,7 @@
     name: Huawei Browser Mobile
     version: 11.0.8.303
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Huawei
@@ -838,7 +838,7 @@
     name: Chrome Webview
     version: 77.0.3865.120
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: tablet
     brand: AllDocube
@@ -856,7 +856,7 @@
     name: Chrome Webview
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: Hisense
@@ -874,7 +874,7 @@
     name: Huawei Browser Mobile
     version: 12.0.0.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: tablet
     brand: Huawei
@@ -892,7 +892,7 @@
     name: Huawei Browser Mobile
     version: 12.0.3.310
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: tablet
     brand: Huawei
@@ -910,7 +910,7 @@
     name: Huawei Browser Mobile
     version: 12.0.2.301
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.105"
   device:
     type: tablet
     brand: Huawei
@@ -964,7 +964,7 @@
     name: Chrome
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: Hamlet
@@ -982,7 +982,7 @@
     name: Chrome
     version: 66.0.3359.126
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.126"
   device:
     type: tablet
     brand: Storex
@@ -1000,7 +1000,7 @@
     name: Chrome Webview
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Storex
@@ -1018,7 +1018,7 @@
     name: Chrome Webview
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: Condor
@@ -1036,7 +1036,7 @@
     name: Chrome
     version: 80.0.3987.119
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: tablet
     brand: ECS
@@ -1054,7 +1054,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Condor
@@ -1072,7 +1072,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Condor
@@ -1090,7 +1090,7 @@
     name: Chrome
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tablet
     brand: Logicom
@@ -1108,7 +1108,7 @@
     name: Chrome
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: tablet
     brand: Logicom
@@ -1126,7 +1126,7 @@
     name: Chrome
     version: 83.0.4103.83
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.83"
   device:
     type: tablet
     brand: Logicom
@@ -1144,7 +1144,7 @@
     name: Chrome
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: smartphone
     brand: InnJoo
@@ -1162,7 +1162,7 @@
     name: Chrome
     version: 87.0.4280.86
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.86"
   device:
     type: tablet
     brand: Vorcom
@@ -1180,7 +1180,7 @@
     name: Chrome
     version: 87.0.4280.66
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.66"
   device:
     type: tablet
     brand: Majestic
@@ -1198,7 +1198,7 @@
     name: Chrome
     version: 87.0.4280.141
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.141"
   device:
     type: tablet
     brand: Simbans
@@ -1216,7 +1216,7 @@
     name: Chrome
     version: 86.0.4240.110
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.110"
   device:
     type: tablet
     brand: Simbans
@@ -1234,7 +1234,7 @@
     name: Chrome
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: EE
@@ -1252,7 +1252,7 @@
     name: Chrome
     version: 64.0.3282.137
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: tablet
     brand: Hipstreet
@@ -1288,7 +1288,7 @@
     name: Chrome Mobile
     version: 74.0.3729.23
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.23"
   device:
     type: tablet
     brand: AllDocube
@@ -1306,7 +1306,7 @@
     name: Chrome Mobile
     version: 76.0.3795.0
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3795.0"
   device:
     type: tablet
     brand: Huawei
@@ -1324,7 +1324,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: Accent
@@ -1342,7 +1342,7 @@
     name: Chrome
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: tablet
     brand: Cube
@@ -1360,7 +1360,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tablet
     brand: Acer
@@ -1378,7 +1378,7 @@
     name: Chrome
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tablet
     brand: Reeder

--- a/Tests/fixtures/tablet.yml
+++ b/Tests/fixtures/tablet.yml
@@ -136,7 +136,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: ""
@@ -172,7 +172,7 @@
     name: Chrome
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: Senkatel
@@ -190,7 +190,7 @@
     name: Chrome
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: Senkatel
@@ -208,7 +208,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Senkatel
@@ -226,7 +226,7 @@
     name: Chrome
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: Senkatel
@@ -244,7 +244,7 @@
     name: Opera
     version: "50.3.2426.136976"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Senkatel
@@ -262,7 +262,7 @@
     name: Chrome
     version: "80.0.3987.162"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tablet
     brand: meanIT
@@ -280,7 +280,7 @@
     name: Chrome
     version: "78.0.3904.90"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tablet
     brand: BB Mobile
@@ -298,7 +298,7 @@
     name: Chrome Webview
     version: "39.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tablet
     brand: BB Mobile
@@ -316,7 +316,7 @@
     name: Chrome
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: BB Mobile
@@ -352,7 +352,7 @@
     name: Chrome
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Sunstech
@@ -370,7 +370,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Chuwi
@@ -388,7 +388,7 @@
     name: Chrome Webview
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Chuwi
@@ -406,7 +406,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Chuwi
@@ -424,7 +424,7 @@
     name: Chrome
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: Chuwi
@@ -442,7 +442,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Chuwi
@@ -460,7 +460,7 @@
     name: Chrome
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Chuwi
@@ -478,7 +478,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Chuwi
@@ -496,7 +496,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Chuwi
@@ -532,7 +532,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Chuwi
@@ -622,7 +622,7 @@
     name: Chrome
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Chuwi
@@ -640,7 +640,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Chuwi
@@ -658,7 +658,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Chuwi
@@ -676,7 +676,7 @@
     name: Chrome
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: Etuline
@@ -748,7 +748,7 @@
     name: Chrome
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: tablet
     brand: MYFON
@@ -820,7 +820,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Multilaser
@@ -856,7 +856,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Sigma
@@ -874,7 +874,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Sigma
@@ -910,7 +910,7 @@
     name: Chrome Webview
     version: "75.0.3770.67"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: tablet
     brand: Sigma
@@ -946,7 +946,7 @@
     name: Chrome
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: MiXzo
@@ -964,7 +964,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: MiXzo
@@ -982,7 +982,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: MiXzo
@@ -1000,7 +1000,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: MiXzo
@@ -1018,7 +1018,7 @@
     name: Chrome
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: MiXzo
@@ -1072,7 +1072,7 @@
     name: Chrome Mobile
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: iLife
@@ -1090,7 +1090,7 @@
     name: Chrome Mobile
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Masstel
@@ -1108,7 +1108,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: Masstel
@@ -1126,7 +1126,7 @@
     name: Chrome
     version: "48.0.2564.95"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.95"
   device:
     type: tablet
     brand: Masstel
@@ -1144,7 +1144,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: Prixton
@@ -1234,7 +1234,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Starway
@@ -1288,7 +1288,7 @@
     name: Chrome Webview
     version: "58.0.3029.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.125"
   device:
     type: tablet
     brand: AllDocube
@@ -1324,7 +1324,7 @@
     name: Chrome
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Contixo
@@ -1342,7 +1342,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Contixo
@@ -1360,7 +1360,7 @@
     name: Chrome
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Contixo
@@ -1378,7 +1378,7 @@
     name: Chrome Webview
     version: "76.0.3809.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Contixo
@@ -1396,7 +1396,7 @@
     name: Chrome
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Contixo
@@ -1414,7 +1414,7 @@
     name: Chrome
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tablet
     brand: Contixo
@@ -1432,7 +1432,7 @@
     name: Chrome
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: Contixo
@@ -1450,7 +1450,7 @@
     name: Chrome
     version: "77.0.3865.73"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: tablet
     brand: Contixo
@@ -1504,7 +1504,7 @@
     name: Chrome Webview
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Aoson
@@ -1522,7 +1522,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Aoson
@@ -1540,7 +1540,7 @@
     name: Chrome
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Aoson
@@ -1558,7 +1558,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Aoson
@@ -1576,7 +1576,7 @@
     name: Chrome
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Aoson
@@ -1594,7 +1594,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Aoson
@@ -1612,7 +1612,7 @@
     name: Chrome
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Aoson
@@ -1630,7 +1630,7 @@
     name: Chrome Webview
     version: "83.0.4103.106"
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.106"
   device:
     type: tablet
     brand: Positivo BGH
@@ -1864,7 +1864,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: 3Q
@@ -1882,7 +1882,7 @@
     name: Chrome
     version: "29.0.1547.72"
     engine: Blink
-    engine_version: ""
+    engine_version: "29.0.1547.72"
   device:
     type: tablet
     brand: 3Q
@@ -1900,7 +1900,7 @@
     name: Chrome
     version: "30.0.1599.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.92"
   device:
     type: tablet
     brand: 3Q
@@ -2350,7 +2350,7 @@
     name: Chrome
     version: "30.0.1599.82"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.82"
   device:
     type: tablet
     brand: 3Q
@@ -2368,7 +2368,7 @@
     name: Chrome
     version: "39.0.2171.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.59"
   device:
     type: tablet
     brand: 3Q
@@ -2386,7 +2386,7 @@
     name: Chrome Mobile
     version: "30.0.1599.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.92"
   device:
     type: tablet
     brand: 3Q
@@ -2422,7 +2422,7 @@
     name: Yandex Browser
     version: "14.5.1847.18432.00"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.131"
   device:
     type: tablet
     brand: 3Q
@@ -2656,7 +2656,7 @@
     name: Chrome
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: 3Q
@@ -2710,7 +2710,7 @@
     name: Chrome
     version: "35.0.1916.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.138"
   device:
     type: tablet
     brand: 3Q
@@ -2728,7 +2728,7 @@
     name: Yandex Browser
     version: "14.10.2062.12160.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.124"
   device:
     type: tablet
     brand: 3Q
@@ -2872,7 +2872,7 @@
     name: Chrome
     version: "38.0.2125.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.114"
   device:
     type: tablet
     brand: 3Q
@@ -2890,7 +2890,7 @@
     name: Chrome Mobile
     version: "35.0.1916.138"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.138"
   device:
     type: tablet
     brand: 3Q
@@ -2908,7 +2908,7 @@
     name: Chrome Mobile
     version: "38.0.2125.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.114"
   device:
     type: tablet
     brand: 3Q
@@ -3034,7 +3034,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: 3Q
@@ -3070,7 +3070,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Shuttle
@@ -3088,7 +3088,7 @@
     name: Chrome
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Shuttle
@@ -3106,7 +3106,7 @@
     name: Chrome
     version: "43.0.2357.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "43.0.2357.93"
   device:
     type: tablet
     brand: Shuttle
@@ -3160,7 +3160,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: 4Good
@@ -3178,7 +3178,7 @@
     name: Chrome
     version: "48.0.2564.95"
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.95"
   device:
     type: tablet
     brand: 4Good
@@ -3196,7 +3196,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: NextTab
@@ -3214,7 +3214,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: NextTab
@@ -3232,7 +3232,7 @@
     name: Chrome Webview
     version: "84.0.4147.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tablet
     brand: Philco
@@ -3250,7 +3250,7 @@
     name: Chrome
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Syrox
@@ -3268,7 +3268,7 @@
     name: Chrome
     version: "74.0.3729.157"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Syrox
@@ -3286,7 +3286,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Syrox
@@ -3304,7 +3304,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Syrox
@@ -3322,7 +3322,7 @@
     name: Chrome
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: TurboKids
@@ -3340,7 +3340,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: TurboKids
@@ -3358,7 +3358,7 @@
     name: Chrome
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tablet
     brand: TurboKids
@@ -3376,7 +3376,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Mystery
@@ -3556,7 +3556,7 @@
     name: Opera
     version: "53.1.2569.142848"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tablet
     brand: Anry
@@ -3574,7 +3574,7 @@
     name: Chrome
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: Anry
@@ -3592,7 +3592,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Anry
@@ -3610,7 +3610,7 @@
     name: Chrome Mobile
     version: "79.0.3945.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tablet
     brand: Torex
@@ -3736,7 +3736,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Time2
@@ -3772,7 +3772,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Tetratab
@@ -3790,7 +3790,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Allview
@@ -3808,7 +3808,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Allview
@@ -3844,7 +3844,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Allview
@@ -3862,7 +3862,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Allview
@@ -3880,7 +3880,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Allview
@@ -3898,7 +3898,7 @@
     name: Chrome Mobile
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Allview
@@ -3952,7 +3952,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Allview
@@ -3970,7 +3970,7 @@
     name: Chrome
     version: "77.0.3865.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tablet
     brand: Allview
@@ -3988,7 +3988,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: Allview
@@ -4006,7 +4006,7 @@
     name: Chrome
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: tablet
     brand: Allview
@@ -4024,7 +4024,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Ask
@@ -4042,7 +4042,7 @@
     name: Chrome
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: Allwinner
@@ -4060,7 +4060,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Allwinner
@@ -4114,7 +4114,7 @@
     name: Opera
     version: "54.3.2672.50220"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Assistant
@@ -4132,7 +4132,7 @@
     name: Chrome
     version: "78.0.3904.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tablet
     brand: Assistant
@@ -4150,7 +4150,7 @@
     name: Chrome
     version: "75.0.3770.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.89"
   device:
     type: tablet
     brand: Assistant
@@ -4186,7 +4186,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Assistant
@@ -4222,7 +4222,7 @@
     name: Opera
     version: "54.2.2672.49907"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tablet
     brand: Assistant
@@ -4240,7 +4240,7 @@
     name: Chrome
     version: "54.0.2840.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "54.0.2840.85"
   device:
     type: tablet
     brand: Assistant
@@ -4294,7 +4294,7 @@
     name: Chrome
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: tablet
     brand: Arian Space
@@ -4312,7 +4312,7 @@
     name: Yandex Browser
     version: "7.45"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2749.0"
   device:
     type: tablet
     brand: Arian Space
@@ -4330,7 +4330,7 @@
     name: Chrome
     version: "74.0.3729.112"
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.112"
   device:
     type: tablet
     brand: Arian Space
@@ -4348,7 +4348,7 @@
     name: Yandex Browser
     version: "7.45"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2749.0"
   device:
     type: tablet
     brand: Arian Space
@@ -4384,7 +4384,7 @@
     name: Chrome
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: tablet
     brand: Acer
@@ -4402,7 +4402,7 @@
     name: Chrome
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: tablet
     brand: Acer
@@ -4420,7 +4420,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Acer
@@ -4456,7 +4456,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Acer
@@ -4546,7 +4546,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Acer
@@ -4564,7 +4564,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Acer
@@ -4582,7 +4582,7 @@
     name: Chrome
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Acer
@@ -4600,7 +4600,7 @@
     name: Chrome
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Acer
@@ -4618,7 +4618,7 @@
     name: Chrome
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: tablet
     brand: Acer
@@ -4636,7 +4636,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Acer
@@ -4654,7 +4654,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Acer
@@ -4672,7 +4672,7 @@
     name: Chrome
     version: "77.0.3865.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tablet
     brand: Acer
@@ -4690,7 +4690,7 @@
     name: Chrome
     version: "79.0.3945.79"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tablet
     brand: Acer
@@ -4708,7 +4708,7 @@
     name: Chrome
     version: "38.0.2125.102"
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.102"
   device:
     type: tablet
     brand: Acer
@@ -4726,7 +4726,7 @@
     name: Chrome
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: tablet
     brand: Acer
@@ -4744,7 +4744,7 @@
     name: Chrome
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: tablet
     brand: Acer
@@ -4762,7 +4762,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Acer
@@ -4780,7 +4780,7 @@
     name: Chrome Mobile
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: Acer
@@ -4798,7 +4798,7 @@
     name: Chrome
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Acer
@@ -4816,7 +4816,7 @@
     name: Chrome
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: Acer
@@ -4834,7 +4834,7 @@
     name: Chrome
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: Acer
@@ -4852,7 +4852,7 @@
     name: Chrome
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Acer
@@ -4870,7 +4870,7 @@
     name: Chrome
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: tablet
     brand: Acer
@@ -4888,7 +4888,7 @@
     name: Chrome
     version: "76.0.3809.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tablet
     brand: Acer
@@ -4906,7 +4906,7 @@
     name: Chrome
     version: "57.0.2987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: tablet
     brand: Acer
@@ -4924,7 +4924,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Acer
@@ -4942,7 +4942,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Acer
@@ -4960,7 +4960,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Acer
@@ -4978,7 +4978,7 @@
     name: Chrome
     version: "73.0.3683.75"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.75"
   device:
     type: tablet
     brand: Acer
@@ -4996,7 +4996,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Acer
@@ -5032,7 +5032,7 @@
     name: Chrome
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: Acer
@@ -5122,7 +5122,7 @@
     name: Chrome
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: Acer
@@ -5140,7 +5140,7 @@
     name: Chrome Mobile
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Acer
@@ -5248,7 +5248,7 @@
     name: Chrome
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: tablet
     brand: Acer
@@ -5320,7 +5320,7 @@
     name: Chrome Webview
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: tablet
     brand: Advance
@@ -5338,7 +5338,7 @@
     name: Chrome
     version: "70.0.3538.110"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tablet
     brand: AVH
@@ -5374,7 +5374,7 @@
     name: Chrome Webview
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: AVH
@@ -5410,7 +5410,7 @@
     name: Opera
     version: "24.0.1565.82529"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.117"
   device:
     type: tablet
     brand: Akai
@@ -5428,7 +5428,7 @@
     name: Chrome Webview
     version: "49.0.2623.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.105"
   device:
     type: tablet
     brand: Akai
@@ -5446,7 +5446,7 @@
     name: Chrome Mobile
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: tablet
     brand: Akai
@@ -5464,7 +5464,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Akai
@@ -5482,7 +5482,7 @@
     name: Chrome Mobile
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Alcatel
@@ -5500,7 +5500,7 @@
     name: Chrome Mobile
     version: "79.0.3945.116"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tablet
     brand: Alcatel
@@ -5518,7 +5518,7 @@
     name: Chrome Mobile
     version: "80.0.3987.132"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tablet
     brand: Alcatel
@@ -5536,7 +5536,7 @@
     name: Chrome Mobile
     version: "80.0.3987.149"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: tablet
     brand: Alcatel
@@ -5554,7 +5554,7 @@
     name: Chrome
     version: "75.0.3770.101"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: Alcatel
@@ -5572,7 +5572,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Alcatel
@@ -5626,7 +5626,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Alcatel
@@ -5644,7 +5644,7 @@
     name: Chrome Webview
     version: "59.0.3071.125"
     engine: Blink
-    engine_version: ""
+    engine_version: "59.0.3071.125"
   device:
     type: tablet
     brand: Alcatel
@@ -5662,7 +5662,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Alcatel
@@ -5680,7 +5680,7 @@
     name: Chrome Mobile
     version: "46.0.2490.76"
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: tablet
     brand: Alcatel
@@ -5698,7 +5698,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Alcatel
@@ -5716,7 +5716,7 @@
     name: Chrome
     version: "49.0.2623.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: tablet
     brand: Alcatel
@@ -5734,7 +5734,7 @@
     name: Chrome Mobile
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Alcatel
@@ -5752,7 +5752,7 @@
     name: Chrome
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: Alcatel
@@ -5770,7 +5770,7 @@
     name: Chrome
     version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: tablet
     brand: Alcatel
@@ -5788,7 +5788,7 @@
     name: Chrome Mobile
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: tablet
     brand: Alcatel
@@ -5806,7 +5806,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Alcatel
@@ -5824,7 +5824,7 @@
     name: Chrome
     version: "37.0.2062.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.117"
   device:
     type: tablet
     brand: Alcatel
@@ -5842,7 +5842,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Alcatel
@@ -5860,7 +5860,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Alcatel
@@ -6040,7 +6040,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Arnova
@@ -6148,7 +6148,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Arnova
@@ -6364,7 +6364,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Arnova
@@ -6562,7 +6562,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Arnova
@@ -6870,7 +6870,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Archos
@@ -6906,7 +6906,7 @@
     name: Chrome
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: tablet
     brand: Archos
@@ -6924,7 +6924,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Archos
@@ -6942,7 +6942,7 @@
     name: Chrome
     version: "78.0.3904.62"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tablet
     brand: Archos
@@ -6960,7 +6960,7 @@
     name: Chrome
     version: "32.0.1700.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.99"
   device:
     type: tablet
     brand: Archos
@@ -7104,7 +7104,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Archos
@@ -7140,7 +7140,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Archos
@@ -7228,7 +7228,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Archos
@@ -7264,7 +7264,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Archos
@@ -7300,7 +7300,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Archos
@@ -7354,7 +7354,7 @@
     name: Chrome
     version: "31.0.1650.59"
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.59"
   device:
     type: tablet
     brand: Archos
@@ -7390,7 +7390,7 @@
     name: Chrome
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: tablet
     brand: Archos
@@ -7444,7 +7444,7 @@
     name: Chrome
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: tablet
     brand: Asus
@@ -7480,7 +7480,7 @@
     name: Chrome
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: tablet
     brand: Asus
@@ -7498,7 +7498,7 @@
     name: Chrome
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: tablet
     brand: Asus
@@ -7516,7 +7516,7 @@
     name: Chrome
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: tablet
     brand: Asus
@@ -7534,7 +7534,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Asus
@@ -7552,7 +7552,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: Asus
@@ -7570,7 +7570,7 @@
     name: Chrome
     version: "52.0.2743.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.98"
   device:
     type: tablet
     brand: Asus
@@ -7588,7 +7588,7 @@
     name: Chrome
     version: "58.0.3029.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "58.0.3029.83"
   device:
     type: tablet
     brand: Asus
@@ -7606,7 +7606,7 @@
     name: Chrome
     version: "36.0.1985.131"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.131"
   device:
     type: tablet
     brand: Asus
@@ -7624,7 +7624,7 @@
     name: Chrome
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: tablet
     brand: Asus
@@ -7642,7 +7642,7 @@
     name: Chrome Webview
     version: "30.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tablet
     brand: Asus
@@ -7660,7 +7660,7 @@
     name: Opera
     version: "16.0.1212.65583"
     engine: Blink
-    engine_version: ""
+    engine_version: "29.0.1547.72"
   device:
     type: tablet
     brand: Asus
@@ -7678,7 +7678,7 @@
     name: Chrome
     version: "33.0.1750.136"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.136"
   device:
     type: tablet
     brand: Asus
@@ -7696,7 +7696,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Asus
@@ -7714,7 +7714,7 @@
     name: Chrome
     version: "28.0.1500.94"
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.94"
   device:
     type: tablet
     brand: Asus
@@ -7732,7 +7732,7 @@
     name: Chrome
     version: "30.0.1599.92"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.92"
   device:
     type: tablet
     brand: Asus
@@ -7750,7 +7750,7 @@
     name: Chrome
     version: "34.0.1847.114"
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.114"
   device:
     type: tablet
     brand: Asus
@@ -7786,7 +7786,7 @@
     name: Chrome
     version: "36.0.1985.135"
     engine: Blink
-    engine_version: ""
+    engine_version: "36.0.1985.135"
   device:
     type: tablet
     brand: Asus
@@ -7804,7 +7804,7 @@
     name: Chrome
     version: "40.0.2214.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "40.0.2214.109"
   device:
     type: tablet
     brand: Asus
@@ -7858,7 +7858,7 @@
     name: Chrome
     version: "35.0.1916.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.117"
   device:
     type: tablet
     brand: Asus
@@ -7894,7 +7894,7 @@
     name: Chrome
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: tablet
     brand: Asus
@@ -7912,7 +7912,7 @@
     name: Chrome
     version: "49.0.2623.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: tablet
     brand: Asus
@@ -7966,7 +7966,7 @@
     name: Chrome
     version: "33.0.1750.166"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.1750.166"
   device:
     type: tablet
     brand: Asus
@@ -8020,7 +8020,7 @@
     name: Opera
     version: "19.0.1340.69721"
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.72"
   device:
     type: tablet
     brand: Asus
@@ -8074,7 +8074,7 @@
     name: Chrome
     version: "75.0.3770.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tablet
     brand: Asus
@@ -8092,7 +8092,7 @@
     name: Chrome
     version: "78.0.3904.108"
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tablet
     brand: Asus
@@ -8110,7 +8110,7 @@
     name: Chrome
     version: "79.0.3945.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tablet
     brand: Asus
@@ -8128,7 +8128,7 @@
     name: Chrome
     version: "50.0.2661.89"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: tablet
     brand: Asus
@@ -8146,7 +8146,7 @@
     name: Chrome
     version: "55.0.2883.91"
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tablet
     brand: Asus
@@ -8164,7 +8164,7 @@
     name: Chrome
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Asus
@@ -8182,7 +8182,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Asus
@@ -8200,7 +8200,7 @@
     name: Chrome
     version: "68.0.3440.85"
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.85"
   device:
     type: tablet
     brand: Asus
@@ -8218,7 +8218,7 @@
     name: Chrome
     version: "69.0.3497.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.86"
   device:
     type: tablet
     brand: Asus
@@ -8236,7 +8236,7 @@
     name: Chrome
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Asus
@@ -8254,7 +8254,7 @@
     name: Chrome
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Asus
@@ -8272,7 +8272,7 @@
     name: Chrome Webview
     version: "67.0.3396.87"
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tablet
     brand: Asus
@@ -8290,7 +8290,7 @@
     name: Chrome
     version: "66.0.3359.158"
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tablet
     brand: Asus
@@ -8308,7 +8308,7 @@
     name: Chrome
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Asus
@@ -8326,7 +8326,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Asus
@@ -8344,7 +8344,7 @@
     name: Chrome Webview
     version: "50.0.2661.86"
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.86"
   device:
     type: tablet
     brand: Asus
@@ -8362,7 +8362,7 @@
     name: Chrome
     version: "71.0.3578.83"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.83"
   device:
     type: tablet
     brand: Asus
@@ -8380,7 +8380,7 @@
     name: Chrome
     version: "60.0.3112.107"
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.107"
   device:
     type: tablet
     brand: Asus
@@ -8398,7 +8398,7 @@
     name: Chrome
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Asus
@@ -8416,7 +8416,7 @@
     name: Yandex Browser
     version: "17.11.1.628.01"
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.94"
   device:
     type: tablet
     brand: Asus
@@ -8434,7 +8434,7 @@
     name: Chrome
     version: "69.0.3497.100"
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tablet
     brand: Asus
@@ -8452,7 +8452,7 @@
     name: Chrome
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: tablet
     brand: Asus
@@ -8470,7 +8470,7 @@
     name: Chrome
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: tablet
     brand: Asus
@@ -8488,7 +8488,7 @@
     name: Chrome
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: tablet
     brand: Asus
@@ -8506,7 +8506,7 @@
     name: Chrome
     version: "71.0.3578.99"
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tablet
     brand: Asus
@@ -8524,7 +8524,7 @@
     name: Chrome
     version: "63.0.3239.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Asus
@@ -8542,7 +8542,7 @@
     name: Chrome
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: tablet
     brand: Asus
@@ -8560,7 +8560,7 @@
     name: Chrome
     version: "72.0.3626.105"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: tablet
     brand: Asus
@@ -8578,7 +8578,7 @@
     name: Chrome
     version: "70.0.3538.80"
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tablet
     brand: Asus
@@ -8596,7 +8596,7 @@
     name: Chrome
     version: "65.0.3325.109"
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tablet
     brand: Asus
@@ -8614,7 +8614,7 @@
     name: Chrome
     version: "61.0.3163.98"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tablet
     brand: Asus
@@ -8632,7 +8632,7 @@
     name: Chrome
     version: "64.0.3282.137"
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.137"
   device:
     type: tablet
     brand: Asus
@@ -8720,7 +8720,7 @@
     name: Chrome
     version: "42.0.2311.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tablet
     brand: Ainol
@@ -8738,7 +8738,7 @@
     name: Chrome
     version: "76.0.3809.111"
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tablet
     brand: Ainol
@@ -8756,7 +8756,7 @@
     name: Chrome Webview
     version: "33.0.0.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: Ainol
@@ -8792,7 +8792,7 @@
     name: Chrome
     version: "41.0.2272.96"
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.96"
   device:
     type: tablet
     brand: Ainol
@@ -8880,7 +8880,7 @@
     name: Opera
     version: "46.3.2246.127744"
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tablet
     brand: Ainol
@@ -8970,7 +8970,7 @@
     name: Chrome
     version: "39.0.2171.93"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: tablet
     brand: Ainol
@@ -8988,7 +8988,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tablet
     brand: X-View
@@ -9006,7 +9006,7 @@
     name: Chrome
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: tablet
     brand: AllDocube
@@ -9024,7 +9024,7 @@
     name: Chrome
     version: 98.0.4758.101
     engine: Blink
-    engine_version: ""
+    engine_version: "98.0.4758.101"
   device:
     type: tablet
     brand: EGL

--- a/Tests/fixtures/tv-1.yml
+++ b/Tests/fixtures/tv-1.yml
@@ -10,7 +10,7 @@
     name: Chrome
     version: 68.0.3440.106
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.106"
   device:
     type: tv
     brand: LG
@@ -28,7 +28,7 @@
     name: Chrome
     version: 53.0.2785.34
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.34"
   device:
     type: tv
     brand: LG
@@ -64,7 +64,7 @@
     name: Chrome
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tv
     brand: Telefunken
@@ -226,7 +226,7 @@
     name: Yandex Browser
     version: 20.11.0.180.01
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tv
     brand: Beelink
@@ -262,7 +262,7 @@
     name: Chrome
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tv
     brand: Savio
@@ -280,7 +280,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tv
     brand: NEXON
@@ -298,7 +298,7 @@
     name: Chrome
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tv
     brand: Alfawise
@@ -316,7 +316,7 @@
     name: Chrome
     version: 90.0.4430.82
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.82"
   device:
     type: tv
     brand: Kivi
@@ -334,7 +334,7 @@
     name: Chrome Webview
     version: 44.0.2403.119
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: tv
     brand: WIWA
@@ -352,7 +352,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: WIWA
@@ -396,7 +396,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tv
     brand: Rombica
@@ -414,7 +414,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tv
     brand: Smotreshka
@@ -432,7 +432,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tv
     brand: Smotreshka
@@ -450,7 +450,7 @@
     name: Chrome
     version: 84.0.4147.105
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.105"
   device:
     type: tv
     brand: Smotreshka
@@ -468,7 +468,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tv
     brand: Smotreshka
@@ -486,7 +486,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tv
     brand: IconBIT
@@ -504,7 +504,7 @@
     name: Chrome
     version: 80.0.3987.40
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.40"
   device:
     type: tv
     brand: IconBIT
@@ -522,7 +522,7 @@
     name: Chrome
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tv
     brand: Vinga
@@ -540,7 +540,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tv
     brand: Erisson
@@ -558,7 +558,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: BBK
@@ -576,7 +576,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tv
     brand: Lumus
@@ -594,7 +594,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tv
     brand: Novex
@@ -612,7 +612,7 @@
     name: Chrome
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tv
     brand: Erisson
@@ -630,7 +630,7 @@
     name: Chrome
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tv
     brand: Digma
@@ -648,7 +648,7 @@
     name: Chrome
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tv
     brand: Digma
@@ -666,7 +666,7 @@
     name: Chrome Webview
     version: 33.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tv
     brand: AMCV
@@ -684,7 +684,7 @@
     name: Chrome
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tv
     brand: AMCV
@@ -702,7 +702,7 @@
     name: Opera
     version: 53.1.2569.142848
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tv
     brand: AMCV
@@ -720,7 +720,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: AMCV
@@ -738,7 +738,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tv
     brand: Digma
@@ -792,7 +792,7 @@
     name: Chrome
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tv
     brand: BBK
@@ -810,7 +810,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: ECON
@@ -828,7 +828,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tv
     brand: ECON
@@ -846,7 +846,7 @@
     name: Chrome
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tv
     brand: Leben
@@ -864,7 +864,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tv
     brand: Starwind
@@ -882,7 +882,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tv
     brand: Starwind
@@ -900,7 +900,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tv
     brand: Starwind
@@ -918,7 +918,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: Telefunken
@@ -936,7 +936,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tv
     brand: Starwind
@@ -954,7 +954,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tv
     brand: ECON
@@ -972,7 +972,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tv
     brand: Kvant
@@ -990,7 +990,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tv
     brand: Hi
@@ -1008,7 +1008,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tv
     brand: Hi
@@ -1026,7 +1026,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tv
     brand: AKIRA
@@ -1044,7 +1044,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tv
     brand: AKIRA
@@ -1062,7 +1062,7 @@
     name: Chrome Webview
     version: 48.0.2542.0
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2542.0"
   device:
     type: tv
     brand: Hi
@@ -1080,7 +1080,7 @@
     name: Chrome
     version: 72.0.3626.105
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: tv
     brand: Elekta
@@ -1098,7 +1098,7 @@
     name: Chrome
     version: 72.0.3626.76
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.76"
   device:
     type: tv
     brand: Elekta
@@ -1116,7 +1116,7 @@
     name: Chrome
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tv
     brand: Elekta
@@ -1134,7 +1134,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tv
     brand: Elekta
@@ -1152,7 +1152,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tv
     brand: Elekta
@@ -1170,7 +1170,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tv
     brand: Elekta
@@ -1188,7 +1188,7 @@
     name: Chrome
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: tv
     brand: Elekta
@@ -1206,7 +1206,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tv
     brand: Lumus
@@ -1224,7 +1224,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tv
     brand: Lumus
@@ -1242,7 +1242,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: Lumus
@@ -1260,7 +1260,7 @@
     name: Chrome Webview
     version: 33.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tv
     brand: Lumus
@@ -1278,7 +1278,7 @@
     name: Chrome
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tv
     brand: Lumus
@@ -1296,7 +1296,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tv
     brand: Leben
@@ -1314,7 +1314,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tv
     brand: Starwind
@@ -1332,7 +1332,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: Starwind
@@ -1350,7 +1350,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tv
     brand: Starwind
@@ -1368,7 +1368,7 @@
     name: Yandex Browser
     version: 18.11.1.1011.01
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: tv
     brand: Leff
@@ -1386,7 +1386,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: Digma
@@ -1422,7 +1422,7 @@
     name: Chrome
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tv
     brand: Telefunken
@@ -1440,7 +1440,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: Telefunken
@@ -1458,7 +1458,7 @@
     name: Chrome
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tv
     brand: Telefunken
@@ -1476,7 +1476,7 @@
     name: Chrome
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tv
     brand: Telefunken
@@ -1512,7 +1512,7 @@
     name: Opera
     version: 44.1.2254.142341
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tv
     brand: Mystery
@@ -1530,7 +1530,7 @@
     name: Opera
     version: 45.0.2254.144848
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tv
     brand: Mystery
@@ -1548,7 +1548,7 @@
     name: Chrome
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tv
     brand: Mystery
@@ -1566,7 +1566,7 @@
     name: Chrome
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tv
     brand: Mystery
@@ -1584,7 +1584,7 @@
     name: Yandex Browser
     version: 18.11.1.1011.01
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.102"
   device:
     type: tv
     brand: Mystery
@@ -1602,7 +1602,7 @@
     name: Opera
     version: 53.0.2569.141117
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tv
     brand: Mystery
@@ -1620,7 +1620,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: Mystery
@@ -1638,7 +1638,7 @@
     name: Chrome
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tv
     brand: Mystery
@@ -1656,7 +1656,7 @@
     name: Chrome
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tv
     brand: Mystery
@@ -1674,7 +1674,7 @@
     name: Chrome
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tv
     brand: Mystery
@@ -1692,7 +1692,7 @@
     name: Opera
     version: 54.2.2672.49907
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tv
     brand: JVC
@@ -1710,7 +1710,7 @@
     name: Opera
     version: 53.1.2569.142848
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tv
     brand: JVC
@@ -1728,7 +1728,7 @@
     name: Opera
     version: 48.2.2331.133274
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: tv
     brand: JVC
@@ -1746,7 +1746,7 @@
     name: Yandex Browser
     version: 17.11.0.526.01
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.94"
   device:
     type: tv
     brand: JVC
@@ -1764,7 +1764,7 @@
     name: Chrome Webview
     version: 33.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tv
     brand: JVC
@@ -1782,7 +1782,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tv
     brand: Loview
@@ -1800,7 +1800,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: Loview
@@ -1818,7 +1818,7 @@
     name: Chrome
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tv
     brand: Erisson
@@ -1836,7 +1836,7 @@
     name: Chrome
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tv
     brand: Erisson
@@ -1854,7 +1854,7 @@
     name: Chrome
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tv
     brand: Yuno
@@ -1872,7 +1872,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tv
     brand: Loview
@@ -1890,7 +1890,7 @@
     name: Chrome
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tv
     brand: YASIN
@@ -1908,7 +1908,7 @@
     name: Chrome Webview
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tv
     brand: Ok
@@ -1926,7 +1926,7 @@
     name: Mobile Silk
     version: 73.5.7
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tv
     brand: Toshiba
@@ -2066,7 +2066,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: DIGIFORS
@@ -2102,7 +2102,7 @@
     name: Chrome
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tv
     brand: Openbox
@@ -2120,7 +2120,7 @@
     name: Chrome
     version: 91.0.4472.88
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.88"
   device:
     type: tv
     brand: Openbox
@@ -2138,7 +2138,7 @@
     name: Chrome
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tv
     brand: ProVision
@@ -2228,7 +2228,7 @@
     name: Mobile Silk
     version: 91.1.138
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.114"
   device:
     type: tv
     brand: Anker
@@ -2246,7 +2246,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tv
     brand: MTC
@@ -2264,7 +2264,7 @@
     name: Chrome
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tv
     brand: Perfeo
@@ -2318,7 +2318,7 @@
     name: Chrome Webview
     version: 81.0.4044.117
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.117"
   device:
     type: tv
     brand: Google
@@ -2336,7 +2336,7 @@
     name: Chrome Webview
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tv
     brand: Google
@@ -2354,7 +2354,7 @@
     name: Chrome
     version: 42.0.2311.111
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.111"
   device:
     type: tv
     brand: IconBIT
@@ -2372,7 +2372,7 @@
     name: Chrome
     version: 85.0.4183.101
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.101"
   device:
     type: tv
     brand: Kanji
@@ -2390,7 +2390,7 @@
     name: Chrome
     version: 85.0.4183.81
     engine: Blink
-    engine_version: ""
+    engine_version: "85.0.4183.81"
   device:
     type: tv
     brand: Galaxy Innovations
@@ -2408,7 +2408,7 @@
     name: Chrome
     version: 69.0.3497.91
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: tv
     brand: Mito
@@ -2426,7 +2426,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tv
     brand: Tanix
@@ -2444,7 +2444,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tv
     brand: Tanix
@@ -2462,7 +2462,7 @@
     name: Chrome Webview
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: tv
     brand: Geotex
@@ -2480,7 +2480,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tv
     brand: Beelink
@@ -2498,7 +2498,7 @@
     name: Opera
     version: 58.0.2254.58176
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: DEXP
@@ -2542,7 +2542,7 @@
     name: Chrome
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: tv
     brand: Ugoos
@@ -2560,7 +2560,7 @@
     name: Chrome Webview
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tv
     brand: STRONG
@@ -2594,7 +2594,7 @@
     name: Chrome Webview
     version: 51.0.2704.91
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.91"
   device:
     type: tv
     brand: Polar
@@ -2630,7 +2630,7 @@
     name: Chrome
     version: 95.0.4638.50
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.50"
   device:
     type: tv
     brand: MyGica
@@ -2648,7 +2648,7 @@
     name: Chrome
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tv
     brand: MyGica
@@ -2666,7 +2666,7 @@
     name: Chrome
     version: 91.0.4472.120
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.120"
   device:
     type: tv
     brand: MyGica
@@ -2684,7 +2684,7 @@
     name: Chrome
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: tv
     brand: MyGica
@@ -2702,7 +2702,7 @@
     name: Chrome
     version: 91.0.4472.101
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.4472.101"
   device:
     type: tv
     brand: MyGica
@@ -2720,7 +2720,7 @@
     name: Chrome Webview
     version: 74.0.3729.186
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.186"
   device:
     type: tv
     brand: Paladin
@@ -2738,7 +2738,7 @@
     name: Chrome Webview
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tv
     brand: Haier
@@ -2756,7 +2756,7 @@
     name: Chrome Webview
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tv
     brand: PolarLine
@@ -2774,7 +2774,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tv
     brand: Rombica
@@ -2792,7 +2792,7 @@
     name: Chrome
     version: 88.0.4324.152
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.152"
   device:
     type: tv
     brand: NEXON
@@ -2810,7 +2810,7 @@
     name: Chrome Mobile
     version: 97.0.4692.20
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.20"
   device:
     type: tv
     brand: TCL
@@ -2846,7 +2846,7 @@
     name: Chrome Webview
     version: 64.0.3282.123
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: tv
     brand: Novex
@@ -2864,7 +2864,7 @@
     name: Chrome Mobile
     version: 57.0.2987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: tv
     brand: TCL
@@ -2882,7 +2882,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tv
     brand: Beelink
@@ -2900,7 +2900,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tv
     brand: Rombica
@@ -2936,7 +2936,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tv
     brand: Tanix
@@ -2954,7 +2954,7 @@
     name: Chrome
     version: 80.0.3987.149
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.149"
   device:
     type: tv
     brand: Rombica
@@ -2972,7 +2972,7 @@
     name: Chrome Webview
     version: 64.0.3282.123
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: tv
     brand: Polar
@@ -2990,7 +2990,7 @@
     name: Yandex Browser
     version: 21.23.1
     engine: Blink
-    engine_version: ""
+    engine_version: "88.0.4324.182"
   device:
     type: tv
     brand: Perfeo
@@ -3008,7 +3008,7 @@
     name: Chrome
     version: 93.0.4577.62
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.62"
   device:
     type: tv
     brand: Rombica
@@ -3026,7 +3026,7 @@
     name: Chrome Webview
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tv
     brand: Erisson
@@ -3060,7 +3060,7 @@
     name: Chrome
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: tv
     brand: Rombica
@@ -3078,7 +3078,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tv
     brand: Rombica
@@ -3096,7 +3096,7 @@
     name: Chrome
     version: 77.0.3865.73
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: tv
     brand: Rombica
@@ -3114,7 +3114,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tv
     brand: Rombica
@@ -3132,7 +3132,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: Rombica
@@ -3150,7 +3150,7 @@
     name: Opera
     version: 63.3.3216.58675
     engine: Blink
-    engine_version: ""
+    engine_version: "89.0.4389.105"
   device:
     type: tv
     brand: Rombica
@@ -3168,7 +3168,7 @@
     name: Chrome
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tv
     brand: Rombica
@@ -3186,7 +3186,7 @@
     name: Chrome Webview
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tv
     brand: Rombica
@@ -3204,7 +3204,7 @@
     name: Chrome
     version: 92.0.4515.131
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.131"
   device:
     type: tv
     brand: Rombica
@@ -3222,7 +3222,7 @@
     name: Chrome Webview
     version: 51.0.2704.91
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.91"
   device:
     type: tv
     brand: Telefunken
@@ -3240,7 +3240,7 @@
     name: Chrome Webview
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tv
     brand: Shivaki
@@ -3258,7 +3258,7 @@
     name: Chrome Webview
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tv
     brand: Shivaki
@@ -3276,7 +3276,7 @@
     name: Chrome Webview
     version: 64.0.3282.123
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: tv
     brand: Shivaki
@@ -3294,7 +3294,7 @@
     name: Chrome
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tv
     brand: SUNWIND
@@ -3312,7 +3312,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: Kivi
@@ -3330,7 +3330,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tv
     brand: H96
@@ -3366,7 +3366,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tv
     brand: Andowl
@@ -3384,7 +3384,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tv
     brand: MDTV
@@ -3402,7 +3402,7 @@
     name: Chrome
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tv
     brand: ""
@@ -3420,7 +3420,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tv
     brand: ""
@@ -3438,7 +3438,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tv
     brand: MBOX
@@ -3456,7 +3456,7 @@
     name: Chrome Webview
     version: 33.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tv
     brand: ""
@@ -3474,7 +3474,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tv
     brand: Q-Box
@@ -3492,7 +3492,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tv
     brand: ""
@@ -3510,7 +3510,7 @@
     name: Chrome
     version: 50.0.2661.89
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: tv
     brand: ""
@@ -3528,7 +3528,7 @@
     name: Chrome
     version: 93.0.4577.82
     engine: Blink
-    engine_version: ""
+    engine_version: "93.0.4577.82"
   device:
     type: tv
     brand: ""
@@ -3546,7 +3546,7 @@
     name: Chrome Webview
     version: 81.0.4044.111
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.111"
   device:
     type: tv
     brand: Hisense
@@ -3580,7 +3580,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tv
     brand: ""
@@ -3598,7 +3598,7 @@
     name: Opera
     version: 66.1.3445.62185
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tv
     brand: Mecool
@@ -3616,7 +3616,7 @@
     name: Chrome Webview
     version: 64.0.3282.123
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: tv
     brand: Shivaki
@@ -3634,7 +3634,7 @@
     name: Chrome
     version: 69.0.3497.91
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: tv
     brand: Telefunken
@@ -3652,7 +3652,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tv
     brand: Divisat
@@ -3670,7 +3670,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tv
     brand: Divisat
@@ -3688,7 +3688,7 @@
     name: Chrome
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: tv
     brand: ArtLine
@@ -3706,7 +3706,7 @@
     name: Chrome
     version: 69.0.3497.91
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: tv
     brand: BBK
@@ -3724,7 +3724,7 @@
     name: Chrome
     version: 69.0.3497.91
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: tv
     brand: BBK
@@ -3742,7 +3742,7 @@
     name: Chrome
     version: 69.0.3497.91
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: tv
     brand: BBK
@@ -3760,7 +3760,7 @@
     name: Chrome Webview
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tv
     brand: Digma
@@ -3778,7 +3778,7 @@
     name: Chrome Webview
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tv
     brand: Digma
@@ -3796,7 +3796,7 @@
     name: Chrome
     version: 69.0.3497.91
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.91"
   device:
     type: tv
     brand: BBK
@@ -3814,7 +3814,7 @@
     name: Chrome Webview
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tv
     brand: Asano
@@ -3832,7 +3832,7 @@
     name: Chrome Webview
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tv
     brand: Asano
@@ -3850,7 +3850,7 @@
     name: Chrome Webview
     version: 64.0.3282.123
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: tv
     brand: Leff
@@ -3868,7 +3868,7 @@
     name: Chrome Webview
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tv
     brand: Kivi
@@ -3904,7 +3904,7 @@
     name: Chrome Mobile
     version: 72.0.3626.121
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: tv
     brand: Orbita
@@ -4012,7 +4012,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tv
     brand: Formuler
@@ -4030,7 +4030,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tv
     brand: Magicsee
@@ -4048,7 +4048,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tv
     brand: Minix
@@ -4066,7 +4066,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tv
     brand: Pendoo
@@ -4084,7 +4084,7 @@
     name: Chrome
     version: 79.0.3945.116
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.116"
   device:
     type: tv
     brand: Transpeed
@@ -4498,7 +4498,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: Pioneer
@@ -4516,7 +4516,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: HKPro
@@ -4534,7 +4534,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: Mastertech
@@ -4552,7 +4552,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: 'Krüger&Matz'
@@ -4570,7 +4570,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: ComTrade Tesla
@@ -4811,7 +4811,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: TCL
@@ -4955,7 +4955,7 @@
     name: Opera
     version: 65.2.3381.61420
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.166"
   device:
     type: tv
     brand: H96
@@ -4973,7 +4973,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tv
     brand: ""
@@ -4991,7 +4991,7 @@
     name: Chrome
     version: 92.0.4515.159
     engine: Blink
-    engine_version: ""
+    engine_version: "92.0.4515.159"
   device:
     type: tv
     brand: ""
@@ -5009,7 +5009,7 @@
     name: Chrome Mobile
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tv
     brand: ""
@@ -5027,7 +5027,7 @@
     name: Chrome
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tv
     brand: ""
@@ -5045,7 +5045,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tv
     brand: ""
@@ -5063,7 +5063,7 @@
     name: Chrome
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tv
     brand: ""
@@ -5081,7 +5081,7 @@
     name: Yandex Browser
     version: 21.111.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tv
     brand: Asano
@@ -5099,7 +5099,7 @@
     name: Chrome Webview
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tv
     brand: ""
@@ -5117,7 +5117,7 @@
     name: Opera Devices
     version: 4.21.0.273
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tv
     brand: Sony
@@ -5135,7 +5135,7 @@
     name: Chrome Mobile
     version: 86.0.4240.185
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.185"
   device:
     type: tv
     brand: Atmaca Elektronik
@@ -5153,7 +5153,7 @@
     name: Chrome
     version: 96.0.4664.104
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.104"
   device:
     type: tv
     brand: EVPAD
@@ -5171,7 +5171,7 @@
     name: Chrome
     version: 90.0.4430.91
     engine: Blink
-    engine_version: ""
+    engine_version: "90.0.4430.91"
   device:
     type: tv
     brand: Kingbox
@@ -5189,7 +5189,7 @@
     name: Chrome
     version: 81.0.4044.138
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tv
     brand: MBOX
@@ -5207,7 +5207,7 @@
     name: Opera Devices
     version: 4.7.0.34
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.82"
   device:
     type: tv
     brand: SK Broadband
@@ -5225,7 +5225,7 @@
     name: Opera Devices
     version: 4.6.1.13
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.125"
   device:
     type: tv
     brand: Philips
@@ -5243,7 +5243,7 @@
     name: Opera Devices
     version: 4.2.13.63
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.153"
   device:
     type: tv
     brand: Sony
@@ -5261,7 +5261,7 @@
     name: Opera Devices
     version: 4.2.12.31
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.153"
   device:
     type: tv
     brand: ""
@@ -5279,7 +5279,7 @@
     name: Opera Devices
     version: 4.1.4.56
     engine: Blink
-    engine_version: ""
+    engine_version: "32.0.1700.107"
   device:
     type: tv
     brand: Sony
@@ -5297,7 +5297,7 @@
     name: Yandex Browser
     version: 21.117.1
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tv
     brand: Horizont
@@ -5315,7 +5315,7 @@
     name: Chrome
     version: 95.0.4638.74
     engine: Blink
-    engine_version: ""
+    engine_version: "95.0.4638.74"
   device:
     type: tv
     brand: Vinabox
@@ -5333,7 +5333,7 @@
     name: Opera
     version: 58.4.2878.56737
     engine: Blink
-    engine_version: ""
+    engine_version: "81.0.4044.138"
   device:
     type: tv
     brand: Rombica
@@ -5351,7 +5351,7 @@
     name: Chrome
     version: 97.0.4692.98
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.98"
   device:
     type: tv
     brand: IconBIT
@@ -5369,7 +5369,7 @@
     name: Chrome Webview
     version: 97.0.4692.87
     engine: Blink
-    engine_version: ""
+    engine_version: "97.0.4692.87"
   device:
     type: tv
     brand: Kivi
@@ -5468,7 +5468,7 @@
     name: Chrome Webview
     version: 94.0.4606.61
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.61"
   device:
     type: tv
     brand: Xiaomi
@@ -5486,7 +5486,7 @@
     name: Chrome Webview
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tv
     brand: Kivi
@@ -5504,7 +5504,7 @@
     name: Chrome Webview
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tv
     brand: Liberton
@@ -5522,7 +5522,7 @@
     name: Chrome Mobile
     version: 48.0.2564.95
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.95"
   device:
     type: tv
     brand: Sony
@@ -5540,7 +5540,7 @@
     name: Opera Devices
     version: 4.8.0.17
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.23"
   device:
     type: tv
     brand: Nvidia
@@ -5558,7 +5558,7 @@
     name: Mobile Silk
     version: 96.2.18
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.175"
   device:
     type: tv
     brand: Amazon
@@ -5576,7 +5576,7 @@
     name: Opera Devices
     version: 4.13.5.431
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.99"
   device:
     type: tv
     brand: Techwood
@@ -5594,7 +5594,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tv
     brand: Ergo
@@ -5612,7 +5612,7 @@
     name: Chrome Mobile
     version: 84.0.4147.111
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.111"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5630,7 +5630,7 @@
     name: Chrome Mobile
     version: 84.0.4147.125
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: smartphone
     brand: Xiaomi
@@ -5648,7 +5648,7 @@
     name: Chrome Mobile
     version: 84.0.4147.89
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.89"
   device:
     type: tv
     brand: Xiaomi
@@ -5666,7 +5666,7 @@
     name: Chrome Webview
     version: 86.0.4240.198
     engine: Blink
-    engine_version: ""
+    engine_version: "86.0.4240.198"
   device:
     type: tv
     brand: Xiaomi
@@ -5684,7 +5684,7 @@
     name: Chrome Mobile
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: tv
     brand: Xiaomi
@@ -5702,7 +5702,7 @@
     name: Chrome Webview
     version: 66.0.3359.158
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tv
     brand: Xiaomi
@@ -5720,7 +5720,7 @@
     name: Chrome
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tv
     brand: ""

--- a/Tests/fixtures/tv.yml
+++ b/Tests/fixtures/tv.yml
@@ -115,7 +115,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: Mecool
@@ -133,7 +133,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tv
     brand: Mecool
@@ -151,7 +151,7 @@
     name: Chrome Mobile
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tv
     brand: Mecool
@@ -169,7 +169,7 @@
     name: Chrome
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tv
     brand: Mecool
@@ -187,7 +187,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tv
     brand: Mecool
@@ -205,7 +205,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: Mecool
@@ -223,7 +223,7 @@
     name: Chrome
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tv
     brand: Mecool
@@ -241,7 +241,7 @@
     name: Chrome
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tv
     brand: Mecool
@@ -259,7 +259,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: Mecool
@@ -277,7 +277,7 @@
     name: Chrome Mobile
     version: 79.0.3945.45
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.45"
   device:
     type: tv
     brand: Mecool
@@ -295,7 +295,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: Mecool
@@ -313,7 +313,7 @@
     name: Chrome
     version: 80.0.3987.68
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.68"
   device:
     type: tv
     brand: Mecool
@@ -331,7 +331,7 @@
     name: Chrome
     version: 83.0.4103.96
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.96"
   device:
     type: tv
     brand: Mecool
@@ -349,7 +349,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tv
     brand: Vontar
@@ -367,7 +367,7 @@
     name: Chrome
     version: 80.0.3987.99
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.99"
   device:
     type: tv
     brand: Vontar
@@ -385,7 +385,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tv
     brand: Vontar
@@ -403,7 +403,7 @@
     name: Chrome
     version: 77.0.3865.73
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.73"
   device:
     type: tv
     brand: Vontar
@@ -421,7 +421,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tv
     brand: Vontar
@@ -439,7 +439,7 @@
     name: Opera
     version: 46.0.2246.126998
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tv
     brand: Vontar
@@ -457,7 +457,7 @@
     name: Chrome
     version: 63.0.3239.111
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.111"
   device:
     type: tv
     brand: Vontar
@@ -475,7 +475,7 @@
     name: Chrome
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: tv
     brand: Vontar
@@ -493,7 +493,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: Minix
@@ -511,7 +511,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tv
     brand: Minix
@@ -565,7 +565,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tv
     brand: Minix
@@ -619,7 +619,7 @@
     name: Chrome Webview
     version: 63.0.3239.60
     engine: Blink
-    engine_version: ""
+    engine_version: "63.0.3239.60"
   device:
     type: tv
     brand: Minix
@@ -637,7 +637,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tv
     brand: Minix
@@ -655,7 +655,7 @@
     name: Chrome
     version: 49.0.2623.91
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.91"
   device:
     type: tv
     brand: Minix
@@ -673,7 +673,7 @@
     name: Chrome
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tv
     brand: Minix
@@ -691,7 +691,7 @@
     name: Chrome
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tv
     brand: Atom
@@ -709,7 +709,7 @@
     name: Chrome
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tv
     brand: Vorke
@@ -727,7 +727,7 @@
     name: Chrome
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tv
     brand: Vorke
@@ -745,7 +745,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tv
     brand: Vorke
@@ -763,7 +763,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tv
     brand: Vorke
@@ -781,7 +781,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: Alfawise
@@ -799,7 +799,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: Eltex
@@ -817,7 +817,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: Eltex
@@ -835,7 +835,7 @@
     name: Chrome
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tv
     brand: Invin
@@ -853,7 +853,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: Invin
@@ -871,7 +871,7 @@
     name: Opera
     version: 46.0.2254.145391
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tv
     brand: Invin
@@ -889,7 +889,7 @@
     name: Chrome
     version: 79.0.3921.2
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3921.2"
   device:
     type: tv
     brand: Tronsmart
@@ -907,7 +907,7 @@
     name: Chrome
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tv
     brand: Tronsmart
@@ -925,7 +925,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: Tronsmart
@@ -943,7 +943,7 @@
     name: Chrome
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tv
     brand: Tronsmart
@@ -961,7 +961,7 @@
     name: Chrome
     version: 72.0.3626.96
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.96"
   device:
     type: tv
     brand: Tronsmart
@@ -979,7 +979,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: Tronsmart
@@ -997,7 +997,7 @@
     name: Chrome
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tv
     brand: Transpeed
@@ -1015,7 +1015,7 @@
     name: Chrome
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tv
     brand: Transpeed
@@ -1033,7 +1033,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: Transpeed
@@ -1069,7 +1069,7 @@
     name: Chrome Webview
     version: 51.0.2704.91
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.91"
   device:
     type: tv
     brand: Asano
@@ -1240,7 +1240,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tv
     brand: Beelink
@@ -1258,7 +1258,7 @@
     name: Chrome
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tv
     brand: Beelink
@@ -1276,7 +1276,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tv
     brand: Beelink
@@ -1294,7 +1294,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: Beelink
@@ -1366,7 +1366,7 @@
     name: Seraphic Sraf
     version: "3.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.1599.114"
   device:
     type: tv
     brand: Changhong
@@ -1420,7 +1420,7 @@
     name: Chrome
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tv
     brand: CVTE
@@ -1438,7 +1438,7 @@
     name: Chrome
     version: 76.0.3809.70
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.70"
   device:
     type: tv
     brand: CVTE
@@ -1456,7 +1456,7 @@
     name: Chrome Mobile
     version: 68.0.3440.91
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.91"
   device:
     type: tv
     brand: Daewoo
@@ -1474,7 +1474,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tv
     brand: Divisat
@@ -1492,7 +1492,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: Dolamee
@@ -1510,7 +1510,7 @@
     name: Chrome Webview
     version: 44.0.2403.119
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: tv
     brand: Dolamee
@@ -1528,7 +1528,7 @@
     name: Chrome Webview
     version: 48.0.2542.0
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2542.0"
   device:
     type: tv
     brand: Doffler
@@ -1631,7 +1631,7 @@
     name: Chrome
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tv
     brand: DEXP
@@ -1649,7 +1649,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: DEXP
@@ -1682,7 +1682,7 @@
     name: Chrome
     version: 31.0.1650.0
     engine: Blink
-    engine_version: ""
+    engine_version: "31.0.1650.0"
   device:
     type: tv
     brand: Google
@@ -1700,7 +1700,7 @@
     name: Chrome
     version: 41.0.2272.75
     engine: Blink
-    engine_version: ""
+    engine_version: "41.0.2272.75"
   device:
     type: tv
     brand: Google
@@ -1736,7 +1736,7 @@
     name: Chrome Webview
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tv
     brand: Grundig
@@ -1754,7 +1754,7 @@
     name: Mobile Silk
     version: 80.1.145
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.119"
   device:
     type: tv
     brand: Grundig
@@ -1772,7 +1772,7 @@
     name: Chrome Webview
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tv
     brand: Grundig
@@ -1790,7 +1790,7 @@
     name: Opera Devices
     version: 4.13.2.294
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.99"
   device:
     type: tv
     brand: Hisense
@@ -2069,7 +2069,7 @@
     name: Chrome
     version: 75.0.3770.67
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.67"
   device:
     type: tv
     brand: IconBIT
@@ -2087,7 +2087,7 @@
     name: Chrome
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tv
     brand: IconBIT
@@ -2105,7 +2105,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tv
     brand: IconBIT
@@ -2123,7 +2123,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tv
     brand: IconBIT
@@ -2159,7 +2159,7 @@
     name: Mobile Silk
     version: 79.5.1
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tv
     brand: Insignia
@@ -2177,7 +2177,7 @@
     name: Chrome Webview
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tv
     brand: Insignia
@@ -2289,7 +2289,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tv
     brand: KATV1
@@ -2325,7 +2325,7 @@
     name: Chrome Webview
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tv
     brand: Amazon
@@ -2343,7 +2343,7 @@
     name: Mobile Silk
     version: 68.3.1
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.85"
   device:
     type: tv
     brand: Amazon
@@ -2361,7 +2361,7 @@
     name: Chrome Webview
     version: 70.0.3538.110
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.110"
   device:
     type: tv
     brand: Amazon
@@ -2379,7 +2379,7 @@
     name: Chrome Webview
     version: 34.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.0.0"
   device:
     type: tv
     brand: Amazon
@@ -2397,7 +2397,7 @@
     name: Chrome Webview
     version: 49.0.2623.10
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.10"
   device:
     type: tv
     brand: Amazon
@@ -2415,7 +2415,7 @@
     name: Chrome Webview
     version: 55.0.28
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.28"
   device:
     type: tv
     brand: Amazon
@@ -2433,7 +2433,7 @@
     name: Chrome Mobile
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: Kivi
@@ -2451,7 +2451,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: Kivi
@@ -2469,7 +2469,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: Kivi
@@ -2487,7 +2487,7 @@
     name: Opera
     version: 55.2.2719.50740
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tv
     brand: Kivi
@@ -2505,7 +2505,7 @@
     name: Chrome Mobile
     version: 66.0.3359.106
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.106"
   device:
     type: tv
     brand: Kivi
@@ -2523,7 +2523,7 @@
     name: Chrome Webview
     version: 48.0.2542.0
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2542.0"
   device:
     type: tv
     brand: Kivi
@@ -2541,7 +2541,7 @@
     name: Opera
     version: 51.3.2461.138727
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: tv
     brand: Kivi
@@ -2559,7 +2559,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tv
     brand: Kivi
@@ -2577,7 +2577,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tv
     brand: Kivi
@@ -2595,7 +2595,7 @@
     name: Chrome Mobile
     version: 64.0.3282.123
     engine: Blink
-    engine_version: ""
+    engine_version: "64.0.3282.123"
   device:
     type: tv
     brand: Kivi
@@ -2613,7 +2613,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: Kivi
@@ -2631,7 +2631,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: Kivi
@@ -2649,7 +2649,7 @@
     name: Chrome Mobile
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tv
     brand: Kivi
@@ -2667,7 +2667,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: Kivi
@@ -2685,7 +2685,7 @@
     name: Chrome Mobile
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tv
     brand: Kivi
@@ -2703,7 +2703,7 @@
     name: Chrome Mobile
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tv
     brand: Kivi
@@ -2721,7 +2721,7 @@
     name: Chrome Mobile
     version: 50.0.2661.89
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: tv
     brand: Kivi
@@ -2739,7 +2739,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: Kivi
@@ -2757,7 +2757,7 @@
     name: Chrome Mobile
     version: 80.0.3987.78
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.78"
   device:
     type: tv
     brand: Kivi
@@ -2775,7 +2775,7 @@
     name: Chrome Mobile
     version: 57.0.2987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: tv
     brand: Kivi
@@ -2793,7 +2793,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: Kivi
@@ -2811,7 +2811,7 @@
     name: Chrome Mobile
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: Kivi
@@ -2829,7 +2829,7 @@
     name: Chrome Mobile
     version: 50.0.2661.89
     engine: Blink
-    engine_version: ""
+    engine_version: "50.0.2661.89"
   device:
     type: tv
     brand: Kivi
@@ -2865,7 +2865,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: Kivi
@@ -2883,7 +2883,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: Kivi
@@ -2901,7 +2901,7 @@
     name: Opera
     version: 53.0.2569.141117
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tv
     brand: Kivi
@@ -2919,7 +2919,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: Kivi
@@ -2937,7 +2937,7 @@
     name: Chrome Webview
     version: 48.0.2542.0
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2542.0"
   device:
     type: tv
     brand: Kivi
@@ -2955,7 +2955,7 @@
     name: Opera
     version: 47.0.2249.129167
     engine: Blink
-    engine_version: ""
+    engine_version: "66.0.3359.158"
   device:
     type: tv
     brand: Kivi
@@ -2973,7 +2973,7 @@
     name: Chrome Webview
     version: 52.0.2743.100
     engine: Blink
-    engine_version: ""
+    engine_version: "52.0.2743.100"
   device:
     type: tv
     brand: Kivi
@@ -2991,7 +2991,7 @@
     name: Chrome Mobile
     version: 76.0.3809.132
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.132"
   device:
     type: tv
     brand: Kivi
@@ -3009,7 +3009,7 @@
     name: Mobile Silk
     version: 65.2.1
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.144"
   device:
     type: tv
     brand: Element
@@ -3027,7 +3027,7 @@
     name: Chrome
     version: 38.0.2125.122
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.122"
   device:
     type: tv
     brand: LG
@@ -3045,7 +3045,7 @@
     name: Chrome
     version: 38.0.2125.122
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.122"
   device:
     type: tv
     brand: LG
@@ -3189,7 +3189,7 @@
     name: Chrome
     version: 38.0.2125.122
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.122"
   device:
     type: tv
     brand: LG
@@ -3337,7 +3337,7 @@
     name: Chrome Webview
     version: 48.0.2542.0
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2542.0"
   device:
     type: tv
     brand: National
@@ -3355,7 +3355,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tv
     brand: NEXON
@@ -3373,7 +3373,7 @@
     name: Chrome
     version: 80.0.3987.162
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.162"
   device:
     type: tv
     brand: NEXON
@@ -3427,7 +3427,7 @@
     name: Chrome
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tv
     brand: NG Optics
@@ -3463,7 +3463,7 @@
     name: Chrome
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tv
     brand: Openbox
@@ -3481,7 +3481,7 @@
     name: Chrome
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tv
     brand: Openbox
@@ -3499,7 +3499,7 @@
     name: Chrome
     version: 80.0.3987.87
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.87"
   device:
     type: tv
     brand: Openbox
@@ -3535,7 +3535,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tv
     brand: OzoneHD
@@ -3553,7 +3553,7 @@
     name: Chrome Webview
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: OzoneHD
@@ -3571,7 +3571,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tv
     brand: OzoneHD
@@ -3737,7 +3737,7 @@
     name: Chrome
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tv
     brand: Philips
@@ -3755,7 +3755,7 @@
     name: Chrome
     version: 29.0.1547.80
     engine: Blink
-    engine_version: ""
+    engine_version: "29.0.1547.80"
   device:
     type: tv
     brand: Philips
@@ -3773,7 +3773,7 @@
     name: Chrome Mobile
     version: 37.0.2062.117
     engine: Blink
-    engine_version: ""
+    engine_version: "37.0.2062.117"
   device:
     type: tv
     brand: Philips
@@ -3924,7 +3924,7 @@
     name: Opera Devices
     version: 4.8.0.142
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.112"
   device:
     type: tv
     brand: Philips
@@ -3942,7 +3942,7 @@
     name: Opera Devices
     version: 4.8.0.142
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.112"
   device:
     type: tv
     brand: Philips
@@ -3960,7 +3960,7 @@
     name: Opera Devices
     version: 4.8.0.142
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.112"
   device:
     type: tv
     brand: Philips
@@ -3978,7 +3978,7 @@
     name: Opera
     version: 52.4.2517.140781
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tv
     brand: Philips
@@ -3996,7 +3996,7 @@
     name: Opera Devices
     version: 4.8.0.129
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.112"
   device:
     type: tv
     brand: Philips
@@ -4050,7 +4050,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tv
     brand: R-TV
@@ -4068,7 +4068,7 @@
     name: Chrome
     version: 73.0.3683.90
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.90"
   device:
     type: tv
     brand: R-TV
@@ -4086,7 +4086,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tv
     brand: R-TV
@@ -4104,7 +4104,7 @@
     name: Chrome
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tv
     brand: R-TV
@@ -4122,7 +4122,7 @@
     name: Chrome
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tv
     brand: R-TV
@@ -4140,7 +4140,7 @@
     name: Chrome Webview
     version: 74.0.3729.136
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.136"
   device:
     type: tv
     brand: R-TV
@@ -4158,7 +4158,7 @@
     name: Chrome
     version: 39.0.2171.93
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.93"
   device:
     type: tv
     brand: Rombica
@@ -4176,7 +4176,7 @@
     name: Chrome
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tv
     brand: Rombica
@@ -4194,7 +4194,7 @@
     name: Chrome Webview
     version: 30.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "30.0.0.0"
   device:
     type: tv
     brand: Rombica
@@ -4212,7 +4212,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tv
     brand: Rombica
@@ -4230,7 +4230,7 @@
     name: Yandex Browser
     version: 19.7.2.90.01
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tv
     brand: Rombica
@@ -4248,7 +4248,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tv
     brand: Rombica
@@ -4315,7 +4315,7 @@
     name: Chrome
     version: 56.0.2924.87
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.87"
   device:
     type: tv
     brand: Savio
@@ -4771,7 +4771,7 @@
     name: Chrome Webview
     version: 71.0.3578.99
     engine: Blink
-    engine_version: ""
+    engine_version: "71.0.3578.99"
   device:
     type: tv
     brand: Sony
@@ -4807,7 +4807,7 @@
     name: Chrome Mobile
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tv
     brand: Sony
@@ -4843,7 +4843,7 @@
     name: Chrome Mobile
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tv
     brand: Sony
@@ -4861,7 +4861,7 @@
     name: Chrome Mobile
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: Sony
@@ -4897,7 +4897,7 @@
     name: Opera Devices
     version: 4.2.12.48
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.153"
   device:
     type: tv
     brand: Sony
@@ -4915,7 +4915,7 @@
     name: Opera Devices
     version: 4.5.23.37
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.152"
   device:
     type: tv
     brand: Sony
@@ -4951,7 +4951,7 @@
     name: Opera Devices
     version: 4.2.12.48
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.153"
   device:
     type: tv
     brand: Sony
@@ -5145,7 +5145,7 @@
     name: Chrome Webview
     version: 51.0.2704.91
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.91"
   device:
     type: tv
     brand: TD Systems
@@ -5163,7 +5163,7 @@
     name: Chrome Mobile
     version: 65.0.3325.109
     engine: Blink
-    engine_version: ""
+    engine_version: "65.0.3325.109"
   device:
     type: tv
     brand: TD Systems
@@ -5181,7 +5181,7 @@
     name: Chrome Webview
     version: 51.0.2704.91
     engine: Blink
-    engine_version: ""
+    engine_version: "51.0.2704.91"
   device:
     type: tv
     brand: TD Systems
@@ -5271,7 +5271,7 @@
     name: Chrome Webview
     version: 48.0.2542.0
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2542.0"
   device:
     type: tv
     brand: Telefunken
@@ -5289,7 +5289,7 @@
     name: Chrome Webview
     version: 48.0.2542.0
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2542.0"
   device:
     type: tv
     brand: Telefunken
@@ -5307,7 +5307,7 @@
     name: Chrome Webview
     version: 48.0.2542.0
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2542.0"
   device:
     type: tv
     brand: Telefunken
@@ -5325,7 +5325,7 @@
     name: Chrome Webview
     version: 48.0.2542.0
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2542.0"
   device:
     type: tv
     brand: Telefunken
@@ -5343,7 +5343,7 @@
     name: Chrome Webview
     version: 48.0.2542.0
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2542.0"
   device:
     type: tv
     brand: Telefunken
@@ -5361,7 +5361,7 @@
     name: Chrome Webview
     version: 48.0.2542.0
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2542.0"
   device:
     type: tv
     brand: Telefunken
@@ -5746,7 +5746,7 @@
     name: Chrome
     version: 80.0.3962.2
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3962.2"
   device:
     type: tv
     brand: Ugoos
@@ -5764,7 +5764,7 @@
     name: Chrome
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tv
     brand: Vinga
@@ -5782,7 +5782,7 @@
     name: Chrome
     version: 79.0.3945.136
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.136"
   device:
     type: tv
     brand: Vinga
@@ -5800,7 +5800,7 @@
     name: Yandex Browser
     version: 19.7.2.90.01
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tv
     brand: Vinga
@@ -5818,7 +5818,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tv
     brand: Vesta
@@ -5923,7 +5923,7 @@
     name: Chrome
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tv
     brand: Soundmax
@@ -5941,7 +5941,7 @@
     name: Chrome Webview
     version: 48.0.2542.0
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2542.0"
   device:
     type: tv
     brand: Soundmax
@@ -5959,7 +5959,7 @@
     name: Chrome
     version: 78.0.3904.62
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.62"
   device:
     type: tv
     brand: Soundmax
@@ -5977,7 +5977,7 @@
     name: Chrome Webview
     version: 44.0.2403.119
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: tv
     brand: NEXBOX
@@ -5995,7 +5995,7 @@
     name: Chrome Webview
     version: 44.0.2403.119
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: tv
     brand: NEXBOX
@@ -6013,7 +6013,7 @@
     name: Chrome
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tv
     brand: NEXBOX
@@ -6031,7 +6031,7 @@
     name: Yandex Browser
     version: "8.11"
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.105"
   device:
     type: tv
     brand: NEXBOX
@@ -6049,7 +6049,7 @@
     name: Chrome
     version: 67.0.3396.87
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.87"
   device:
     type: tv
     brand: NEXBOX
@@ -6067,7 +6067,7 @@
     name: Chrome Webview
     version: 39.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.0.0"
   device:
     type: tv
     brand: NEXBOX
@@ -6085,7 +6085,7 @@
     name: Chrome
     version: 60.0.3112.116
     engine: Blink
-    engine_version: ""
+    engine_version: "60.0.3112.116"
   device:
     type: tv
     brand: Xgody
@@ -6121,7 +6121,7 @@
     name: Chrome Webview
     version: 62.0.3202.97
     engine: Blink
-    engine_version: ""
+    engine_version: "62.0.3202.97"
   device:
     type: tv
     brand: Xiaomi
@@ -6139,7 +6139,7 @@
     name: Opera Devices
     version: 4.9.0.59
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: Xiaomi
@@ -6157,7 +6157,7 @@
     name: Chrome Mobile
     version: 78.0.3904.90
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.90"
   device:
     type: tv
     brand: Xiaomi
@@ -6175,7 +6175,7 @@
     name: Opera Devices
     version: 4.9.0.59
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: Xiaomi
@@ -6193,7 +6193,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: tv
     brand: Xiaomi
@@ -6229,7 +6229,7 @@
     name: Opera
     version: 31.0.2254.122029
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tv
     brand: Xiaomi
@@ -6247,7 +6247,7 @@
     name: Opera Devices
     version: 4.9.0.59
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: Xiaomi
@@ -6265,7 +6265,7 @@
     name: Chrome Mobile
     version: 57.0.2987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.132"
   device:
     type: tv
     brand: Xiaomi
@@ -6283,7 +6283,7 @@
     name: Opera Devices
     version: 4.9.0.59
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: Xiaomi
@@ -6301,7 +6301,7 @@
     name: Opera Devices
     version: 4.9.0.59
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: Xiaomi
@@ -6319,7 +6319,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tv
     brand: Xoro
@@ -6337,7 +6337,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tv
     brand: Zidoo
@@ -6355,7 +6355,7 @@
     name: Opera
     version: 53.0.2569.141117
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tv
     brand: Zidoo
@@ -6373,7 +6373,7 @@
     name: Chrome
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tv
     brand: Zidoo
@@ -6391,7 +6391,7 @@
     name: Chrome
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tv
     brand: Zidoo
@@ -6409,7 +6409,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: Zidoo
@@ -6445,7 +6445,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: Zidoo
@@ -6481,7 +6481,7 @@
     name: Chrome
     version: "63"
     engine: Blink
-    engine_version: ""
+    engine_version: "63"
   device:
     type: tv
     brand: Samsung
@@ -6517,7 +6517,7 @@
     name: Chrome
     version: "76"
     engine: Blink
-    engine_version: ""
+    engine_version: "76"
   device:
     type: tv
     brand: Samsung
@@ -6535,7 +6535,7 @@
     name: Chrome
     version: "76"
     engine: Blink
-    engine_version: ""
+    engine_version: "76"
   device:
     type: tv
     brand: Samsung
@@ -6553,7 +6553,7 @@
     name: Seraphic Sraf
     version: "4.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.106"
   device:
     type: tv
     brand: Sharp
@@ -6650,7 +6650,7 @@
     name: Opera Devices
     version: 4.8.0.129
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.112"
   device:
     type: tv
     brand: Philips
@@ -6668,7 +6668,7 @@
     name: Opera Devices
     version: 4.8.0.66
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.112"
   device:
     type: tv
     brand: Philips
@@ -6686,7 +6686,7 @@
     name: Opera Devices
     version: 4.9.0.237
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: Salora
@@ -6704,7 +6704,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.87"
   device:
     type: tv
     brand: Westpoint
@@ -6722,7 +6722,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.152"
   device:
     type: tv
     brand: Kalley
@@ -6740,7 +6740,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.87"
   device:
     type: tv
     brand: TCL
@@ -6758,7 +6758,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.152"
   device:
     type: tv
     brand: JVC
@@ -6776,7 +6776,7 @@
     name: Opera Devices
     version: 4.6.1.40
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
   device:
     type: tv
     brand: JVC
@@ -6794,7 +6794,7 @@
     name: Opera Devices
     version: 4.6.1.40
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
   device:
     type: tv
     brand: Hitachi
@@ -6812,7 +6812,7 @@
     name: Opera Devices
     version: 4.6.1.40
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
   device:
     type: tv
     brand: Techwood
@@ -6830,7 +6830,7 @@
     name: Opera Devices
     version: 4.3.18.7
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.122"
   device:
     type: tv
     brand: Digihome
@@ -6848,7 +6848,7 @@
     name: Opera Devices
     version: 4.6.1.40
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
   device:
     type: tv
     brand: Finlux
@@ -6866,7 +6866,7 @@
     name: Opera Devices
     version: 4.3.18.7
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.122"
   device:
     type: tv
     brand: X.Vision
@@ -6884,7 +6884,7 @@
     name: Opera Devices
     version: 4.6.1.40
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
   device:
     type: tv
     brand: Bush
@@ -6902,7 +6902,7 @@
     name: Opera Devices
     version: 4.6.1.40
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
   device:
     type: tv
     brand: Luxor
@@ -6920,7 +6920,7 @@
     name: Opera Devices
     version: 4.6.1.40
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
   device:
     type: tv
     brand: Polaroid
@@ -6938,7 +6938,7 @@
     name: Opera Devices
     version: 4.6.1.40
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
   device:
     type: tv
     brand: Linsar
@@ -6956,7 +6956,7 @@
     name: Opera Devices
     version: 4.6.1.40
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
   device:
     type: tv
     brand: Nordmende
@@ -6974,7 +6974,7 @@
     name: Opera Devices
     version: 4.6.1.40
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
   device:
     type: tv
     brand: Hotel
@@ -6992,7 +6992,7 @@
     name: Opera Devices
     version: 4.6.1.40
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
   device:
     type: tv
     brand: ALDI SÜD
@@ -7010,7 +7010,7 @@
     name: Opera Devices
     version: 4.3.18.7
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.122"
   device:
     type: tv
     brand: Celcus
@@ -7028,7 +7028,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.100"
   device:
     type: tv
     brand: Akai
@@ -7046,7 +7046,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.152"
   device:
     type: tv
     brand: Thomson
@@ -7064,7 +7064,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.87"
   device:
     type: tv
     brand: TCL
@@ -7100,7 +7100,7 @@
     name: Opera Devices
     version: 4.8.0.66
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.112"
   device:
     type: tv
     brand: AOC
@@ -7118,7 +7118,7 @@
     name: Opera Devices
     version: 4.8.0.66
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.112"
   device:
     type: tv
     brand: AOC
@@ -7136,7 +7136,7 @@
     name: Opera Devices
     version: 4.8.0.129
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.112"
   device:
     type: tv
     brand: AOC
@@ -7154,7 +7154,7 @@
     name: Opera Devices
     version: 4.8.0.66
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.112"
   device:
     type: tv
     brand: AOC
@@ -7172,7 +7172,7 @@
     name: Opera Devices
     version: 4.8.0.66
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.112"
   device:
     type: tv
     brand: AOC
@@ -7190,7 +7190,7 @@
     name: Opera Devices
     version: 4.8.0.53
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.112"
   device:
     type: tv
     brand: AOC
@@ -7208,7 +7208,7 @@
     name: Opera Devices
     version: 4.8.0.66
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.112"
   device:
     type: tv
     brand: AOC
@@ -7226,7 +7226,7 @@
     name: Opera Devices
     version: 4.8.0.9
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.87"
   device:
     type: tv
     brand: AOC
@@ -7244,7 +7244,7 @@
     name: Opera Devices
     version: 4.8.0.129
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.112"
   device:
     type: tv
     brand: AOC
@@ -7262,7 +7262,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: Thomson
@@ -7280,7 +7280,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: Thomson
@@ -7298,7 +7298,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: Thomson
@@ -7316,7 +7316,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: TCL
@@ -7334,7 +7334,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: TCL
@@ -7352,7 +7352,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: TCL
@@ -7370,7 +7370,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: TCL
@@ -7388,7 +7388,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: TCL
@@ -7406,7 +7406,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: TCL
@@ -7424,7 +7424,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: TCL
@@ -7442,7 +7442,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: TCL
@@ -7460,7 +7460,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: TCL
@@ -7478,7 +7478,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: TCL
@@ -7496,7 +7496,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: TCL
@@ -7514,7 +7514,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: TCL
@@ -7532,7 +7532,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: TCL
@@ -7550,7 +7550,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: Thomson
@@ -7568,7 +7568,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "42.0.2311.152"
   device:
     type: tv
     brand: Thomson
@@ -7586,7 +7586,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: Panasonic
@@ -7604,7 +7604,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: Panasonic
@@ -7622,7 +7622,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: Panasonic
@@ -7640,7 +7640,7 @@
     name: T-Browser
     version: "2.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.75"
   device:
     type: tv
     brand: Panasonic
@@ -7658,7 +7658,7 @@
     name: Opera Devices
     version: 4.6.1.40
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
   device:
     type: tv
     brand: Saba
@@ -7712,7 +7712,7 @@
     name: Opera Devices
     version: 4.6.1.40
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
   device:
     type: tv
     brand: Haier
@@ -7748,7 +7748,7 @@
     name: Opera Devices
     version: 4.9.0.176
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: Laurus
@@ -7766,7 +7766,7 @@
     name: Opera Devices
     version: 4.9.0.176
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: Fuego
@@ -7784,7 +7784,7 @@
     name: Opera Devices
     version: 4.9.0.176
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: Technika
@@ -7802,7 +7802,7 @@
     name: Opera Devices
     version: 4.6.1.40
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
   device:
     type: tv
     brand: GoGEN
@@ -7820,7 +7820,7 @@
     name: Opera Devices
     version: 4.6.1.40
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
   device:
     type: tv
     brand: KUBO
@@ -7838,7 +7838,7 @@
     name: Opera Devices
     version: 4.9.0.176
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: VOX
@@ -7856,7 +7856,7 @@
     name: Opera Devices
     version: 4.6.1.40
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
   device:
     type: tv
     brand: ELECTRONIA
@@ -7874,7 +7874,7 @@
     name: Opera Devices
     version: 4.9.0.237
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: WELLINGTON
@@ -7892,7 +7892,7 @@
     name: Opera Devices
     version: 4.9.0.176
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: REGAL
@@ -7946,7 +7946,7 @@
     name: Opera Devices
     version: 4.6.1.40
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
   device:
     type: tv
     brand: Lifemaxx
@@ -8018,7 +8018,7 @@
     name: Opera Devices
     version: 4.9.0.237
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: ALDI NORD
@@ -8054,7 +8054,7 @@
     name: Chrome
     version: 53.0.2785.34
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.34"
   device:
     type: tv
     brand: LG
@@ -8072,7 +8072,7 @@
     name: Opera Devices
     version: 4.2.12.48
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.153"
   device:
     type: tv
     brand: Sony
@@ -8090,7 +8090,7 @@
     name: Chrome
     version: 53.0.2785.34
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.34"
   device:
     type: tv
     brand: LG
@@ -8108,7 +8108,7 @@
     name: Opera Devices
     version: 4.9.0.237
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: Horizon
@@ -8144,7 +8144,7 @@
     name: Opera Devices
     version: 4.9.0.237
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: Ok
@@ -8162,7 +8162,7 @@
     name: Opera Devices
     version: 4.9.0.237
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: Essentielb
@@ -8180,7 +8180,7 @@
     name: Opera Devices
     version: 4.13.5.431
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.99"
   device:
     type: tv
     brand: Hi-Level
@@ -8213,7 +8213,7 @@
     name: Opera Devices
     version: 4.6.1.40
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.130"
   device:
     type: tv
     brand: Hyundai
@@ -8231,7 +8231,7 @@
     name: Opera Devices
     version: 4.9.0.237
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: Qilive
@@ -8267,7 +8267,7 @@
     name: Opera Devices
     version: 4.9.0.237
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: SEG
@@ -8285,7 +8285,7 @@
     name: Chrome
     version: 53.0.2785.34
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.34"
   device:
     type: tv
     brand: LG
@@ -8303,7 +8303,7 @@
     name: Opera Devices
     version: 4.9.0.237
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: PROFiLO
@@ -8321,7 +8321,7 @@
     name: Seraphic Sraf
     version: "3.6"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.71"
   device:
     type: tv
     brand: Haier
@@ -8339,7 +8339,7 @@
     name: Seraphic Sraf
     version: "3.5"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.71"
   device:
     type: tv
     brand: Blaupunkt
@@ -8357,7 +8357,7 @@
     name: Opera Devices
     version: 4.9.0.237
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: tv
     brand: 'F&U'
@@ -8393,7 +8393,7 @@
     name: Seraphic Sraf
     version: "3.6"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.71"
   device:
     type: tv
     brand: SCBC
@@ -8411,7 +8411,7 @@
     name: Seraphic Sraf
     version: "3.6"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.71"
   device:
     type: tv
     brand: SCBC
@@ -8429,7 +8429,7 @@
     name: Seraphic Sraf
     version: "3.5"
     engine: Blink
-    engine_version: ""
+    engine_version: "39.0.2171.71"
   device:
     type: tv
     brand: Sharp
@@ -8487,7 +8487,7 @@
     name: Opera Devices
     version: 4.2.12.48
     engine: Blink
-    engine_version: ""
+    engine_version: "35.0.1916.153"
   device:
     type: tv
     brand: Sony
@@ -8505,7 +8505,7 @@
     name: Opera Devices
     version: 4.8.0.129
     engine: Blink
-    engine_version: ""
+    engine_version: "49.0.2623.112"
   device:
     type: tv
     brand: Sony
@@ -8523,7 +8523,7 @@
     name: Opera Devices
     version: 4.20.3.54
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: tv
     brand: Hisense
@@ -8541,7 +8541,7 @@
     name: Opera Devices
     version: 4.21.1.75
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.140"
   device:
     type: tv
     brand: Hisense
@@ -8559,7 +8559,7 @@
     name: Opera Devices
     version: 4.21.1.75
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.140"
   device:
     type: tv
     brand: Hisense
@@ -8577,7 +8577,7 @@
     name: Opera Devices
     version: 4.20.5.35
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.120"
   device:
     type: tv
     brand: Sony
@@ -8595,7 +8595,7 @@
     name: Opera Devices
     version: 4.21.0.273
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tv
     brand: Sony
@@ -8613,7 +8613,7 @@
     name: Opera Devices
     version: 4.21.0.273
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tv
     brand: Sony
@@ -8631,7 +8631,7 @@
     name: Opera Devices
     version: 4.21.0.273
     engine: Blink
-    engine_version: ""
+    engine_version: "84.0.4147.125"
   device:
     type: tv
     brand: JVC
@@ -8649,7 +8649,7 @@
     name: Opera Devices
     version: 4.13.5.431
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.99"
   device:
     type: tv
     brand: Sony
@@ -8667,7 +8667,7 @@
     name: Opera Devices
     version: 4.13.5.431
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.99"
   device:
     type: tv
     brand: Sony
@@ -8685,7 +8685,7 @@
     name: Seraphic Sraf
     version: "4.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.106"
   device:
     type: tv
     brand: MStar
@@ -8703,7 +8703,7 @@
     name: Seraphic Sraf
     version: "4.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.106"
   device:
     type: tv
     brand: MStar
@@ -8721,7 +8721,7 @@
     name: Seraphic Sraf
     version: "4.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.106"
   device:
     type: tv
     brand: TD Systems
@@ -8739,7 +8739,7 @@
     name: Seraphic Sraf
     version: "4.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.106"
   device:
     type: tv
     brand: TD Systems
@@ -8757,7 +8757,7 @@
     name: Seraphic Sraf
     version: "4.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "47.0.2526.106"
   device:
     type: tv
     brand: Hisense
@@ -8775,7 +8775,7 @@
     name: Chrome
     version: 38.0.2125.122
     engine: Blink
-    engine_version: ""
+    engine_version: "38.0.2125.122"
   device:
     type: tv
     brand: LG
@@ -8793,7 +8793,7 @@
     name: Chrome
     version: 53.0.2785.34
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.34"
   device:
     type: tv
     brand: LG
@@ -8811,7 +8811,7 @@
     name: Chrome
     version: 53.0.2785.34
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.34"
   device:
     type: tv
     brand: LG
@@ -8829,7 +8829,7 @@
     name: Chrome
     version: 53.0.2785.34
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.34"
   device:
     type: tv
     brand: LG
@@ -8847,7 +8847,7 @@
     name: Chrome
     version: 53.0.2785.34
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.34"
   device:
     type: tv
     brand: LG
@@ -8865,7 +8865,7 @@
     name: Chrome
     version: 53.0.2785.34
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.34"
   device:
     type: tv
     brand: LG
@@ -8883,7 +8883,7 @@
     name: Chrome
     version: 53.0.2785.34
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.34"
   device:
     type: tv
     brand: LG
@@ -8901,7 +8901,7 @@
     name: Chrome
     version: 53.0.2785.34
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.34"
   device:
     type: tv
     brand: LG
@@ -8937,7 +8937,7 @@
     name: Odin
     version: 74.3729.2.10
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.108"
   device:
     type: tv
     brand: Hisense
@@ -8955,7 +8955,7 @@
     name: Odin
     version: 3.2987.2.8
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.133"
   device:
     type: tv
     brand: Hisense
@@ -8973,7 +8973,7 @@
     name: Odin
     version: 3.2987.2.8
     engine: Blink
-    engine_version: ""
+    engine_version: "57.0.2987.133"
   device:
     type: tv
     brand: Hisense
@@ -8991,7 +8991,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: LG
@@ -9009,7 +9009,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: LG
@@ -9027,7 +9027,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: LG
@@ -9045,7 +9045,7 @@
     name: Chrome
     version: 68.0.3440.106
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.106"
   device:
     type: tv
     brand: LG
@@ -9063,7 +9063,7 @@
     name: Chrome
     version: 68.0.3440.106
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.106"
   device:
     type: tv
     brand: LG
@@ -9081,7 +9081,7 @@
     name: Chrome
     version: 68.0.3440.106
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.106"
   device:
     type: tv
     brand: LG
@@ -9099,7 +9099,7 @@
     name: Chrome
     version: 68.0.3440.106
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.106"
   device:
     type: tv
     brand: LG
@@ -9117,7 +9117,7 @@
     name: Chrome
     version: 68.0.3440.106
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.106"
   device:
     type: tv
     brand: LG
@@ -9135,7 +9135,7 @@
     name: Chrome Webview
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: Facebook
@@ -9153,7 +9153,7 @@
     name: Chrome
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tv
     brand: SWTV
@@ -9171,7 +9171,7 @@
     name: Chrome
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tv
     brand: MTC
@@ -9189,7 +9189,7 @@
     name: Chrome
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tv
     brand: MTC
@@ -9207,7 +9207,7 @@
     name: Chrome
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tv
     brand: MediaTek
@@ -9225,7 +9225,7 @@
     name: Chrome
     version: 68.0.3440.106
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.106"
   device:
     type: tv
     brand: LG
@@ -9243,7 +9243,7 @@
     name: Chrome
     version: 68.0.3440.106
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.106"
   device:
     type: tv
     brand: LG
@@ -9261,7 +9261,7 @@
     name: Chrome
     version: 68.0.3440.106
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.106"
   device:
     type: tv
     brand: LG
@@ -9279,7 +9279,7 @@
     name: Chrome
     version: 68.0.3440.106
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.106"
   device:
     type: tv
     brand: LG
@@ -9297,7 +9297,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: LG
@@ -9315,7 +9315,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: LG
@@ -9333,7 +9333,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: LG
@@ -9351,7 +9351,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: LG
@@ -9369,7 +9369,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: LG
@@ -9387,7 +9387,7 @@
     name: Chrome
     version: 68.0.3440.106
     engine: Blink
-    engine_version: ""
+    engine_version: "68.0.3440.106"
   device:
     type: tv
     brand: LG
@@ -9405,7 +9405,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: LG
@@ -9423,7 +9423,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: LG
@@ -9441,7 +9441,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: LG
@@ -9459,7 +9459,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: LG
@@ -9477,7 +9477,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: LG
@@ -9495,7 +9495,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: LG
@@ -9513,7 +9513,7 @@
     name: Chrome
     version: 79.0.3945.79
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.79"
   device:
     type: tv
     brand: LG
@@ -9531,7 +9531,7 @@
     name: Chrome
     version: 75.0.3770.143
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.143"
   device:
     type: tv
     brand: Vontar
@@ -9549,7 +9549,7 @@
     name: Opera Devices
     version: 4.13.180
     engine: Blink
-    engine_version: ""
+    engine_version: "67.0.3396.99"
   device:
     type: tv
     brand: ARRIS
@@ -9595,7 +9595,7 @@
     name: Chrome Webview
     version: 76.0.3809.89
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.89"
   device:
     type: tv
     brand: Nvidia
@@ -9613,7 +9613,7 @@
     name: Seraphic Sraf
     version: "5.0"
     engine: Blink
-    engine_version: ""
+    engine_version: "73.0.3683.103"
   device:
     type: tv
     brand: Technicolor
@@ -9667,7 +9667,7 @@
     name: Chrome Mobile
     version: 74.0.3729.157
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.157"
   device:
     type: tv
     brand: OzoneHD
@@ -9685,7 +9685,7 @@
     name: Chrome
     version: 80.0.3987.132
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.132"
   device:
     type: tv
     brand: Sunvell
@@ -9703,7 +9703,7 @@
     name: Chrome
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tv
     brand: Sunvell
@@ -9721,7 +9721,7 @@
     name: Chrome
     version: 83.0.4103.101
     engine: Blink
-    engine_version: ""
+    engine_version: "83.0.4103.101"
   device:
     type: tv
     brand: Zidoo
@@ -9739,7 +9739,7 @@
     name: Chrome
     version: 77.0.3865.92
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.92"
   device:
     type: tv
     brand: SPC
@@ -9757,7 +9757,7 @@
     name: Chrome
     version: 76.0.3809.111
     engine: Blink
-    engine_version: ""
+    engine_version: "76.0.3809.111"
   device:
     type: tv
     brand: SPC
@@ -9775,7 +9775,7 @@
     name: Chrome Webview
     version: 44.0.2403.119
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: tv
     brand: Pendoo
@@ -9811,7 +9811,7 @@
     name: Chrome
     version: 87.0.4280.101
     engine: Blink
-    engine_version: ""
+    engine_version: "87.0.4280.101"
   device:
     type: tv
     brand: Pendoo
@@ -9829,7 +9829,7 @@
     name: Chrome
     version: 70.0.3538.80
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.80"
   device:
     type: tv
     brand: Pendoo
@@ -9847,7 +9847,7 @@
     name: Chrome Webview
     version: 44.0.2403.119
     engine: Blink
-    engine_version: ""
+    engine_version: "44.0.2403.119"
   device:
     type: tv
     brand: Pendoo
@@ -9865,7 +9865,7 @@
     name: Chrome
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tv
     brand: Pendoo
@@ -9883,7 +9883,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tv
     brand: Pendoo
@@ -9901,7 +9901,7 @@
     name: Chrome Webview
     version: 55.0.2883.91
     engine: Blink
-    engine_version: ""
+    engine_version: "55.0.2883.91"
   device:
     type: tv
     brand: Pendoo
@@ -9919,7 +9919,7 @@
     name: Chrome
     version: 78.0.3904.108
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.108"
   device:
     type: tv
     brand: Pendoo
@@ -9937,7 +9937,7 @@
     name: Chrome
     version: 46.0.2490.76
     engine: Blink
-    engine_version: ""
+    engine_version: "46.0.2490.76"
   device:
     type: tv
     brand: PiPO
@@ -9955,7 +9955,7 @@
     name: Chrome Webview
     version: 48.0.2564.106
     engine: Blink
-    engine_version: ""
+    engine_version: "48.0.2564.106"
   device:
     type: tv
     brand: PiPO
@@ -10063,7 +10063,7 @@
     name: Chrome Mobile
     version: 94.0.4606.85
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.85"
   device:
     type: tv
     brand: Andowl

--- a/Tests/fixtures/unknown.yml
+++ b/Tests/fixtures/unknown.yml
@@ -45,7 +45,7 @@
     name: Chrome Webview
     version: "80.0.3987.117"
     engine: Blink
-    engine_version: ""
+    engine_version: "80.0.3987.117"
   device:
     type: ""
     brand: ""
@@ -2905,7 +2905,7 @@
     name: Microsoft Edge
     version: 77.07.4.5059
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: desktop
     brand: ""
@@ -2954,7 +2954,7 @@
     name: Opera
     version: 24.0.2254.115213
     engine: Blink
-    engine_version: ""
+    engine_version: "33.0.0.0"
   device:
     type: tablet
     brand: ""
@@ -2972,7 +2972,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tv
     brand: ""
@@ -2990,7 +2990,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tv
     brand: ""
@@ -3008,7 +3008,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: tv
     brand: ""
@@ -3026,7 +3026,7 @@
     name: Chrome
     version: 77.0.3865.116
     engine: Blink
-    engine_version: ""
+    engine_version: "77.0.3865.116"
   device:
     type: tv
     brand: ""
@@ -3044,7 +3044,7 @@
     name: Chrome
     version: 78.0.3904.96
     engine: Blink
-    engine_version: ""
+    engine_version: "78.0.3904.96"
   device:
     type: tv
     brand: ""
@@ -3062,7 +3062,7 @@
     name: Opera
     version: 51.2.2461.137690
     engine: Blink
-    engine_version: ""
+    engine_version: "72.0.3626.121"
   device:
     type: tablet
     brand: ""
@@ -3080,7 +3080,7 @@
     name: Chrome Webview
     version: 45.0.2454.94
     engine: Blink
-    engine_version: ""
+    engine_version: "45.0.2454.94"
   device:
     type: smartphone
     brand: "" # beeline ?
@@ -3098,7 +3098,7 @@
     name: Chrome
     version: 96.0.4664.45
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.45"
   device:
     type: tablet
     brand: ""
@@ -3116,7 +3116,7 @@
     name: Chrome Webview
     version: 69.0.3497.100
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.100"
   device:
     type: smartphone
     brand: ""
@@ -3134,7 +3134,7 @@
     name: Chrome Mobile
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: ""
@@ -3152,7 +3152,7 @@
     name: Chrome
     version: 75.0.3770.101
     engine: Blink
-    engine_version: ""
+    engine_version: "75.0.3770.101"
   device:
     type: tablet
     brand: ""
@@ -3170,7 +3170,7 @@
     name: Chrome Webview
     version: 96.0.4664.92
     engine: Blink
-    engine_version: ""
+    engine_version: "96.0.4664.92"
   device:
     type: smartphone
     brand: ""
@@ -3188,7 +3188,7 @@
     name: Chrome Mobile
     version: 91.0.0.0
     engine: Blink
-    engine_version: ""
+    engine_version: "91.0.0.0"
   device:
     type: smartphone
     brand: ""

--- a/Tests/fixtures/wearable.yml
+++ b/Tests/fixtures/wearable.yml
@@ -10,7 +10,7 @@
     name: Chrome
     version: "53.0.2785.143"
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: wearable
     brand: Huawei
@@ -368,7 +368,7 @@
     name: Chrome
     version: 53.0.2785.143
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: wearable
     brand: Asus
@@ -438,7 +438,7 @@
     name: Chrome Webview
     version: 61.0.3163.98
     engine: Blink
-    engine_version: ""
+    engine_version: "61.0.3163.98"
   device:
     type: wearable
     brand: Pico
@@ -456,7 +456,7 @@
     name: Chrome Mobile
     version: 79.0.3945.93
     engine: Blink
-    engine_version: ""
+    engine_version: "79.0.3945.93"
   device:
     type: wearable
     brand: Digma
@@ -474,7 +474,7 @@
     name: Chrome
     version: 53.0.2785.143
     engine: Blink
-    engine_version: ""
+    engine_version: "53.0.2785.143"
   device:
     type: wearable
     brand: New Balance
@@ -564,7 +564,7 @@
     name: Chrome Mobile
     version: 69.0.3497.106
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.106"
   device:
     type: wearable
     brand: Samsung
@@ -582,7 +582,7 @@
     name: Chrome Mobile
     version: 69.0.3497.106
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.106"
   device:
     type: wearable
     brand: Samsung
@@ -600,7 +600,7 @@
     name: Chrome Mobile
     version: 56.0.2924.0
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.0"
   device:
     type: wearable
     brand: Samsung
@@ -618,7 +618,7 @@
     name: Chrome Mobile
     version: 56.0.2924.0
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.0"
   device:
     type: wearable
     brand: Samsung
@@ -654,7 +654,7 @@
     name: Chrome Mobile
     version: 69.0.3497.106
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.106"
   device:
     type: wearable
     brand: Samsung
@@ -672,7 +672,7 @@
     name: Chrome Mobile
     version: 56.0.2924.0
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.0"
   device:
     type: wearable
     brand: Samsung
@@ -726,7 +726,7 @@
     name: Chrome Mobile
     version: 56.0.2924.0
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.0"
   device:
     type: wearable
     brand: Samsung
@@ -744,7 +744,7 @@
     name: Chrome Mobile
     version: 56.0.2924.0
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.0"
   device:
     type: wearable
     brand: Samsung
@@ -762,7 +762,7 @@
     name: Chrome Mobile
     version: 56.0.2924.0
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.0"
   device:
     type: wearable
     brand: Samsung
@@ -780,7 +780,7 @@
     name: Chrome Mobile
     version: 69.0.3497.106
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.106"
   device:
     type: wearable
     brand: Samsung
@@ -816,7 +816,7 @@
     name: Chrome Mobile
     version: 69.0.3497.106
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.106"
   device:
     type: wearable
     brand: Samsung
@@ -834,7 +834,7 @@
     name: Chrome Mobile
     version: 56.0.2924.0
     engine: Blink
-    engine_version: ""
+    engine_version: "56.0.2924.0"
   device:
     type: wearable
     brand: Samsung
@@ -870,7 +870,7 @@
     name: Chrome Mobile
     version: 69.0.3497.106
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.106"
   device:
     type: wearable
     brand: Samsung
@@ -888,7 +888,7 @@
     name: Chrome Mobile
     version: 69.0.3497.106
     engine: Blink
-    engine_version: ""
+    engine_version: "69.0.3497.106"
   device:
     type: wearable
     brand: Samsung
@@ -906,7 +906,7 @@
     name: Chrome Mobile
     version: 70.0.3538.57
     engine: Blink
-    engine_version: ""
+    engine_version: "70.0.3538.57"
   device:
     type: wearable
     brand: Lenovo
@@ -1048,7 +1048,7 @@
     name: Chrome Mobile
     version: 94.0.4606.71
     engine: Blink
-    engine_version: ""
+    engine_version: "94.0.4606.71"
   device:
     type: wearable
     brand: Gocomma
@@ -1066,7 +1066,7 @@
     name: Chrome Webview
     version: 74.0.3729.186
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.186"
   device:
     type: wearable
     brand: LEMFO
@@ -1174,7 +1174,7 @@
     name: Opera Mobile
     version: 15.0.1162.59192
     engine: Blink
-    engine_version: ""
+    engine_version: "28.0.1500.45"
   device:
     type: wearable
     brand: Motorola
@@ -1210,7 +1210,7 @@
     name: Chrome
     version: 34.0.1847.76
     engine: Blink
-    engine_version: ""
+    engine_version: "34.0.1847.76"
   device:
     type: wearable
     brand: Samsung
@@ -1277,7 +1277,7 @@
     name: Chrome Webview
     version: 74.0.3729.186
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.186"
   device:
     type: wearable
     brand: Autan
@@ -1295,7 +1295,7 @@
     name: Chrome Webview
     version: 74.0.3729.186
     engine: Blink
-    engine_version: ""
+    engine_version: "74.0.3729.186"
   device:
     type: wearable
     brand: LOKMAT


### PR DESCRIPTION
### Description:

The engine version parser looks for a token that specifically matches the engine name by default. However, Blink-based browsers don't mention "Blink" in the user agent; they almost always mention Chrome instead, and they include the engine version under that. Because of that confusion, none of the Blink browsers include engine versions (except for Chrome Mobile on the "Andi 5G Blink 4G" smartphone, which incorrectly returns the 4). This PR adds an override in the engine version parser to look for the Chrome/ token instead.

### Review

* [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
