### PR TITLE
Fix false positive for Edge engine on Motorola Edge.

### DIFF
--- a/Tests/fixtures/smartphone-37.yml
+++ b/Tests/fixtures/smartphone-37.yml
@@ -4677,8 +4677,8 @@
     type: browser
     name: Samsung Browser
     version: "23.0"
-    engine: Edge
-    engine_version: "40"
+    engine: WebKit
+    engine_version: "537.36"
   device:
     type: smartphone
     brand: Motorola

--- a/regexes/client/browser_engine.yml
+++ b/regexes/client/browser_engine.yml
@@ -8,7 +8,7 @@
 - regex: 'NetFront'
   name: 'NetFront'
 
-- regex: 'Edge'
+- regex: 'Edge/'
   name: 'Edge'
 
 - regex: 'Trident'


### PR DESCRIPTION
### Description:

Motorola Edge devices were being incorrectly detected as the Edge engine. This PR changes the match to be more strict (`Edge` -> `Edge/`) to prevent that false positive.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
