### PR TITLE
Add JHelioviewer regex

### DIFF
--- a/Tests/Parser/Client/fixtures/mediaplayer.yml
+++ b/Tests/Parser/Client/fixtures/mediaplayer.yml
@@ -197,3 +197,9 @@
     type: mediaplayer
     name: StudioDisplay
     version: "0.5"
+-
+  user_agent: JHV/SWHV-4.4.2.10777 (x86_64 Mac OS X 13.2.1) Eclipse Adoptium JRE 19.0.2
+  client:
+    type: mediaplayer
+    name: JHelioviewer
+    version: 4.4.2.10777

--- a/regexes/client/mediaplayers.yml
+++ b/regexes/client/mediaplayers.yml
@@ -128,3 +128,8 @@
 - regex: 'StudioDisplay/(\d+\.[\d\.]+)'
   name: 'StudioDisplay'
   version: '$1'
+
+# JHelioviewer (https://www.jhelioviewer.org/)
+- regex: 'JHV/SWHV-([.\d+]+)'
+  name: 'JHelioviewer'
+  version: '$1'


### PR DESCRIPTION
### Description:

Add support for the [JHelioviewer](https://www.jhelioviewer.org/) user agent.

This application is very niche, it doesn't really fit into any of your existing client categories.

If you would like to test it, a sample user agent looks like "JHV/SWHV-4.4.2.10777 (x86_64 Mac OS X 13.2.1) Eclipse Adoptium JRE 19.0.2"

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
