### PR TITLE
fix Android tablet detection in VERSION_TRUNCATION_MAJOR mode

### DIFF
--- a/DeviceDetector.php
+++ b/DeviceDetector.php
@@ -980,10 +980,10 @@ class DeviceDetector
          * Devices running Android 3.X are tablets. Device type of Android 2.X and 4.X+ are unknown
          */
         if (null === $this->device && 'Android' === $osName && '' !== $osVersion) {
-            if (-1 === \version_compare($osVersion, '2.0')) {
+            if (-1 === \version_compare($osVersion, '2')) {
                 $this->device = AbstractDeviceParser::DEVICE_TYPE_SMARTPHONE;
-            } elseif (\version_compare($osVersion, '3.0') >= 0
-                && -1 === \version_compare($osVersion, '4.0')
+            } elseif (\version_compare($osVersion, '3') >= 0
+                && -1 === \version_compare($osVersion, '4')
             ) {
                 $this->device = AbstractDeviceParser::DEVICE_TYPE_TABLET;
             }

--- a/Parser/AbstractParser.php
+++ b/Parser/AbstractParser.php
@@ -356,6 +356,18 @@ abstract class AbstractParser
         $versionString = $this->buildByMatch($versionString, $matches);
         $versionString = \str_replace('_', '.', $versionString);
 
+        return \trim($versionString, ' .');
+    }
+
+    /**
+     * Truncate the version based on the current truncation rule
+     *
+     * @param string $versionString
+     *
+     * @return string
+     */
+    protected function truncateVersion(string $versionString): string
+    {
         if (self::VERSION_TRUNCATION_NONE !== static::$maxMinorParts
             && \substr_count($versionString, '.') > static::$maxMinorParts
         ) {

--- a/Parser/Client/AbstractClientParser.php
+++ b/Parser/Client/AbstractClientParser.php
@@ -53,7 +53,7 @@ abstract class AbstractClientParser extends AbstractParser
                     $result = [
                         'type'    => $this->parserName,
                         'name'    => $this->buildByMatch($regex['name'], $matches),
-                        'version' => $this->buildVersion((string) $regex['version'], $matches),
+                        'version' => $this->truncateVersion($this->buildVersion((string) $regex['version'], $matches)),
                     ];
 
                     break;

--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -917,7 +917,7 @@ class Browser extends AbstractClientParser
         return [
             'name'       => $name,
             'short_name' => $short,
-            'version'    => $this->buildVersion($version, []),
+            'version'    => $this->truncateVersion($this->buildVersion($version, [])),
         ];
     }
 
@@ -952,8 +952,9 @@ class Browser extends AbstractClientParser
         $browserShort = self::getBrowserShortName($name);
 
         if (null !== $browserShort) {
-            $version       = $this->buildVersion((string) $regex['version'], $matches);
-            $engine        = $this->buildEngine($regex['engine'] ?? [], $version);
+            $fullVersion   = $this->buildVersion((string) $regex['version'], $matches);
+            $version       = $this->truncateVersion($fullVersion);
+            $engine        = $this->buildEngine($regex['engine'] ?? [], $fullVersion);
             $engineVersion = $this->buildEngineVersion($engine);
 
             return [

--- a/Parser/OperatingSystem.php
+++ b/Parser/OperatingSystem.php
@@ -450,7 +450,7 @@ class OperatingSystem extends AbstractParser
         return [
             'name'       => $name,
             'short_name' => $short,
-            'version'    => $this->buildVersion($version, []),
+            'version'    => $this->truncateVersion($this->buildVersion($version, [])),
         ];
     }
 
@@ -479,7 +479,7 @@ class OperatingSystem extends AbstractParser
             ['name' => $name, 'short' => $short] = self::getShortOsData($name);
 
             $version = \array_key_exists('version', $osRegex)
-                ? $this->buildVersion((string) $osRegex['version'], $matches)
+                ? $this->truncateVersion($this->buildVersion((string) $osRegex['version'], $matches))
                 : '';
 
             foreach ($osRegex['versions'] ?? [] as $regex) {
@@ -495,7 +495,7 @@ class OperatingSystem extends AbstractParser
                 }
 
                 if (\array_key_exists('version', $regex)) {
-                    $version = $this->buildVersion((string) $regex['version'], $matches);
+                    $version = $this->truncateVersion($this->buildVersion((string) $regex['version'], $matches));
                 }
 
                 break;

--- a/Tests/DeviceDetectorTest.php
+++ b/Tests/DeviceDetectorTest.php
@@ -230,7 +230,7 @@ class DeviceDetectorTest extends TestCase
         }
 
         $errorMessage = \sprintf(
-            "UserAgent: %s\nHeaders: %s",
+            "UserAgent: %s\nHeaders: %s\nVersion truncation: none",
             $ua,
             \print_r($fixtureData['headers'] ?? null, true)
         );
@@ -238,6 +238,48 @@ class DeviceDetectorTest extends TestCase
         unset($fixtureData['headers']); // ignore headers in result
 
         $this->assertEquals($fixtureData, $uaInfo, $errorMessage);
+    }
+
+    /**
+     * @dataProvider getFixtures
+     */
+    public function testParseWithVersionTruncationMajor(array $fixtureData): void
+    {
+        $ua          = $fixtureData['user_agent'];
+        $clientHints = !empty($fixtureData['headers']) ? ClientHints::factory($fixtureData['headers']) : null;
+
+        AbstractDeviceParser::setVersionTruncation(AbstractDeviceParser::VERSION_TRUNCATION_MAJOR);
+
+        try {
+            $uaInfo = DeviceDetector::getInfoFromUserAgent($ua, $clientHints);
+        } catch (\Exception $exception) {
+            throw new \Exception(
+                \sprintf('Error: %s from useragent %s', $exception->getMessage(), $ua),
+                $exception->getCode(),
+                $exception
+            );
+        }
+
+        $errorMessage = \sprintf(
+            "UserAgent: %s\nHeaders: %s\nVersion truncation: major",
+            $ua,
+            \print_r($fixtureData['headers'] ?? null, true)
+        );
+
+        unset($fixtureData['headers']); // ignore headers in result
+
+        // truncate versions
+        if (\array_key_exists('version', $fixtureData['os'] ?? [])) {
+            $fixtureData['os']['version'] = self::truncateVersion($fixtureData['os']['version']);
+        }
+
+        if (\array_key_exists('version', $fixtureData['client'] ?? [])) {
+            $fixtureData['client']['version'] = self::truncateVersion($fixtureData['client']['version']);
+        }
+
+        $this->assertEquals($fixtureData, $uaInfo, $errorMessage);
+
+        AbstractDeviceParser::setVersionTruncation(AbstractDeviceParser::VERSION_TRUNCATION_NONE);
     }
 
     public function getFixtures(): array
@@ -613,7 +655,7 @@ class DeviceDetectorTest extends TestCase
     public function testSetYamlParser(): void
     {
         $reader = function & ($object, $property) {
-            $value = & Closure::bind(function & () use ($property) {
+            $value = &Closure::bind(function & () use ($property) {
                 return $this->$property;
             }, $object, $object)->__invoke();
 
@@ -630,7 +672,7 @@ class DeviceDetectorTest extends TestCase
 
         foreach ($dd->getClientParsers() as $parser) {
             if ($parser instanceof MobileApp) {
-                $appHints = & $reader($parser, 'appHints');
+                $appHints = &$reader($parser, 'appHints');
                 $this->assertInstanceOf(Symfony::class, $appHints->getYamlParser());
             }
 
@@ -638,7 +680,7 @@ class DeviceDetectorTest extends TestCase
                 continue;
             }
 
-            $browserHints = & $reader($parser, 'browserHints');
+            $browserHints = &$reader($parser, 'browserHints');
             $this->assertInstanceOf(Symfony::class, $browserHints->getYamlParser());
         }
     }
@@ -740,5 +782,20 @@ class DeviceDetectorTest extends TestCase
         }
 
         return $dd;
+    }
+
+    private static function truncateVersion(?string $versionString): ?string
+    {
+        if (null === $versionString) {
+            return null;
+        }
+
+        if (\substr_count($versionString, '.') > 0) {
+            $versionParts  = \explode('.', $versionString);
+            $versionParts  = \array_slice($versionParts, 0, 1);
+            $versionString = \implode('.', $versionParts);
+        }
+
+        return \trim($versionString, ' .');
     }
 }


### PR DESCRIPTION
### Description:

Hello,

First, thanks a lot for this awesome library!

Because of privacy concerns, I'm using this library in `VERSION_TRUNCATION_MAJOR`, and I noticed some issues when parsing some old Android 3 tablet user-agents. The device ends up empty instead of `tablet`.

Looking at the code, it's because of the builtin `version_compare`, for which, I'm not sure why, `3` is lower than `3.0` instead of being equals. I fixed the issue by using only major versions in `version_compare`, instead of major + minor.

For the tests, I've just duplicated the existing ones, running with `VERSION_TRUNCATION_MAJOR` instead of `VERSION_TRUNCATION_NONE`. There's probably a better / faster solution, please tell me what you think.

Thanks a lot in advance!

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
