### PR TITLE
Regex YMLs: use stringified "Yes" cause it might be parsed as Boolean with other Parsers

### DIFF
--- a/regexes/device/mobiles.yml
+++ b/regexes/device/mobiles.yml
@@ -30108,7 +30108,7 @@ Yarvik:
       model: 'Xenta 13c'
 
 # Yes
-Yes:
+"Yes":
   regex: 'M631Y|M685Y4|M651G_MY|YES (?:Altitude 4|MPY(?:48|54))'
   device: 'smartphone'
   models:


### PR DESCRIPTION
### Description:

When parsing the `mobiles.yml` with a parser like Psych (for Ruby, which uses libyml), it converts various string representations of booleans into bool values, so `Yes` becomes `true`. I could not find an option to work around this, cause even `safe_load` would only apply on values, not nodes.

I'm presenting a simply change that should have no impact on the definition itself, but makes the YML definition fully compatible with the Psych loader.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
