### PR TITLE
Adds detection for the HeartFocus Education for iOS

### DIFF
--- a/Tests/Parser/Client/fixtures/mobile_app.yml
+++ b/Tests/Parser/Client/fixtures/mobile_app.yml
@@ -2319,5 +2319,5 @@
   user_agent: HFEducationIOS/1.0.6+g5a01fc39-dirty (iOS; 18.1.1; iPad13,18)
   client:
     type: mobile app
-    name: HFEducationIOS
+    name: HeartFocus Education
     version: 1.0.6

--- a/Tests/Parser/Client/fixtures/mobile_app.yml
+++ b/Tests/Parser/Client/fixtures/mobile_app.yml
@@ -2315,3 +2315,9 @@
     type: mobile app
     name: Edmodo
     version: 10.43.5
+-
+  user_agent: HFEducationIOS/1.0.6+g5a01fc39-dirty (iOS; 18.1.1; iPad13,18)
+  client:
+    type: mobile app
+    name: HFEducationIOS
+    version: 1.0.6

--- a/regexes/client/mobile_apps.yml
+++ b/regexes/client/mobile_apps.yml
@@ -2628,6 +2628,7 @@
   name: 'Edmodo'
   version: '$1'
 
+# HeartFocus Education (https://apps.apple.com/us/app/heartfocus-education/id6618151502)
 - regex: 'HFEducationIOS/([\d.]+)'
   name: 'HeartFocus Education'
   version: '$1'

--- a/regexes/client/mobile_apps.yml
+++ b/regexes/client/mobile_apps.yml
@@ -2628,6 +2628,10 @@
   name: 'Edmodo'
   version: '$1'
 
+- regex: 'HFEducationIOS/([\d.]+)'
+  name: 'HFEducationIOS'
+  version: '$1'
+
 # Electron generic apps
 - regex: ' (?!(?:AppleWebKit|brave|Cypress|Franz|Mailspring|Notion|Basecamp|Evernote|catalyst|ramboxpro|BlueMail|BeakerBrowser|Dezor|TweakStyle|Colibri|Polypane|Singlebox|Skye|VibeMate|(?:d|LT|Glass|Sushi|Flash|OhHai)Browser|Sizzy))([a-z0-9]*)(?:-desktop|-electron-app)?/(\d+\.[\d.]+).*Electron/'
   name: '$1'

--- a/regexes/client/mobile_apps.yml
+++ b/regexes/client/mobile_apps.yml
@@ -2629,7 +2629,7 @@
   version: '$1'
 
 - regex: 'HFEducationIOS/([\d.]+)'
-  name: 'HFEducationIOS'
+  name: 'HeartFocus Education'
   version: '$1'
 
 # Electron generic apps


### PR DESCRIPTION
### Description:

This adds the new mobile app HeartFocus Education by DESKI.
* link to deski : https://www.heartfocus.ai(https://www.heartfocus.ai/)
* iOS app: https://apps.apple.com/us/app/heartfocus-education/id6618151502 (https://apps.apple.com/us/app/heartfocus-education/id6618151502)


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
