### PR TITLE
Rename Arc to Arc Search and improves detection for Arc Search and Chrome Webview

### DIFF
--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -108,7 +108,7 @@ class Browser extends AbstractClientParser
         'AW' => 'Amiga Aweb',
         'PN' => 'APN Browser',
         '6A' => 'Arachne',
-        'RA' => 'Arc',
+        'RA' => 'Arc Search',
         'R5' => 'Armorfly Browser',
         'AI' => 'Arvin',
         'AK' => 'Ask.com',

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -7930,7 +7930,7 @@
   user_agent: ArcMobile2/1 CFNetwork/1494.0.5 Darwin/23.4.0
   client:
     type: browser
-    name: Arc
+    name: Arc Search
     version: ""
     engine: WebKit
     engine_version: ""
@@ -9435,7 +9435,7 @@
   user_agent: ArcMobile2/1.3.1; iPhone; iOS 16.1.1; Scale/2.00
   client:
     type: browser
-    name: Arc
+    name: Arc Search
     version: 1.3.1
     engine: WebKit
     engine_version: ""

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -10350,3 +10350,14 @@
     family: Chrome
   headers:
     http-x-requested-with: company.thebrowser.arc
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Mobile Safari/537.36
+  client:
+    type: browser
+    name: Chrome Webview
+    version: ""
+    engine: Blink
+    engine_version: 123.0.0.0
+    family: Chrome
+  headers:
+    http-x-requested-with: com.android.webview

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -10339,3 +10339,14 @@
     engine: Blink
     engine_version: 116.0.5845.190
     family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.6723.60 Mobile Safari/537.36
+  client:
+    type: browser
+    name: Arc Search
+    version: ""
+    engine: Blink
+    engine_version: 130.0.6723.60
+    family: Chrome
+  headers:
+    http-x-requested-with: company.thebrowser.arc

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -502,9 +502,9 @@
   engine:
     default: 'Blink'
 
-# Arc (https://arc.net/)
+# Arc Search (https://arc.net/ | https://arc.net/search)
 - regex: 'ArcMobile2(?:/(\d+\.[.\d]+);)?'
-  name: 'Arc'
+  name: 'Arc Search'
   version: '$1'
   engine:
     default: 'WebKit'

--- a/regexes/client/hints/browsers.yml
+++ b/regexes/client/hints/browsers.yml
@@ -322,3 +322,4 @@
 'com.hawk.android.browser': 'Hawk Turbo Browser'
 'com.zte.nubrowser': 'ZTE Browser'
 'com.cloaktp.browser': 'Privacy Pioneer Browser'
+'company.thebrowser.arc': 'Arc Search'

--- a/regexes/client/hints/browsers.yml
+++ b/regexes/client/hints/browsers.yml
@@ -323,3 +323,4 @@
 'com.zte.nubrowser': 'ZTE Browser'
 'com.cloaktp.browser': 'Privacy Pioneer Browser'
 'company.thebrowser.arc': 'Arc Search'
+'com.android.webview': 'Chrome Webview'


### PR DESCRIPTION
`Arc Search` is the mobile browser.