### PR TITLE
Adds detection for Blackbox Exporter bot

### DIFF
--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -446,6 +446,15 @@
       name: Bitly, Inc.
       url: https://bitly.com
 -
+  user_agent: Blackbox Exporter/0.24.0
+  bot:
+    name: Blackbox Exporter
+    category: Site Monitor
+    url: https://github.com/prometheus/blackbox_exporter
+    producer:
+      name: Prometheus
+      url: https://prometheus.io/
+-
   user_agent: Mozilla/5.0 (compatible; Blekkobot; ScoutJet; +http://blekko.com/about/blekkobot)
   bot:
     name: Blekkobot

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -249,6 +249,14 @@
     name: 'Microsoft Corporation'
     url: 'http://www.microsoft.com'
 
+- regex: 'Blackbox Exporter'
+  name: 'Blackbox Exporter'
+  category: 'Site Monitor'
+  url: 'https://github.com/prometheus/blackbox_exporter'
+  producer:
+    name: 'Prometheus'
+    url: 'https://prometheus.io/'
+
 - regex: 'Blekkobot'
   name: 'Blekkobot'
   category: 'Search bot'


### PR DESCRIPTION
### Description:

Adds detection for Blackbox Exporter monitoring bot by Prometheus: https://github.com/prometheus/blackbox_exporter

Here is the user agent header value: https://github.com/prometheus/blackbox_exporter/blob/master/prober/http.go#L236