### PR TITLE
Adds detection for Puffin OS, Puffin Cloud Browser, Puffin Incognito Browser and renames Puffin to Puffin Secure Browser

### DIFF
--- a/DeviceDetector.php
+++ b/DeviceDetector.php
@@ -1056,7 +1056,7 @@ class DeviceDetector
         /**
          * All devices running Puffin Web Browser that contain letter 'T' are assumed to be tablets
          */
-        if (null === $this->device && $this->matchUserAgent('Puffin/.*[AIFLW]T')) {
+        if (null === $this->device && $this->matchUserAgent('Puffin/.*[AILW]T')) {
             $this->device = AbstractDeviceParser::DEVICE_TYPE_TABLET;
         }
 

--- a/DeviceDetector.php
+++ b/DeviceDetector.php
@@ -1042,21 +1042,21 @@ class DeviceDetector
         /**
          * All devices running Puffin Secure Browser that contain letter 'D' are assumed to be desktops
          */
-        if (null === $this->device && $this->matchUserAgent('Puffin/.*[LMW]D')) {
+        if (null === $this->device && $this->matchUserAgent('Puffin/(?:\d+[.\d]+)[LMW]D')) {
             $this->device = AbstractDeviceParser::DEVICE_TYPE_DESKTOP;
         }
 
         /**
          * All devices running Puffin Web Browser that contain letter 'P' are assumed to be smartphones
          */
-        if (null === $this->device && $this->matchUserAgent('Puffin/.*[AIFLW]P')) {
+        if (null === $this->device && $this->matchUserAgent('Puffin/(?:\d+[.\d]+)[AIFLW]P')) {
             $this->device = AbstractDeviceParser::DEVICE_TYPE_SMARTPHONE;
         }
 
         /**
          * All devices running Puffin Web Browser that contain letter 'T' are assumed to be tablets
          */
-        if (null === $this->device && $this->matchUserAgent('Puffin/.*[AILW]T')) {
+        if (null === $this->device && $this->matchUserAgent('Puffin/(?:\d+[.\d]+)[AILW]T')) {
             $this->device = AbstractDeviceParser::DEVICE_TYPE_TABLET;
         }
 

--- a/DeviceDetector.php
+++ b/DeviceDetector.php
@@ -1040,6 +1040,27 @@ class DeviceDetector
         }
 
         /**
+         * All devices running Puffin Secure Browser that contain letter 'D' are assumed to be desktops
+         */
+        if (null === $this->device && $this->matchUserAgent('Puffin/.*[LMW]D')) {
+            $this->device = AbstractDeviceParser::DEVICE_TYPE_DESKTOP;
+        }
+
+        /**
+         * All devices running Puffin Web Browser that contain letter 'P' are assumed to be smartphones
+         */
+        if (null === $this->device && $this->matchUserAgent('Puffin/.*[AIFLW]P')) {
+            $this->device = AbstractDeviceParser::DEVICE_TYPE_SMARTPHONE;
+        }
+
+        /**
+         * All devices running Puffin Web Browser that contain letter 'T' are assumed to be tablets
+         */
+        if (null === $this->device && $this->matchUserAgent('Puffin/.*[AIFLW]T')) {
+            $this->device = AbstractDeviceParser::DEVICE_TYPE_TABLET;
+        }
+
+        /**
          * All devices running Opera TV Store are assumed to be a tv
          */
         if ($this->matchUserAgent('Opera TV Store| OMI/')) {

--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -765,7 +765,7 @@ class Browser extends AbstractClientParser
             'K4', 'WK', 'T3', 'K5', 'MU', '9P', 'K6', 'VR', 'N9',
             'M9', 'F9', '0P', '0A', 'JR', 'D3', 'TK', 'BP', '2F',
             '2M', 'K7', '1N', '8A', 'H7', 'X3', 'T4', 'X4', '5O',
-            '8C', '3M', '6I', '2P',
+            '8C', '3M', '6I', '2P', 'PU',
         ],
         'Firefox'            => [
             'FF', 'BI', 'BF', 'BH', 'BN', 'C0', 'CU', 'EI', 'F1',

--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -765,7 +765,7 @@ class Browser extends AbstractClientParser
             'K4', 'WK', 'T3', 'K5', 'MU', '9P', 'K6', 'VR', 'N9',
             'M9', 'F9', '0P', '0A', 'JR', 'D3', 'TK', 'BP', '2F',
             '2M', 'K7', '1N', '8A', 'H7', 'X3', 'T4', 'X4', '5O',
-            '8C', '3M', '6I',
+            '8C', '3M', '6I', '2P',
         ],
         'Firefox'            => [
             'FF', 'BI', 'BF', 'BH', 'BN', 'C0', 'CU', 'EI', 'F1',

--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -793,7 +793,7 @@ class Browser extends AbstractClientParser
         '36', 'AH', 'AI', 'BL', 'C1', 'C4', 'CB', 'CW', 'DB',
         '3M', 'DT', 'EU', 'EZ', 'FK', 'FM', 'FR', 'FX', 'GH',
         'GI', 'GR', 'HA', 'HU', 'IV', 'JB', 'KD', 'M1', 'MF',
-        'MN', 'MZ', 'NX', 'OC', 'OI', 'OM', 'OZ', 'PU', 'PI',
+        'MN', 'MZ', 'NX', 'OC', 'OI', 'OM', 'OZ', '2P', 'PI',
         'PE', 'QU', 'RE', 'S0', 'S7', 'SA', 'SB', 'SG', 'SK',
         'ST', 'SU', 'T1', 'UH', 'UM', 'UT', 'VE', 'VV', 'WI',
         'WP', 'YN', 'IO', 'IS', 'HQ', 'RW', 'HI', 'PN', 'BW',

--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -491,7 +491,7 @@ class Browser extends AbstractClientParser
         'PP' => 'Oppo Browser',
         'P6' => 'Opus Browser',
         'PR' => 'Palm Pre',
-        'PU' => 'Puffin',
+        'PU' => 'Puffin Secure Browser',
         '2P' => 'Puffin Web Browser',
         'PW' => 'Palm WebPro',
         'PA' => 'Palmscape',

--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -491,6 +491,7 @@ class Browser extends AbstractClientParser
         'PP' => 'Oppo Browser',
         'P6' => 'Opus Browser',
         'PR' => 'Palm Pre',
+        '6I' => 'Puffin Incognito Browser',
         'PU' => 'Puffin Secure Browser',
         '2P' => 'Puffin Web Browser',
         'PW' => 'Palm WebPro',
@@ -764,7 +765,7 @@ class Browser extends AbstractClientParser
             'K4', 'WK', 'T3', 'K5', 'MU', '9P', 'K6', 'VR', 'N9',
             'M9', 'F9', '0P', '0A', 'JR', 'D3', 'TK', 'BP', '2F',
             '2M', 'K7', '1N', '8A', 'H7', 'X3', 'T4', 'X4', '5O',
-            '8C', '3M',
+            '8C', '3M', '6I',
         ],
         'Firefox'            => [
             'FF', 'BI', 'BF', 'BH', 'BN', 'C0', 'CU', 'EI', 'F1',
@@ -812,7 +813,7 @@ class Browser extends AbstractClientParser
         '5A', 'TT', '6P', 'G3', '7P', 'VU', 'F8', 'L4', 'DK',
         'DP', 'KL', 'K4', 'N6', 'KU', 'WK', 'M8', 'UP', 'ZT',
         '9P', 'N8', 'VR', 'N9', 'M9', 'F9', '0P', '0A', '2F',
-        '2M', 'K7', '1N', '8A', 'H7', 'X3', 'X4', '5O',
+        '2M', 'K7', '1N', '8A', 'H7', 'X3', 'X4', '5O', '6I',
     ];
 
     /**

--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -491,6 +491,7 @@ class Browser extends AbstractClientParser
         'PP' => 'Oppo Browser',
         'P6' => 'Opus Browser',
         'PR' => 'Palm Pre',
+        '7I' => 'Puffin Cloud Browser',
         '6I' => 'Puffin Incognito Browser',
         'PU' => 'Puffin Secure Browser',
         '2P' => 'Puffin Web Browser',
@@ -765,7 +766,7 @@ class Browser extends AbstractClientParser
             'K4', 'WK', 'T3', 'K5', 'MU', '9P', 'K6', 'VR', 'N9',
             'M9', 'F9', '0P', '0A', 'JR', 'D3', 'TK', 'BP', '2F',
             '2M', 'K7', '1N', '8A', 'H7', 'X3', 'T4', 'X4', '5O',
-            '8C', '3M', '6I', '2P', 'PU',
+            '8C', '3M', '6I', '2P', 'PU', '7I',
         ],
         'Firefox'            => [
             'FF', 'BI', 'BF', 'BH', 'BN', 'C0', 'CU', 'EI', 'F1',
@@ -814,6 +815,7 @@ class Browser extends AbstractClientParser
         'DP', 'KL', 'K4', 'N6', 'KU', 'WK', 'M8', 'UP', 'ZT',
         '9P', 'N8', 'VR', 'N9', 'M9', 'F9', '0P', '0A', '2F',
         '2M', 'K7', '1N', '8A', 'H7', 'X3', 'X4', '5O', '6I',
+        '7I',
     ];
 
     /**

--- a/Parser/OperatingSystem.php
+++ b/Parser/OperatingSystem.php
@@ -156,6 +156,7 @@ class OperatingSystem extends AbstractParser
         'PSP' => 'PlayStation Portable',
         'PS3' => 'PlayStation',
         'PVE' => 'Proxmox VE',
+        'PUF' => 'Puffin OS',
         'PUR' => 'PureOS',
         'QTP' => 'Qtopia',
         'PIO' => 'Raspberry Pi OS',
@@ -232,7 +233,7 @@ class OperatingSystem extends AbstractParser
         'Android'               => [
             'AND', 'CYN', 'FIR', 'REM', 'RZD', 'MLD', 'MCD', 'YNS', 'GRI', 'HAR',
             'ADR', 'CLR', 'BOS', 'REV', 'LEN', 'SIR', 'RRS', 'WER', 'PIC', 'ARM',
-            'HEL', 'BYI', 'RIS',
+            'HEL', 'BYI', 'RIS', 'PUF',
         ],
         'AmigaOS'               => ['AMG', 'MOR', 'ARO'],
         'BlackBerry'            => ['BLB', 'QNX'],

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -10176,3 +10176,12 @@
     family: Chrome
   headers:
     http-x-requested-with: com.cloudmosa.puffinIncognito
+-
+  user_agent: Mozilla/5.0 (Cloud Phone; Generic) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.243 Mobile Safari/537.36 Puffin/12.1.1.51391FP
+  client:
+    type: browser
+    name: Puffin Web Browser
+    version: 12.1.1.51391
+    engine: Blink
+    engine_version: 124.0.6367.243
+    family: Chrome

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -10248,3 +10248,12 @@
     engine: Blink
     engine_version: 79.0.3945.136
     family: Chrome
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; en-CA) AppleWebKit/534.35 (KHTML, like Gecko) Chrome/11.0.696.65 Safari/534.35 Puffin/2.0.5603
+  client:
+    type: browser
+    name: Puffin Web Browser
+    version: 2.0.5603
+    engine: WebKit
+    engine_version: "534.35"
+    family: Chrome

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -10180,7 +10180,7 @@
   user_agent: Mozilla/5.0 (Cloud Phone; Generic) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.243 Mobile Safari/537.36 Puffin/12.1.1.51391FP
   client:
     type: browser
-    name: Puffin Web Browser
+    name: Puffin Cloud Browser
     version: 12.1.1.51391
     engine: Blink
     engine_version: 124.0.6367.243
@@ -10257,3 +10257,14 @@
     engine: WebKit
     engine_version: "534.35"
     family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 13; SM-A137F Build/TP1A.220624.014; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/112.0.5615.136 Mobile Safari/537.36
+  client:
+    type: browser
+    name: Puffin Cloud Browser
+    version: ""
+    engine: Blink
+    engine_version: 112.0.5615.136
+    family: Chrome
+  headers:
+    http-x-requested-with: com.cloudmosa.puffinCloudBrowser

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -1395,14 +1395,14 @@
     engine_version: 525.27.1
     family: ""
 -
-  user_agent: 'Mozilla/5.0 (X11; U; Linux x86_64; fa-ir) AppleWebKit/534.35 (KHTML, like Gecko)  Chrome/11.0.696.65 Safari/534.35 Puffin/2.10977AP'
+  user_agent: Mozilla/5.0 (X11; U; Linux x86_64; fa-ir) AppleWebKit/534.35 (KHTML, like Gecko) Chrome/11.0.696.65 Safari/534.35 Puffin/2.10977AP
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: "2.10977"
     engine: WebKit
     engine_version: "534.35"
-    family: ""
+    family: Chrome
 -
   user_agent: Mozilla/4.76 (compatible; MSIE 6.0; U; Windows 95; PalmSource; PalmOS; WebPro; Tungsten Proxyless 1.1 320x320x16)
   client:
@@ -10184,4 +10184,40 @@
     version: 12.1.1.51391
     engine: Blink
     engine_version: 124.0.6367.243
+    family: Chrome
+-
+  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 17_6_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/21G93 Safari/604.1 Puffin/8.0.2LP
+  client:
+    type: browser
+    name: Puffin Web Browser
+    version: 8.0.2
+    engine: WebKit
+    engine_version: 605.1.15
+    family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 14; V2315 Build/UP1A.231005.007; en-us) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.66 Mobile Safari/537.36 Puffin/10.2.1.51662AP
+  client:
+    type: browser
+    name: Puffin Web Browser
+    version: 10.2.1.51662
+    engine: Blink
+    engine_version: 87.0.4280.66
+    family: Chrome
+-
+  user_agent: Mozilla/5.0 (iPod; U; CPU iPhone OS 6_1 like Mac OS X; en-HK) AppleWebKit/534.35 (KHTML, like Gecko) Chrome/11.0.696.65 Safari/534.35 Puffin/3.9174IP Mobile
+  client:
+    type: browser
+    name: Puffin Web Browser
+    version: "3.9174"
+    engine: WebKit
+    engine_version: "534.35"
+    family: Chrome
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; en-gb) AppleWebKit/534.35 (KHTML, like Gecko) Chrome/11.0.696.65 Safari/534.35 Puffin/2.0.5603M
+  client:
+    type: browser
+    name: Puffin Web Browser
+    version: 2.0.5603
+    engine: WebKit
+    engine_version: "534.35"
     family: Chrome

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -10221,3 +10221,30 @@
     engine: WebKit
     engine_version: "534.35"
     family: Chrome
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36 Puffin/8.2.4.705LD
+  client:
+    type: browser
+    name: Puffin Secure Browser
+    version: 8.2.4.705
+    engine: Blink
+    engine_version: 69.0.3497.100
+    family: Chrome
+-
+  user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_16_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36 Puffin/7.9.0.102MD
+  client:
+    type: browser
+    name: Puffin Secure Browser
+    version: 7.9.0.102
+    engine: Blink
+    engine_version: 69.0.3497.100
+    family: Chrome
+-
+  user_agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36 Puffin/9.0.1.982WD
+  client:
+    type: browser
+    name: Puffin Secure Browser
+    version: 9.0.1.982
+    engine: Blink
+    engine_version: 79.0.3945.136
+    family: Chrome

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -1398,7 +1398,7 @@
   user_agent: 'Mozilla/5.0 (X11; U; Linux x86_64; fa-ir) AppleWebKit/534.35 (KHTML, like Gecko)  Chrome/11.0.696.65 Safari/534.35 Puffin/2.10977AP'
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: "2.10977"
     engine: WebKit
     engine_version: "534.35"

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -10165,3 +10165,14 @@
     family: Chrome
   headers:
     Sec-CH-UA: '"Not_A Brand";v="8", "Chromium";v="120", "Mises";v="120"'
+-
+  user_agent: Mozilla/5.0 (Linux; Android 13; SM-A137F Build/TP1A.220624.014; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/112.0.5615.136 Mobile Safari/537.36
+  client:
+    type: browser
+    name: Puffin Incognito Browser
+    version: ""
+    engine: Blink
+    engine_version: 112.0.5615.136
+    family: Chrome
+  headers:
+    http-x-requested-with: com.cloudmosa.puffinIncognito

--- a/Tests/Parser/fixtures/oss.yml
+++ b/Tests/Parser/fixtures/oss.yml
@@ -5206,3 +5206,11 @@
     version: 15.4.1
     platform: ""
     family: iOS
+-
+  user_agent: Mozilla/5.0 (Cloud Phone; Generic) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.243 Mobile Safari/537.36 Puffin/12.1.1.51391FP
+  os:
+    name: Puffin OS
+    short_name: PUF
+    version: ""
+    platform: ""
+    family: Android

--- a/Tests/Parser/fixtures/type-methods.yml
+++ b/Tests/Parser/fixtures/type-methods.yml
@@ -33,7 +33,7 @@
   user_agent: Opera/9.80 (J2ME/MIDP; Opera Mini/9.5/37.8069; U; en) Presto/2.12.423 Version/12.16
   check: [false, true, false, false, false, false]
 -
-  user_agent: 'Mozilla/5.0 (X11; U; Linux i686; th-TH@calendar=gregorian) AppleWebKit/534.12 (KHTML, like Gecko) Puffin/1.3.2665MS Safari/534.12'
+  user_agent: 'Mozilla/5.0 (Linux; Android 14; V2315 Build/UP1A.231005.007; en-us) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.66 Mobile Safari/537.36 Puffin/10.2.1.51662AP'
   check: [false, true, false, false, false, false]
 -
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; MX4 Pro Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36; 360 Aphone Browser (6.9.7)

--- a/Tests/fixtures/desktop-1.yml
+++ b/Tests/fixtures/desktop-1.yml
@@ -35,3 +35,21 @@
     model: ""
   os_family: Mac
   browser_family: Chrome
+-
+  user_agent: 'Mozilla/5.0 (X11; U; Linux x86_64; fa-ir) AppleWebKit/534.35 (KHTML, like Gecko)  Chrome/11.0.696.65 Safari/534.35 Puffin/2.10977AP'
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: x64
+  client:
+    type: browser
+    name: Puffin Secure Browser
+    version: "2.10977"
+    engine: WebKit
+    engine_version: "534.35"
+  device:
+    type: desktop
+    brand: ""
+    model: ""
+  os_family: GNU/Linux
+  browser_family: Unknown

--- a/Tests/fixtures/desktop-1.yml
+++ b/Tests/fixtures/desktop-1.yml
@@ -35,3 +35,21 @@
     model: ""
   os_family: Mac
   browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36 Puffin/8.2.4.705LD
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: ARM
+  client:
+    type: browser
+    name: Puffin Secure Browser
+    version: 8.2.4.705
+    engine: Blink
+    engine_version: 69.0.3497.100
+  device:
+    type: desktop
+    brand: ""
+    model: ""
+  os_family: GNU/Linux
+  browser_family: Chrome

--- a/Tests/fixtures/desktop-1.yml
+++ b/Tests/fixtures/desktop-1.yml
@@ -35,21 +35,3 @@
     model: ""
   os_family: Mac
   browser_family: Chrome
--
-  user_agent: 'Mozilla/5.0 (X11; U; Linux x86_64; fa-ir) AppleWebKit/534.35 (KHTML, like Gecko)  Chrome/11.0.696.65 Safari/534.35 Puffin/2.10977AP'
-  os:
-    name: GNU/Linux
-    version: ""
-    platform: x64
-  client:
-    type: browser
-    name: Puffin Secure Browser
-    version: "2.10977"
-    engine: WebKit
-    engine_version: "534.35"
-  device:
-    type: desktop
-    brand: ""
-    model: ""
-  os_family: GNU/Linux
-  browser_family: Unknown

--- a/Tests/fixtures/smartphone-15.yml
+++ b/Tests/fixtures/smartphone-15.yml
@@ -3604,7 +3604,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 7.5.3.20547
     engine: Blink
     engine_version: 63.0.3239.111
@@ -3613,7 +3613,7 @@
     brand: teXet
     model: X-Driver Quad
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 6.0; X-Force(TM-5009) Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.91 Mobile Safari/537.36
   os:

--- a/Tests/fixtures/smartphone-15.yml
+++ b/Tests/fixtures/smartphone-15.yml
@@ -3604,7 +3604,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 7.5.3.20547
     engine: Blink
     engine_version: 63.0.3239.111

--- a/Tests/fixtures/smartphone-19.yml
+++ b/Tests/fixtures/smartphone-19.yml
@@ -403,7 +403,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 8.4.0.42081
     engine: Blink
     engine_version: 69.0.3497.100
@@ -412,7 +412,7 @@
     brand: Oukitel
     model: U16 Max
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 7.0; U7 Max) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:

--- a/Tests/fixtures/smartphone-19.yml
+++ b/Tests/fixtures/smartphone-19.yml
@@ -403,7 +403,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 8.4.0.42081
     engine: Blink
     engine_version: 69.0.3497.100

--- a/Tests/fixtures/smartphone-2.yml
+++ b/Tests/fixtures/smartphone-2.yml
@@ -2050,7 +2050,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 7.8.3.40913
     engine: Blink
     engine_version: 69.0.3497.100
@@ -2059,7 +2059,7 @@
     brand: Asus
     model: ZenFone 3 Max
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ASUS_A001) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:

--- a/Tests/fixtures/smartphone-2.yml
+++ b/Tests/fixtures/smartphone-2.yml
@@ -2050,7 +2050,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 7.8.3.40913
     engine: Blink
     engine_version: 69.0.3497.100

--- a/Tests/fixtures/smartphone-24.yml
+++ b/Tests/fixtures/smartphone-24.yml
@@ -2889,7 +2889,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 7.5.0.20369
     engine: Blink
     engine_version: 63.0.3239.111
@@ -2898,7 +2898,7 @@
     brand: LG
     model: L Bello
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 9; LGL322DL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:

--- a/Tests/fixtures/smartphone-24.yml
+++ b/Tests/fixtures/smartphone-24.yml
@@ -2889,7 +2889,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 7.5.0.20369
     engine: Blink
     engine_version: 63.0.3239.111

--- a/Tests/fixtures/smartphone-28.yml
+++ b/Tests/fixtures/smartphone-28.yml
@@ -9501,7 +9501,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 9.6.0.51126
     engine: Blink
     engine_version: 79.0.3945.136
@@ -9510,7 +9510,7 @@
     brand: Reeder
     model: P13 Blue Max
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 11; Redmi K30 Pro Zoom Edition) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.87 Mobile Safari/537.36
   os:

--- a/Tests/fixtures/smartphone-28.yml
+++ b/Tests/fixtures/smartphone-28.yml
@@ -9501,7 +9501,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 9.6.0.51126
     engine: Blink
     engine_version: 79.0.3945.136

--- a/Tests/fixtures/smartphone-29.yml
+++ b/Tests/fixtures/smartphone-29.yml
@@ -8913,7 +8913,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 7.8.2.40664
     engine: Blink
     engine_version: 69.0.3497.100

--- a/Tests/fixtures/smartphone-29.yml
+++ b/Tests/fixtures/smartphone-29.yml
@@ -8913,7 +8913,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 7.8.2.40664
     engine: Blink
     engine_version: 69.0.3497.100
@@ -8922,7 +8922,7 @@
     brand: Fly
     model: Cirrus 2
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 9; lineage_serranoltexx) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:

--- a/Tests/fixtures/smartphone-3.yml
+++ b/Tests/fixtures/smartphone-3.yml
@@ -1605,7 +1605,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 7.8.1.40497
     engine: Blink
     engine_version: 69.0.3497.81

--- a/Tests/fixtures/smartphone-3.yml
+++ b/Tests/fixtures/smartphone-3.yml
@@ -1605,7 +1605,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 7.8.1.40497
     engine: Blink
     engine_version: 69.0.3497.81
@@ -1614,7 +1614,7 @@
     brand: bq
     model: Fresh
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-5002G Build/OPM2.171019.012 AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.121 Mobile Safari/537.36
   os:

--- a/Tests/fixtures/smartphone-37.yml
+++ b/Tests/fixtures/smartphone-37.yml
@@ -7513,7 +7513,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: "2.10990"
     engine: WebKit
     engine_version: "534.35"
@@ -7522,7 +7522,7 @@
     brand: ""
     model: ""
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/113.0.5672.162 Mobile DuckDuckGo/5 Safari/537.36
   os:
@@ -8425,7 +8425,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 9.6.1.51244
     engine: Blink
     engine_version: 79.0.3945.136
@@ -8434,7 +8434,7 @@
     brand: Safaricom
     model: ET Kimem
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Tesla_SP6_4_Lite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Mobile Safari/537.36
   os:

--- a/Tests/fixtures/smartphone-37.yml
+++ b/Tests/fixtures/smartphone-37.yml
@@ -7513,7 +7513,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: "2.10990"
     engine: WebKit
     engine_version: "534.35"
@@ -8425,7 +8425,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 9.6.1.51244
     engine: Blink
     engine_version: 79.0.3945.136

--- a/Tests/fixtures/smartphone-4.yml
+++ b/Tests/fixtures/smartphone-4.yml
@@ -4109,7 +4109,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 6.1.0.15920
     engine: Blink
     engine_version: 42.0.2311.135

--- a/Tests/fixtures/smartphone-4.yml
+++ b/Tests/fixtures/smartphone-4.yml
@@ -4109,7 +4109,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 6.1.0.15920
     engine: Blink
     engine_version: 42.0.2311.135
@@ -4118,7 +4118,7 @@
     brand: Fly
     model: Cirrus 2
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 5.1; FS506 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:

--- a/Tests/fixtures/smartphone-5.yml
+++ b/Tests/fixtures/smartphone-5.yml
@@ -4001,7 +4001,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 7.0.6.18027
     engine: Blink
     engine_version: 59.0.3071.117
@@ -4010,7 +4010,7 @@
     brand: HTC
     model: Bolt
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; HTC Butterfly Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:

--- a/Tests/fixtures/smartphone-5.yml
+++ b/Tests/fixtures/smartphone-5.yml
@@ -4001,7 +4001,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 7.0.6.18027
     engine: Blink
     engine_version: 59.0.3071.117

--- a/Tests/fixtures/smartphone-7.yml
+++ b/Tests/fixtures/smartphone-7.yml
@@ -5547,7 +5547,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 7.8.2.40664
     engine: Blink
     engine_version: 69.0.3497.81
@@ -5556,7 +5556,7 @@
     brand: Keneksi
     model: Glass
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; Hemera Build/JDQ39 AppleWebKit/537.36 KHTML, like Gecko Chrome/71.0.3578.99 Mobile Safari/537.36 OPR/50.3.2426.136976
   os:
@@ -5727,7 +5727,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 7.8.0.40457
     engine: Blink
     engine_version: 69.0.3497.81
@@ -5736,7 +5736,7 @@
     brand: Keneksi
     model: Solo
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; KENEKSI_Soul AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.157 Mobile Safari/537.36
   os:

--- a/Tests/fixtures/smartphone-7.yml
+++ b/Tests/fixtures/smartphone-7.yml
@@ -5547,7 +5547,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 7.8.2.40664
     engine: Blink
     engine_version: 69.0.3497.81
@@ -5727,7 +5727,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 7.8.0.40457
     engine: Blink
     engine_version: 69.0.3497.81

--- a/Tests/fixtures/smartphone.yml
+++ b/Tests/fixtures/smartphone.yml
@@ -2365,7 +2365,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 7.8.1.40497
     engine: Blink
     engine_version: 69.0.3497.100
@@ -2374,7 +2374,7 @@
     brand: Tele2
     model: Mini 1.1
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; Masstel_Juno_Q3 AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.157 Mobile Safari/537.36
   os:

--- a/Tests/fixtures/smartphone.yml
+++ b/Tests/fixtures/smartphone.yml
@@ -8981,3 +8981,18 @@
     model: GSmart Alto A2
   os_family: Android
   browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Cloud Phone; Generic) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.243 Mobile Safari/537.36 Puffin/12.1.1.51391FP
+  os: [ ]
+  client:
+    type: browser
+    name: Puffin Web Browser
+    version: 12.1.1.51391
+    engine: Blink
+    engine_version: 124.0.6367.243
+  device:
+    type: smartphone
+    brand: ""
+    model: ""
+  os_family: Unknown
+  browser_family: Chrome

--- a/Tests/fixtures/smartphone.yml
+++ b/Tests/fixtures/smartphone.yml
@@ -8996,3 +8996,21 @@
     model: ""
   os_family: Unknown
   browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux x86_64; fa-ir) AppleWebKit/534.35 (KHTML, like Gecko) Chrome/11.0.696.65 Safari/534.35 Puffin/2.10977AP
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: x64
+  client:
+    type: browser
+    name: Puffin Web Browser
+    version: "2.10977"
+    engine: WebKit
+    engine_version: "534.35"
+  device:
+    type: smartphone
+    brand: ""
+    model: ""
+  os_family: GNU/Linux
+  browser_family: Chrome

--- a/Tests/fixtures/smartphone.yml
+++ b/Tests/fixtures/smartphone.yml
@@ -8989,7 +8989,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Web Browser
+    name: Puffin Cloud Browser
     version: 12.1.1.51391
     engine: Blink
     engine_version: 124.0.6367.243

--- a/Tests/fixtures/smartphone.yml
+++ b/Tests/fixtures/smartphone.yml
@@ -8983,7 +8983,10 @@
   browser_family: Chrome
 -
   user_agent: Mozilla/5.0 (Cloud Phone; Generic) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.243 Mobile Safari/537.36 Puffin/12.1.1.51391FP
-  os: [ ]
+  os:
+    name: Puffin OS
+    version: ""
+    platform: ""
   client:
     type: browser
     name: Puffin Web Browser
@@ -8994,7 +8997,7 @@
     type: smartphone
     brand: ""
     model: ""
-  os_family: Unknown
+  os_family: Android
   browser_family: Chrome
 -
   user_agent: Mozilla/5.0 (X11; U; Linux x86_64; fa-ir) AppleWebKit/534.35 (KHTML, like Gecko) Chrome/11.0.696.65 Safari/534.35 Puffin/2.10977AP

--- a/Tests/fixtures/smartphone.yml
+++ b/Tests/fixtures/smartphone.yml
@@ -2365,7 +2365,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 7.8.1.40497
     engine: Blink
     engine_version: 69.0.3497.100

--- a/Tests/fixtures/tablet-1.yml
+++ b/Tests/fixtures/tablet-1.yml
@@ -1607,7 +1607,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 7.7.5.30963
     engine: Blink
     engine_version: 66.0.3359.139

--- a/Tests/fixtures/tablet-1.yml
+++ b/Tests/fixtures/tablet-1.yml
@@ -1607,7 +1607,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 7.7.5.30963
     engine: Blink
     engine_version: 66.0.3359.139
@@ -1616,7 +1616,7 @@
     brand: bq
     model: Clarion
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQ-1051G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:

--- a/Tests/fixtures/tablet-10.yml
+++ b/Tests/fixtures/tablet-10.yml
@@ -7067,7 +7067,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 7.8.2.40664
     engine: Blink
     engine_version: 69.0.3497.100

--- a/Tests/fixtures/tablet-10.yml
+++ b/Tests/fixtures/tablet-10.yml
@@ -7067,7 +7067,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 7.8.2.40664
     engine: Blink
     engine_version: 69.0.3497.100
@@ -7076,7 +7076,7 @@
     brand: Digma
     model: Optima 7.6" 3G
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; UNO_X8 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:

--- a/Tests/fixtures/tablet-4.yml
+++ b/Tests/fixtures/tablet-4.yml
@@ -7844,7 +7844,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 7.1.2.18064
     engine: Blink
     engine_version: 59.0.3071.117
@@ -7853,7 +7853,7 @@
     brand: teXet
     model: TM-7047HD 3G
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 Linux; Android 5.1; TM-7052 Build/LMY47D AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:

--- a/Tests/fixtures/tablet-4.yml
+++ b/Tests/fixtures/tablet-4.yml
@@ -7844,7 +7844,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 7.1.2.18064
     engine: Blink
     engine_version: 59.0.3071.117

--- a/Tests/fixtures/tablet-7.yml
+++ b/Tests/fixtures/tablet-7.yml
@@ -4163,7 +4163,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 7.8.2.40664
     engine: Blink
     engine_version: 69.0.3497.81

--- a/Tests/fixtures/tablet-7.yml
+++ b/Tests/fixtures/tablet-7.yml
@@ -4163,7 +4163,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 7.8.2.40664
     engine: Blink
     engine_version: 69.0.3497.81
@@ -4172,7 +4172,7 @@
     brand: HP
     model: Touch 9.7" WiFi
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; DIGMA_IDSD Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36 OPR/50.4.2426.146257
   os:

--- a/Tests/fixtures/tablet.yml
+++ b/Tests/fixtures/tablet.yml
@@ -9121,3 +9121,21 @@
     model: Poke 3
   os_family: Android
   browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux x86_64; ru-MD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.114 Safari/537.36 Puffin/4.7.2IT
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: x64
+  client:
+    type: browser
+    name: Puffin Web Browser
+    version: 4.7.2
+    engine: Blink
+    engine_version: 30.0.1599.114
+  device:
+    type: tablet
+    brand: ""
+    model: ""
+  os_family: GNU/Linux
+  browser_family: Chrome

--- a/Tests/fixtures/tablet.yml
+++ b/Tests/fixtures/tablet.yml
@@ -583,7 +583,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 7.8.3.40913
     engine: Blink
     engine_version: 69.0.3497.100
@@ -709,7 +709,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 7.8.1.40497
     engine: Blink
     engine_version: 69.0.3497.81

--- a/Tests/fixtures/tablet.yml
+++ b/Tests/fixtures/tablet.yml
@@ -583,7 +583,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 7.8.3.40913
     engine: Blink
     engine_version: 69.0.3497.100
@@ -592,7 +592,7 @@
     brand: Chuwi
     model: Vi10 Plus
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; CW-Vi7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
@@ -709,7 +709,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 7.8.1.40497
     engine: Blink
     engine_version: 69.0.3497.81
@@ -718,7 +718,7 @@
     brand: Etuline
     model: ETL-T980
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MYPAD7s Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Safari/537.36
   os:

--- a/Tests/fixtures/tv.yml
+++ b/Tests/fixtures/tv.yml
@@ -2847,7 +2847,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin
+    name: Puffin Secure Browser
     version: 7.8.2.40664
     engine: Blink
     engine_version: 69.0.3497.100

--- a/Tests/fixtures/tv.yml
+++ b/Tests/fixtures/tv.yml
@@ -2847,7 +2847,7 @@
     platform: ""
   client:
     type: browser
-    name: Puffin Secure Browser
+    name: Puffin Web Browser
     version: 7.8.2.40664
     engine: Blink
     engine_version: 69.0.3497.100
@@ -2856,7 +2856,7 @@
     brand: Kivi
     model: 43UK35G
   os_family: Android
-  browser_family: Unknown
+  browser_family: Chrome
 -
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 43UP50GU Build/NMF26Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.100 Mobile Safari/537.36
   os:

--- a/Tests/fixtures/unknown.yml
+++ b/Tests/fixtures/unknown.yml
@@ -3411,21 +3411,3 @@
     model: ""
   os_family: Android
   browser_family: Chrome
--
-  user_agent: Mozilla/5.0 (X11; U; Linux x86_64; fa-ir) AppleWebKit/534.35 (KHTML, like Gecko) Chrome/11.0.696.65 Safari/534.35 Puffin/2.10977AP
-  os:
-    name: GNU/Linux
-    version: ""
-    platform: x64
-  client:
-    type: browser
-    name: Puffin Web Browser
-    version: "2.10977"
-    engine: WebKit
-    engine_version: "534.35"
-  device:
-    type: ""
-    brand: ""
-    model: ""
-  os_family: GNU/Linux
-  browser_family: Chrome

--- a/Tests/fixtures/unknown.yml
+++ b/Tests/fixtures/unknown.yml
@@ -2614,24 +2614,6 @@
   os_family: Android
   browser_family: Android Browser
 -
-  user_agent: 'Mozilla/5.0 (X11; U; Linux x86_64; fa-ir) AppleWebKit/534.35 (KHTML, like Gecko)  Chrome/11.0.696.65 Safari/534.35 Puffin/2.10977AP'
-  os:
-    name: GNU/Linux
-    version: ""
-    platform: x64
-  client:
-    type: browser
-    name: Puffin
-    version: "2.10977"
-    engine: WebKit
-    engine_version: "534.35"
-  device:
-    type: ""
-    brand: ""
-    model: ""
-  os_family: GNU/Linux
-  browser_family: Unknown
--
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; SPHS on Hsdroid Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid

--- a/Tests/fixtures/unknown.yml
+++ b/Tests/fixtures/unknown.yml
@@ -3411,3 +3411,57 @@
     model: ""
   os_family: Android
   browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (X11; U; U; Linux x86_64; es-pe) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36 Puffin/9.3.0.51570AV
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: x64
+  client:
+    type: browser
+    name: Puffin Web Browser
+    version: 9.3.0.51570
+    engine: Blink
+    engine_version: 79.0.3945.136
+  device:
+    type: ""
+    brand: ""
+    model: ""
+  os_family: GNU/Linux
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux i686; th-TH@calendar=gregorian) AppleWebKit/534.12 (KHTML, like Gecko) Puffin/1.3.2665MS Safari/534.12
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: x86
+  client:
+    type: browser
+    name: Puffin Web Browser
+    version: 1.3.2665
+    engine: WebKit
+    engine_version: "534.12"
+  device:
+    type: ""
+    brand: ""
+    model: ""
+  os_family: GNU/Linux
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; es-us) AppleWebKit/534.12 (KHTML, like Gecko) Puffin/1.3.2913S Mobile Safari/534.12
+  os:
+    name: Android
+    version: 2.2.1
+    platform: ""
+  client:
+    type: browser
+    name: Puffin Web Browser
+    version: 1.3.2913
+    engine: WebKit
+    engine_version: "534.12"
+  device:
+    type: ""
+    brand: ""
+    model: ""
+  os_family: Android
+  browser_family: Chrome

--- a/Tests/fixtures/unknown.yml
+++ b/Tests/fixtures/unknown.yml
@@ -3411,3 +3411,21 @@
     model: ""
   os_family: Android
   browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (X11; U; Linux x86_64; fa-ir) AppleWebKit/534.35 (KHTML, like Gecko) Chrome/11.0.696.65 Safari/534.35 Puffin/2.10977AP
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: x64
+  client:
+    type: browser
+    name: Puffin Web Browser
+    version: "2.10977"
+    engine: WebKit
+    engine_version: "534.35"
+  device:
+    type: ""
+    brand: ""
+    model: ""
+  os_family: GNU/Linux
+  browser_family: Chrome

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -2424,9 +2424,9 @@
   engine:
     default: '' # Trident and WebKit
 
-#Puffin
+# Puffin Secure Browser (https://www.puffin.com/secure-browser)
 - regex: 'Puffin(?:/(\d+[\.\d]+))?'
-  name: 'Puffin'
+  name: 'Puffin Secure Browser'
   version: '$1'
 
 #MobileIron

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -2424,6 +2424,11 @@
   engine:
     default: '' # Trident and WebKit
 
+# Puffin Web Browser (https://www.puffin.com/web-browser)
+- regex: 'Puffin/(\d+[\.\d]+)FP'
+  name: 'Puffin Web Browser'
+  version: '$1'
+
 # Puffin Secure Browser (https://www.puffin.com/secure-browser)
 - regex: 'Puffin(?:/(\d+[\.\d]+))?'
   name: 'Puffin Secure Browser'

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -2430,7 +2430,7 @@
   version: '$1'
 
 # Puffin Secure Browser (https://www.puffin.com/secure-browser)
-- regex: 'Puffin(?:/(\d+[\.\d]+))?'
+- regex: 'Puffin/(\d+[\.\d]+)(?:[LMW]D)'
   name: 'Puffin Secure Browser'
   version: '$1'
 

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -2425,7 +2425,7 @@
     default: '' # Trident and WebKit
 
 # Puffin Web Browser (https://www.puffin.com/web-browser)
-- regex: 'Puffin/(\d+[\.\d]+)FP'
+- regex: 'Puffin/(\d+[\.\d]+)(?:[AIFLW][PT]|M)'
   name: 'Puffin Web Browser'
   version: '$1'
 

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -2424,14 +2424,14 @@
   engine:
     default: '' # Trident and WebKit
 
-# Puffin Web Browser (https://www.puffin.com/web-browser)
-- regex: 'Puffin/(\d+[\.\d]+)(?:[AIFLW][PT]|M)'
-  name: 'Puffin Web Browser'
-  version: '$1'
-
 # Puffin Secure Browser (https://www.puffin.com/secure-browser)
 - regex: 'Puffin/(\d+[\.\d]+)(?:[LMW]D)'
   name: 'Puffin Secure Browser'
+  version: '$1'
+
+# Puffin Web Browser (https://www.puffin.com/web-browser)
+- regex: 'Puffin/(\d+[\.\d]+)(?:[AIFLW][PT]|M)?'
+  name: 'Puffin Web Browser'
   version: '$1'
 
 #MobileIron

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -2424,13 +2424,18 @@
   engine:
     default: '' # Trident and WebKit
 
+# Puffin Cloud Browser (https://play.google.com/store/apps/details?id=com.cloudmosa.puffinCloudBrowser)
+- regex: 'Puffin/(\d+[\.\d]+)FP'
+  name: 'Puffin Cloud Browser'
+  version: '$1'
+
 # Puffin Secure Browser (https://www.puffin.com/secure-browser)
 - regex: 'Puffin/(\d+[\.\d]+)(?:[LMW]D)'
   name: 'Puffin Secure Browser'
   version: '$1'
 
 # Puffin Web Browser (https://www.puffin.com/web-browser)
-- regex: 'Puffin/(\d+[\.\d]+)(?:[AIFLW][PT]|M)?'
+- regex: 'Puffin/(\d+[\.\d]+)(?:[AILW][PT]|M)?'
   name: 'Puffin Web Browser'
   version: '$1'
 

--- a/regexes/client/hints/browsers.yml
+++ b/regexes/client/hints/browsers.yml
@@ -14,8 +14,9 @@
 'com.darkbrowser': 'Dark Browser'
 'com.kiwibrowser.browser': 'Kiwi'
 'com.cloudmosa.puffinFree': 'Puffin Web Browser'
-'com.cloudmosa.puffin': 'Puffin Web Browser' # Puffin Cloud Browser or Puffin Web Browser Pro
+'com.cloudmosa.puffin': 'Puffin Web Browser' # or Puffin Web Browser Pro
 'com.cloudmosa.puffinIncognito': 'Puffin Incognito Browser'
+'com.cloudmosa.puffinCloudBrowser': 'Puffin Cloud Browser'
 'com.aloha.browser': 'Aloha Browser'
 'com.cake.browser': 'Cake Browser'
 'com.UCMobile.intl': 'UC Browser'

--- a/regexes/client/hints/browsers.yml
+++ b/regexes/client/hints/browsers.yml
@@ -15,6 +15,7 @@
 'com.kiwibrowser.browser': 'Kiwi'
 'com.cloudmosa.puffinFree': 'Puffin Web Browser'
 'com.cloudmosa.puffin': 'Puffin Web Browser' # Puffin Cloud Browser or Puffin Web Browser Pro
+'com.cloudmosa.puffinIncognito': 'Puffin Incognito Browser'
 'com.aloha.browser': 'Aloha Browser'
 'com.cake.browser': 'Cake Browser'
 'com.UCMobile.intl': 'UC Browser'

--- a/regexes/device/mobiles.yml
+++ b/regexes/device/mobiles.yml
@@ -42013,7 +42013,7 @@ SERVO:
 
 # Devices with undectable brand, but detectable model
 Unknown:
-  regex: 'Plasma Mobile|WebTV/(\d+\.\d+)|TV Bro| BOX|BOX | BOX |roku|YouView|DirectFB|avdn/|wired|wireless|AndroidTV|cordova-amazon-fireos|wv-atv|SDSTB|SDOTT|(?:M10 Ultra|FO-R15|TVBOX|Smart[ _-]?TV|SmartATV|M8S\+ 4K|PCBox|rk(?:3128|322x|3368)(?:[_-]box)?|H10 PLAY|Smart AIO TV|TVBOX_L|L-BOX|TVBOX-5G|mips.+(?:Opera TV|wireless|wired)|smartbox|TV BOX|BOX TV|I12Pro Max|(?:audi_)?ks1280x480|AT&T TV|RealtekATV|AOSP on r33a0|tv001 on rtd289x|hx322x_box|X98_S500|8K3528-T|MX10|V88|H8S|X92|AI PONT|tv\.plus|WayDroid x86_64 Device|MediaBox)(?:[);/ ]|$)'
+  regex: 'Plasma Mobile|WebTV/(\d+\.\d+)|TV Bro| BOX|BOX | BOX |roku|YouView|DirectFB|avdn/|wired|wireless|AndroidTV|cordova-amazon-fireos|wv-atv|SDSTB|SDOTT|(?:M10 Ultra|FO-R15|TVBOX|Smart[ _-]?TV|SmartATV|M8S\+ 4K|PCBox|rk(?:3128|322x|3368)(?:[_-]box)?|H10 PLAY|Smart AIO TV|TVBOX_L|L-BOX|TVBOX-5G|mips.+(?:Opera TV|wireless|wired)|smartbox|TV BOX|BOX TV|I12Pro Max|(?:audi_)?ks1280x480|AT&T TV|RealtekATV|AOSP on r33a0|tv001 on rtd289x|hx322x_box|X98_S500|8K3528-T|MX10|V88|H8S|X92|AI PONT|tv\.plus|WayDroid x86_64 Device|MediaBox|Cloud Phone)(?:[);/ ]|$)'
   device: 'smartphone'
   models:
     - regex: 'LGE; ([a-z0-9]+);'

--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -6,6 +6,13 @@
 ###############
 
 ##########
+# Puffin OS (https://www.puffin.com/os/help/faq/)
+##########
+- regex: 'Cloud Phone'
+  name: 'Puffin OS'
+  version: ''
+
+##########
 # risingOS (https://github.com/RisingTechOSS/android)
 ##########
 - regex: 'RisingOS'


### PR DESCRIPTION
`WD` - Windows / Desktop
`LD` - Linux / Desktop
`MD` - macOS / Desktop

`AP` - Android / Smartphone
`IP` - iOS / Smartphone
`FP` - Puffin OS / Smartphone
`LP` - Linux / Smartphone
`WP` - Windows / Smartphone

`AT` - Android / Tablet
`IT` - iOS/iPadOS / Tablet
`LT` - Linux / Tablet
`WT` - Windows / Tablet

`M` - Smartphone

For those fragments there is no detection (can't find any info):

`AV` - probably Android / TV
`MS` - probably Puffin cloud server
`S` - probably Puffin cloud server

Also, where OS doesn't match the fragment, probably the user-agent is spoofed.

```
https://www.puffinbrowser.com/help/developer/#article-what-is-the-user-agent-of-puffin-cloud-browser
https://web.archive.org/web/20160522085326/https://www.whatismybrowser.com/blog/view/2013-06-10/puffin-browsers-new-user-agent-format
```