### PR TITLE
Detect GNOME Web if is this linux OS and browser safari

### DIFF
--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -939,7 +939,7 @@ class Browser extends AbstractClientParser
             $engine        = $this->buildEngine($regex['engine'] ?? [], $version);
             $engineVersion = $this->buildEngineVersion($engine);
 
-            if ('Safari' === $name && $this->matchUserAgent('X11; Linux')) {
+            if ('Safari' === $name && $this->matchUserAgent('\(X11; Linux')) {
                 $name         = 'GNOME Web';
                 $version      = '';
                 $browserShort = 'EP';

--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -939,6 +939,12 @@ class Browser extends AbstractClientParser
             $engine        = $this->buildEngine($regex['engine'] ?? [], $version);
             $engineVersion = $this->buildEngineVersion($engine);
 
+            if ('Safari' === $name && $this->matchUserAgent('X11; Linux')) {
+                $name         = 'GNOME Web';
+                $version      = '';
+                $browserShort = 'EP';
+            }
+
             return [
                 'name'           => $name,
                 'short_name'     => $browserShort,

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -7203,3 +7203,12 @@
     engine: Gecko
     engine_version: "105.0"
     family: Firefox
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15
+  client:
+    type: browser
+    name: GNOME Web
+    version:
+    engine: WebKit
+    engine_version: 605.1.15
+    family:


### PR DESCRIPTION
#7340 
I agree that Safari cannot be in linux, so this browser has been replaced with GNOME Web, in this fix.