### PR TITLE
Fix Class Spyc not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,12 @@
         "psr-4": { "DeviceDetector\\": "" },
         "exclude-from-classmap": ["Tests/"]
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/mustangostang/spyc.git"
+        }
+    ],
     "require": {
         "php": "^7.2|^8.0",
         "mustangostang/spyc": "*"


### PR DESCRIPTION
Fixes #7620.

Something went wrong on https://packagist.org/packages/mustangostang/spyc