### PR TITLE
Fix bot detection for Matomo itself

### DIFF
--- a/DeviceDetector.php
+++ b/DeviceDetector.php
@@ -68,7 +68,7 @@ class DeviceDetector
     /**
      * Current version number of DeviceDetector
      */
-    public const VERSION = '6.4.4';
+    public const VERSION = '6.4.5';
 
     /**
      * Constant used as value for unknown browser / os

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -3761,7 +3761,7 @@
   category: 'Service Agent'
   url: 'https://www.phpmyadmin.net/'
 
-- regex: 'Matomo'
+- regex: 'Matomo/[\d.]+'
   name: 'Matomo'
   category: 'Service Agent'
   url: 'https://github.com/matomo-org/matomo'


### PR DESCRIPTION
### Description:

We need to keep the `/[\d.]+` for the detection of Matomo, as it otherwise may break the LogImporter as it send `Matomo/LogImport` as useragent if non is provided in the logfile.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
