### PR TITLE
Fix detecting device type by form factor of client hints

### DIFF
--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -2212,6 +2212,8 @@ abstract class AbstractDeviceParser extends AbstractParser
         }
 
         if (empty($matches)) {
+            $this->deviceType = $resultClientHint['deviceType'] ?? null;
+
             return $resultClientHint;
         }
 
@@ -2294,21 +2296,19 @@ abstract class AbstractDeviceParser extends AbstractParser
     protected function parseClientHints(): ?array
     {
         if ($this->clientHints && $this->clientHints->getModel()) {
-            $deviceType  = null;
-            $formFactors = $this->clientHints->getFormFactors();
+            $deviceTypeByFormFactor = null;
+            $formFactors            = $this->clientHints->getFormFactors();
 
-            if (\count($formFactors) > 0) {
-                foreach (self::$clientHintFormFactorsMapping as $formFactor => $deviceTypeId) {
-                    if (\array_key_exists($formFactor, $formFactors)) {
-                        $deviceType = self::getDeviceName($deviceTypeId);
+            foreach ($formFactors as $formFactor) {
+                if (isset(self::$clientHintFormFactorsMapping[$formFactor])) {
+                    $deviceTypeByFormFactor = self::$clientHintFormFactorsMapping[$formFactor];
 
-                        break;
-                    }
+                    break;
                 }
             }
 
             return [
-                'deviceType' => $deviceType,
+                'deviceType' => $deviceTypeByFormFactor,
                 'model'      => $this->clientHints->getModel(),
                 'brand'      => '',
             ];

--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -2296,19 +2296,19 @@ abstract class AbstractDeviceParser extends AbstractParser
     protected function parseClientHints(): ?array
     {
         if ($this->clientHints && $this->clientHints->getModel()) {
-            $deviceTypeByFormFactor = null;
-            $formFactors            = $this->clientHints->getFormFactors();
+            $deviceType  = null;
+            $formFactors = $this->clientHints->getFormFactors();
 
             foreach ($formFactors as $formFactor) {
                 if (isset(self::$clientHintFormFactorsMapping[$formFactor])) {
-                    $deviceTypeByFormFactor = self::$clientHintFormFactorsMapping[$formFactor];
+                    $deviceType = self::$clientHintFormFactorsMapping[$formFactor];
 
                     break;
                 }
             }
 
             return [
-                'deviceType' => $deviceTypeByFormFactor,
+                'deviceType' => $deviceType,
                 'model'      => $this->clientHints->getModel(),
                 'brand'      => '',
             ];

--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -2047,11 +2047,11 @@ abstract class AbstractDeviceParser extends AbstractParser
     protected static $clientHintFormFactorsMapping = [
         'automotive' => self::DEVICE_TYPE_CAR_BROWSER,
         'xr'         => self::DEVICE_TYPE_WEARABLE,
-        'eink'       => self::DEVICE_TYPE_TABLET,
         'watch'      => self::DEVICE_TYPE_WEARABLE,
         'mobile'     => self::DEVICE_TYPE_SMARTPHONE,
         'tablet'     => self::DEVICE_TYPE_TABLET,
         'desktop'    => self::DEVICE_TYPE_DESKTOP,
+        'eink'       => self::DEVICE_TYPE_TABLET,
     ];
 
     /**
@@ -2296,19 +2296,19 @@ abstract class AbstractDeviceParser extends AbstractParser
     protected function parseClientHints(): ?array
     {
         if ($this->clientHints && $this->clientHints->getModel()) {
-            $deviceType  = null;
-            $formFactors = $this->clientHints->getFormFactors();
+            $detectedDeviceType = null;
+            $formFactors        = $this->clientHints->getFormFactors();
 
-            foreach ($formFactors as $formFactor) {
-                if (isset(self::$clientHintFormFactorsMapping[$formFactor])) {
-                    $deviceType = self::$clientHintFormFactorsMapping[$formFactor];
+            foreach (self::$clientHintFormFactorsMapping as $formFactor => $deviceType) {
+                if (\in_array($formFactor, $formFactors)) {
+                    $detectedDeviceType = $deviceType;
 
                     break;
                 }
             }
 
             return [
-                'deviceType' => $deviceType,
+                'deviceType' => $detectedDeviceType,
                 'model'      => $this->clientHints->getModel(),
                 'brand'      => '',
             ];

--- a/Tests/fixtures/unknown.yml
+++ b/Tests/fixtures/unknown.yml
@@ -3218,7 +3218,7 @@
 -
   user_agent: Some Unknown UA
   device:
-    type: "tablet"
+    type: "wearable"
     brand: ""
     model: "Some Unknown Model"
   os: [ ]
@@ -3226,7 +3226,7 @@
   os_family: Unknown
   browser_family: Unknown
   headers:
-    sec-ch-ua-form-factors: '"EInk", "Tablet"'
+    sec-ch-ua-form-factors: '"EInk", "Watch"'
     sec-ch-ua-model: '"Some Unknown Model"'
 -
   user_agent: Microsoft Office Word/16.78.1008 (Desktop; Desktop app; Unknown/Unknown)

--- a/Tests/fixtures/unknown.yml
+++ b/Tests/fixtures/unknown.yml
@@ -3216,6 +3216,19 @@
   headers:
     http-x-requested-with: every.browser.inc
 -
+  user_agent: Some Unknown UA
+  device:
+    type: "tablet"
+    brand: ""
+    model: "Some Unknown Model"
+  os: [ ]
+  client: null
+  os_family: Unknown
+  browser_family: Unknown
+  headers:
+    sec-ch-ua-form-factors: '"EInk", "Tablet"'
+    sec-ch-ua-model: '"Some Unknown Model"'
+-
   user_agent: Microsoft Office Word/16.78.1008 (Desktop; Desktop app; Unknown/Unknown)
   os: [ ]
   client:


### PR DESCRIPTION
### Description:

In the method \DeviceDetector\Parser\Device\AbstractDeviceParser::parseClientHints,
condition `\array_key_exists($formFactor, $formFactors)` is always false because $formFactor is a string and $formFactors keys are integers ($formFactors is a list of strings). If we fix just this condition, then $deviceType gets the string value of self::getDeviceName, but it should be an int (we don't need the getDeviceName call)
Then, if we fix that, we see that 'deviceType' field is never used in the \DeviceDetector\Parser\Device\AbstractDeviceParser::parse method, so we need to fill $this->deviceType with it to get advantage of client hints when nothing else helps to detect device type.

I am not sure if the fixture I created fits your conventions, but it detects the described problems and does its job.