### PR TITLE
Apple watches most commonly use a generic watchOS version.

### DIFF
--- a/Tests/fixtures/wearable.yml
+++ b/Tests/fixtures/wearable.yml
@@ -288,6 +288,20 @@
   os_family: iOS
   browser_family: Unknown
 -
+  user_agent: atc/1.0 watchOS
+  os:
+    name: watchOS
+    version: ""
+    platform: ARM
+  client: null
+  device:
+    type: wearable
+    brand: Apple
+    model: Watch
+  os_family: iOS
+  browser_family: Unknown
+
+-
   user_agent: com.apple.appstored/1.0 watchOS/7.0 model/Watch6,1 hwp/t8301 build/18R382 (6; dt:226) AMS/1
   os:
     name: watchOS

--- a/regexes/device/mobiles.yml
+++ b/regexes/device/mobiles.yml
@@ -1006,7 +1006,7 @@ Apple:
     - regex: 'Watch7,[24]'
       device: 'wearable'
       model: 'Watch Series 9 45mm'
-    - regex: 'Apple Watch'
+    - regex: '(:?Apple Watch|watchOS)'
       device: 'wearable'
       model: 'Watch'
 

--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -1200,7 +1200,7 @@
 ##########
 # watchOS (https://developer.apple.com/watchos/)
 ##########
-- regex: '(?:Watch1,[12]/|Watch OS,|watchOS[ /])(\d+[\.\d]*)'
+- regex: '(?:Watch1,[12]/|Watch OS,|watchOS[ /]?)(\d+[\.\d]*)?'
   name: 'watchOS'
   version: '$1'
 - regex: 'Apple Watch(?!;)'


### PR DESCRIPTION
### Description:

One of the most common user agents we receive is merely 'atc/1.0 watchOS' with no other information. Always an apple watch so far as I know.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
