### PR TITLE
Fix version truncation for client hints

### DIFF
--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -817,7 +817,7 @@ class Browser extends AbstractClientParser
         return [
             'name'       => $name,
             'short_name' => $short,
-            'version'    => $version,
+            'version'    => $this->buildVersion($version, []),
         ];
     }
 

--- a/Parser/OperatingSystem.php
+++ b/Parser/OperatingSystem.php
@@ -439,7 +439,7 @@ class OperatingSystem extends AbstractParser
         return [
             'name'       => $name,
             'short_name' => $short,
-            'version'    => $version,
+            'version'    => $this->buildVersion($version, []),
         ];
     }
 

--- a/Tests/DeviceDetectorTest.php
+++ b/Tests/DeviceDetectorTest.php
@@ -290,6 +290,31 @@ class DeviceDetectorTest extends TestCase
         ];
     }
 
+    public function testVersionTruncationForClientHints(): void
+    {
+        AbstractParser::setVersionTruncation(AbstractParser::VERSION_TRUNCATION_MINOR);
+        $dd = new DeviceDetector();
+        $dd->setClientHints(new ClientHints(
+            'Galaxy 4',
+            'Android',
+            '8.0.5',
+            '98.0.14335.105',
+            [
+                ['brand' => ' Not A;Brand', 'version' => '99.0.0.0'],
+                ['brand' => 'Chromium', 'version' => '98.0.14335.105'],
+                ['brand' => 'Chrome', 'version' => '98.0.14335.105'],
+            ],
+            true,
+            '',
+            '',
+            ''
+        ));
+        $dd->parse();
+        $this->assertEquals('8.0', $dd->getOs('version'));
+        $this->assertEquals('98.0', $dd->getClient('version'));
+        AbstractParser::setVersionTruncation(AbstractParser::VERSION_TRUNCATION_NONE);
+    }
+
     /**
      * @dataProvider getBotFixtures
      */


### PR DESCRIPTION
When the browser or os version is detected using client hints, the version is currently not truncated using the configured version truncation.