### PR TITLE
Improves detection for macOS

### DIFF
--- a/Tests/Parser/fixtures/oss.yml
+++ b/Tests/Parser/fixtures/oss.yml
@@ -5190,3 +5190,19 @@
     version: "15.1"
     platform: ""
     family: Mac
+-
+  user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15 (Ecosia ios@10.0.4.1853)
+  os:
+    name: Mac
+    short_name: MAC
+    version: 10.15.7
+    platform: ""
+    family: Mac
+-
+  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 15_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) (Ecosia ios@4.0.6.795)
+  os:
+    name: iOS
+    short_name: IOS
+    version: 15.4.1
+    platform: ""
+    family: iOS

--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -1530,7 +1530,7 @@
   name: 'iOS'
   version: ''
 
-- regex: 'CaptiveNetworkSupport|AirPlay|.*[ \.\-/]iOS'
+- regex: 'CaptiveNetworkSupport|AirPlay|.*[ \.\-/]iOS(?!@)'
   name: 'iOS'
   version: ''
 


### PR DESCRIPTION
`Ecosia` on `macOS` was wrongly detected as `iOS`.