### PR TITLE
Fix issue when providing an array with numeric index for client hint factory

### DIFF
--- a/ClientHints.php
+++ b/ClientHints.php
@@ -236,7 +236,7 @@ class ClientHints
         $fullVersionList = [];
 
         foreach ($headers as $name => $value) {
-            switch (\str_replace('_', '-', \strtolower($name))) {
+            switch (\str_replace('_', '-', \strtolower(\strval($name)))) {
                 case 'http-sec-ch-ua-arch':
                 case 'sec-ch-ua-arch':
                 case 'arch':

--- a/ClientHints.php
+++ b/ClientHints.php
@@ -236,7 +236,7 @@ class ClientHints
         $fullVersionList = [];
 
         foreach ($headers as $name => $value) {
-            switch (\str_replace('_', '-', \strtolower(\strval($name)))) {
+            switch (\str_replace('_', '-', \strtolower((string) $name))) {
                 case 'http-sec-ch-ua-arch':
                 case 'sec-ch-ua-arch':
                 case 'arch':


### PR DESCRIPTION
### Description:

The factory for client hints might throw an error on PHP 8, if the provided array contains a record with a numeric key, as `strtolower` doesn't accept integers anymore.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
