### PR TITLE
Fix Uncaught TypeError

### DIFF
--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -2264,11 +2264,11 @@ abstract class AbstractDeviceParser extends AbstractParser
             $formFactors = $this->clientHints->getFormFactors();
 
             if (\count($formFactors) > 0) {
-                foreach (self::$clientHintFormFactorsMapping as $formFactor) {
-                    $deviceType = $formFactors[$formFactor] ?? null;
+                foreach (self::$clientHintFormFactorsMapping as $formFactor => $deviceType) {
+                    $hasDeviceType = $formFactors[$formFactor] ?? null;
 
-                    if (null !== $deviceType) {
-                        $deviceType = self::getDeviceName($formFactor);
+                    if (null !== $hasDeviceType) {
+                        $deviceType = self::getDeviceName($deviceType);
 
                         break;
                     }

--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -2268,7 +2268,7 @@ abstract class AbstractDeviceParser extends AbstractParser
                     $deviceType = $formFactors[$formFactor] ?? null;
 
                     if (null !== $deviceType) {
-                        $deviceType = self::getDeviceName($deviceType);
+                        $deviceType = self::getDeviceName($formFactor);
 
                         break;
                     }


### PR DESCRIPTION
@sanchezzzhak, @sgiehl can you double check this? I've got this error when testing the code in Chrome after page refresh:

```
PHP Fatal error:  Uncaught TypeError: DeviceDetector\Parser\Device\AbstractDeviceParser::getDeviceName(): Argument #1 ($deviceType) must be of type int, string given, called in Z:\GitHub\device-detector\Parser\Device\AbstractDeviceParser.php on line 2271 and defined in Z:\GitHub\device-detector\Parser\Device\AbstractDeviceParser.php:2075
```

```PHP
<?php

header('Accept-CH: Sec-CH-UA, Sec-CH-UA-Mobile, Sec-CH-UA-Platform, Sec-CH-UA-Platform-Version, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List, Sec-CH-UA-Arch, Sec-CH-UA-Model, Sec-CH-UA-Form-Factors, Sec-CH-UA-Bitness, Sec-CH-UA-WoW64');

include_once 'path/to/spyc/Spyc.php';
include_once 'path/to/device-detector/autoload.php';

use DeviceDetector\ClientHints;
use DeviceDetector\DeviceDetector;
use DeviceDetector\Parser\Device\AbstractDeviceParser;

AbstractDeviceParser::setVersionTruncation(AbstractDeviceParser::VERSION_TRUNCATION_NONE);

$result = DeviceDetector::getInfoFromUserAgent($_SERVER['HTTP_USER_AGENT'], ClientHints::factory($_SERVER));

echo Spyc::YAMLDump($result, 2, 0);
```

Feel free to push commits if the fix is not okay.

Also, probably the `Usage` in README should be updated, to let the user know he should request all the headers from browser for detection to fully work. There's an open issue where the model is not detected, and I have the impression this is the cause. By default in Chrome I only get this:

```
[HTTP_SEC_CH_UA_PLATFORM] => "Windows"
[HTTP_SEC_CH_UA_MOBILE] => ?0
[HTTP_SEC_CH_UA] => "Chromium";v="130", "Google Chrome";v="130", "Not?A_Brand";v="99"
```