### PR TITLE
Add OnlineOrNot to bots.yml

### DIFF
--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -2175,7 +2175,7 @@
     url: "https://onlineornot.com/website-monitoring"
     producer:
       name: OnlineOrNot
-      url: https://www.onlineornot.com
+      url: https://onlineornot.com
 -
   user_agent: Mozilla/5.0 (compatible; spbot/4.0.9; +http://OpenLinkProfiler.org/bot )
   bot:

--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -2168,6 +2168,15 @@
       name: Omgili
       url: http://www.omgili.com
 -
+  user_agent: OnlineOrNot.com_bot_1.0_(https://onlineornot.com)
+  bot:
+    name: OnlineOrNot Bot
+    category: Site Monitor
+    url: "https://onlineornot.com/website-monitoring"
+    producer:
+      name: OnlineOrNot
+      url: https://www.onlineornot.com
+-
   user_agent: Mozilla/5.0 (compatible; spbot/4.0.9; +http://OpenLinkProfiler.org/bot )
   bot:
     name: OpenLinkProfiler

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -1028,6 +1028,14 @@
 - regex: 'Octopus [0-9]'
   name: 'Octopus'
 
+- regex: 'OnlineOrNot.com_bot'
+  name: 'OnlineOrNot Bot'
+  category: 'Site Monitor'
+  url: 'https://onlineornot.com/website-monitoring'
+  producer:
+    name: 'OnlineOrNot'
+    url: 'https://onlineornot.com/'
+
 - regex: 'omgili'
   name: 'Omgili bot'
   category: 'Search bot'

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -1034,7 +1034,7 @@
   url: 'https://onlineornot.com/website-monitoring'
   producer:
     name: 'OnlineOrNot'
-    url: 'https://onlineornot.com/'
+    url: 'https://onlineornot.com'
 
 - regex: 'omgili'
   name: 'Omgili bot'


### PR DESCRIPTION
### Description:

This PR adds OnlineOrNot to matomo's bot detection. The full user agent of the bot is `OnlineOrNot.com_bot_1.0_(https://onlineornot.com)`.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
