### PR TITLE
Fix false positives on Comodo Dragon browser for Dragon-model devices.

### DIFF
--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -7851,3 +7851,12 @@
     engine: Blink
     engine_version: ""
     family: Chrome
+-
+  user_agent: Mozilla/5.0 (Windows NT 10.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36 Dragon/103.0.2674.92
+  client:
+    type: browser
+    name: Comodo Dragon
+    version: "103.0.2674.92"
+    engine: Blink
+    engine_version: "104.0.0.0"
+    family: Chrome

--- a/Tests/fixtures/smartphone-33.yml
+++ b/Tests/fixtures/smartphone-33.yml
@@ -2113,10 +2113,10 @@
     platform: ""
   client:
     type: browser
-    name: Comodo Dragon
-    version: ""
-    engine: WebKit
-    engine_version: "537.36"
+    name: Chrome Mobile
+    version: "105.0.0.0"
+    engine: Blink
+    engine_version: "105.0.0.0"
   device:
     type: smartphone
     brand: Figgers

--- a/Tests/fixtures/smartphone-35.yml
+++ b/Tests/fixtures/smartphone-35.yml
@@ -8345,10 +8345,10 @@
     platform: ""
   client:
     type: browser
-    name: Comodo Dragon
-    version: ""
-    engine: WebKit
-    engine_version: "537.36"
+    name: Chrome Mobile
+    version: "78.0.3904.96"
+    engine: Blink
+    engine_version: "78.0.3904.96"
   device:
     type: smartphone
     brand: SKK Mobile

--- a/Tests/fixtures/tv-1.yml
+++ b/Tests/fixtures/tv-1.yml
@@ -8712,10 +8712,10 @@
     platform: ""
   client:
     type: browser
-    name: Comodo Dragon
-    version: ""
-    engine: WebKit
-    engine_version: "537.36"
+    name: Chrome Webview
+    version: "103.0.5060.129"
+    engine: Blink
+    engine_version: "103.0.5060.129"
   device:
     type: tv
     brand: DRAGON

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -1719,7 +1719,7 @@
     default: '' # multi engine
 
 #Comodo Dragon
-- regex: '(?:Comodo[ _])?Dragon(?!fruit)(?:/(\d+[\.\d]+))?'
+- regex: 'Comodo[ _]Dragon(?:/(\d+[\.\d]+))?'
   name: 'Comodo Dragon'
   version: '$1'
   engine:

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -1719,7 +1719,7 @@
     default: '' # multi engine
 
 #Comodo Dragon
-- regex: 'Comodo[ _]Dragon(?:/(\d+[\.\d]+))?'
+- regex: '(?:Comodo[ _])?Dragon/(\d+[\.\d]+)'
   name: 'Comodo Dragon'
   version: '$1'
   engine:


### PR DESCRIPTION
### Description:

While looking at detection of some Chrome-based browsers, I noticed that some Android devices with the word "Dragon" in their model name (Figgers DragonX, Dragon OTT, and HyperX Dragon) were being detected as the Comodo Dragon browser. [Comodo Dragon seems to be a desktop-only browser according to their website](https://www.comodo.com/home/browsers-toolbars/browser.php), so I believe these detections are incorrect.

This bug seems to have been originally introduced in [#6019](https://github.com/matomo-org/device-detector/pull/6019/commits/e2265b735db2deb0af7887207fda20a7b3d8d802#diff-e9f1828dc013af23fc0fc945235ca192a44a36869ce0f6f3be7087d1ba5fd5f7R493), which loosened the regex from `Comodo[ _]Dragon(?:/(\d+[\.\d]+))?` to `(?:Comodo[ _])?Dragon(?!fruit)(?:/(\d+[\.\d]+))?` (making the "Comodo" part optional as long as it isn't in the context of the word "Dragonfruit"). However, that PR didn't add any new test cases for the Comodo Dragon browser to indicate that the browser uses a user agent without the word "Comodo".

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
