### PR TITLE
Improves detection for frozen client hints in Linux

### DIFF
--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -2162,6 +2162,15 @@ abstract class AbstractDeviceParser extends AbstractParser
             ));
         }
 
+        // is freeze user-agent then restoring the original UA for the device definition
+        if ('' !== $deviceModel && $this->hasDesktopFragment()) {
+            $this->setUserAgent((string) \preg_replace(
+                '(X11; Linux x86_64)',
+                \sprintf('X11; Linux x86_64; %s', $deviceModel),
+                $this->userAgent
+            ));
+        }
+
         if ('' === $deviceModel && $this->hasUserAgentClientHintsFragment()) {
             return $this->getResult();
         }

--- a/Tests/DeviceDetectorTest.php
+++ b/Tests/DeviceDetectorTest.php
@@ -418,7 +418,7 @@ class DeviceDetectorTest extends TestCase
     {
         $dd = $this->createPartialMock(Mobile::class, ['hasDesktopFragment']);
 
-        $dd->expects($this->once())->method('hasDesktopFragment')->willReturn(true);
+        $dd->expects($this->exactly(2))->method('hasDesktopFragment')->willReturn(true);
 
         // simulate work not use clienthints
         $dd->setUserAgent('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.53 Safari/537.36');

--- a/Tests/fixtures/clienthints.yml
+++ b/Tests/fixtures/clienthints.yml
@@ -1200,3 +1200,28 @@
     model: Explr 9
   os_family: Android
   browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.134 Safari/537.36 OPR/88.0.4412.53
+  headers:
+    Sec-CH-UA: '" Not A;Brand";v="99.0.0.0", "Chromium";v="102.0.5005.134"'
+    Sec-CH-UA-Platform: "Android"
+    Sec-CH-UA-Mobile: "?0"
+    Sec-CH-UA-Full-Version: "102.0.5005.134"
+    Sec-CH-UA-Platform-Version: "9.0.0"
+    Sec-CH-UA-Model: "RVL-AL09"
+  os:
+    name: Android
+    version: 9.0.0
+    platform: x64
+  client:
+    type: browser
+    name: Opera
+    version: 88.0.4412.53
+    engine: Blink
+    engine_version: 102.0.5005.134
+  device:
+    type: smartphone
+    brand: Huawei
+    model: Honor Note 10
+  os_family: Android
+  browser_family: Opera


### PR DESCRIPTION
Detection wasn't working for user agents that contain `X11; Linux x86_64` and have client hints.