### PR TITLE
Improvement of condition for detection the platform when using clienthints

### DIFF
--- a/Parser/OperatingSystem.php
+++ b/Parser/OperatingSystem.php
@@ -522,7 +522,7 @@ class OperatingSystem extends AbstractParser
             }
 
             if (false !== \strpos($arch, 'x64')
-                || (false !== \strpos($arch, 'x86')) && '64' === $this->clientHints->getBitness()
+                || (false !== \strpos($arch, 'x86') && '64' === $this->clientHints->getBitness())
             ) {
                 return 'x64';
             }


### PR DESCRIPTION
fix warning

[EA] Operations priority might differ from what you expect: please wrap needed with '(...)'. 
 Inspection info: The inspection reports variety of cases like checking values being instanceof a trait, unclear and suspicious operations priority, misplaced operators, hardcoded booleans and more cases which can contain bugs.