### PR TITLE
Add User-Agent strings for Kiwi TCMS

### DIFF
--- a/Tests/Parser/Client/fixtures/library.yml
+++ b/Tests/Parser/Client/fixtures/library.yml
@@ -611,3 +611,27 @@
     type: library
     name: request
     version: ""
+-
+  user_agent: kiwi-tcms/13.0
+  client:
+    type: library
+    name: Kiwi TCMS
+    version: 13.0
+-
+  user_agent: kiwi-tcms/12.6.1-Enterprise
+  client:
+    type: library
+    name: Kiwi TCMS
+    version: 12.6.1
+-
+  user_agent: tcms-api/12.9.1/Python 3.11.8 (main, Feb  7 2024, 04:02:05) [GCC 11.4.0]
+  client:
+    type: library
+    name: Kiwi TCMS API
+    version: 12.9.1
+-
+  user_agent: tcms-api/12.7/Java
+  client:
+    type: library
+    name: Kiwi TCMS API
+    version: 12.7

--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -6862,3 +6862,21 @@
     producer:
       name: Barracuda Networks, Inc.
       url: https://www.barracudanetworks.com/
+-
+  user_agent: kiwitcms-gitops/0.1
+  bot:
+    name: Kiwi TCMS GitOps
+    category: Service Agent
+    url: https://kiwitcms.org
+    producer:
+      name: Open Technologies Bulgaria, Ltd.
+      url: https://kiwitcms.org
+-
+  user_agent: kiwitcms-gitops/1
+  bot:
+    name: Kiwi TCMS GitOps
+    category: Service Agent
+    url: https://kiwitcms.org
+    producer:
+      name: Open Technologies Bulgaria, Ltd.
+      url: https://kiwitcms.org

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -4002,6 +4002,14 @@
     name: 'Barracuda Networks, Inc.'
     url: 'https://www.barracudanetworks.com/'
 
+- regex: 'kiwitcms-gitops/[\d.]+'
+  name: 'Kiwi TCMS GitOps'
+  category: 'Service Agent'
+  url: 'https://kiwitcms.org'
+  producer:
+    name: 'Open Technologies Bulgaria, Ltd.'
+    url: 'https://kiwitcms.org'
+
 # Generic detections
 - regex: 'nuhk|grub-client|Download Demon|SearchExpress|Microsoft URL Control|borg|altavista|dataminr\.com|tweetedtimes\.com|teoma|oegp|http%20client|htdig|mogimogi|larbin|scrubby|searchsight|semanticdiscovery|snappy|vortex(?!(?: Build|Plus))|zeal(?!ot)|dataparksearch|findlinks|BrowserMob|URL2PNG|ZooShot|GomezA|Google SketchUp|Read%20Later|7Siters|centuryb\.o\.t9|InterNaetBoten|EasyBib AutoCite|Bidtellect|tomnomnom/meg|cortex|Re-re Studio|adreview|AHC/|NameOfAgent|Request-Promise|ALittle Client|Hello,? world|wp_is_mobile|0xAbyssalDoesntExist|Anarchy99|daumoa,damoa,daum,daumos,duamoa,duam,duamos|^revolt|nvd0rz|xfa1|Hakai|gbrmss|fuck-your-hp|IDBTE4M CODE87|Antoine|Insomania|Hells-Net|b3astmode|Linux Gnu \(cow\)|Test Certificate Info|iplabel|Magellan|TheSafex?Internetx?Search|kirkland-signature|^xenu|^ZmEu|^(?:chrome|firefox|Zeus)$'
   name: 'Generic Bot'

--- a/regexes/client/libraries.yml
+++ b/regexes/client/libraries.yml
@@ -5,6 +5,16 @@
 # @license http://www.gnu.org/licenses/lgpl.html LGPL v3 or later
 ###############
 
+- regex: 'kiwi-tcms/(\d+[\.\d]+)'
+  name: 'Kiwi TCMS'
+  version: '$1'
+  url: 'https://kiwitcms.org'
+
+- regex: 'tcms-api/(\d+[\.\d]+)'
+  name: 'Kiwi TCMS API'
+  version: '$1'
+  url: 'https://kiwitcms.org'
+
 - regex: 'Fuzz Faster U Fool v(\d+[\.\d]+)'
   name: 'FFUF'
   version: '$1'


### PR DESCRIPTION
primarily so we can see our own stats display nicely in Plausible.io

### Description:

[Kiwi TCMS](http://kiwitcms.org) is using the Plausible.io API to collect anonymous stats like numbers of active installations and their versions out there in the wild.  Adding our user-agent string so that the parser can recognize them and Plausible can show nicer stats. 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
