### PR TITLE
change brand names for 2 devices

### DIFF
--- a/Tests/fixtures/smartphone-41.yml
+++ b/Tests/fixtures/smartphone-41.yml
@@ -7974,7 +7974,7 @@
     engine_version: 120.0.0.0
   device:
     type: smartphone
-    brand: Ulefone
+    brand: KENSHI
     model: Armor C1 Max
   os_family: Android
   browser_family: Chrome
@@ -8028,7 +8028,7 @@
     engine_version: 124.0.0.0
   device:
     type: smartphone
-    brand: Ulefone
+    brand: KENSHI
     model: Armor P1 Pro
   os_family: Android
   browser_family: Chrome

--- a/regexes/device/mobiles.yml
+++ b/regexes/device/mobiles.yml
@@ -27667,7 +27667,7 @@ UTStarcom:
 
 # Ulefone (ulefone.com or ulefone.ru)
 Ulefone:
-  regex: 'Ulefone|Gemini Pro|Power[ _]Armor14|Power 3S|Power_[356]|Power_5S|S(?:10|9)_Pro|(?:Note [89]P|Note 1[23]P|Armor(?! P1[sw]| H[12]s| I2w| V1s| I1 Slim)(?:[ _](?:[2367]|2S|X[236]|6[SE]|3WT|3W|X))?|U00[78][ _]Pro|Be[ _]X|Be[ _]Touch(?:[ _][23])?|Be[ _](?:One|Pure|Pro)(?:[ _]Lite)?|Note 14|Note (?:11P|7T)|Note 16 Pro|Tiger_lite|Note_7P|Note 10P|Paris_(?:Lite|X)|Paris|P6000_Plus|Vienna|GQ3060TF3|Android 11(?:[\d.]*);(?: [\w-]+;)? Note 6P?|Tab A11 Pro)(?:[);/ ]|$)'
+  regex: 'Ulefone|Gemini Pro|Power[ _]Armor14|Power 3S|Power_[356]|Power_5S|S(?:10|9)_Pro|(?:Note [89]P|Note 1[23]P|Armor(?! P1[sw]| P1 Pro| H[12]s| I2w| V1s| I1 Slim| C1 Max)(?:[ _](?:[2367]|2S|X[236]|6[SE]|3WT|3W|X))?|U00[78][ _]Pro|Be[ _]X|Be[ _]Touch(?:[ _][23])?|Be[ _](?:One|Pure|Pro)(?:[ _]Lite)?|Note 14|Note (?:11P|7T)|Note 16 Pro|Tiger_lite|Note_7P|Note 10P|Paris_(?:Lite|X)|Paris|P6000_Plus|Vienna|GQ3060TF3|Android 11(?:[\d.]*);(?: [\w-]+;)? Note 6P?|Tab A11 Pro)(?:[);/ ]|$)'
   device: 'smartphone'
   models:
     - regex: 'S(10|9)_Pro'
@@ -43768,13 +43768,13 @@ Lville:
 
 # KENSHI
 KENSHI:
-  regex: '(?:Android 1[34](?:[\d.]*);(?: [\w-]+;)? (?:E1[01278]|E28|E38|H3[48]|H2[14]|H19|H1[14]|H44)|Pad Lite E[45]8|Armor_C1w|Armor (?:P1[sw]|I2w|V1s|H[12]s|I1 Slim)|Kenshi[_ ]K10|Pad Pro E11[01])(?:[);/ ]|$)'
+  regex: '(?:Android 1[34](?:[\d.]*);(?: [\w-]+;)? (?:E1[01278]|E28|E38|H3[48]|H2[14]|H19|H1[14]|H44)|Pad Lite E[45]8|Armor_C1w|Armor C1 Max|Armor (?:P1(?:[sw]| Pro)|I2w|V1s|H[12]s|I1 Slim)|Kenshi[_ ]K10|Pad Pro E11[01])(?:[);/ ]|$)'
   device: 'tablet'
   models:
     - regex: 'Armor I1 Slim'
       device: 'smartphone'
       model: 'Armor I1 Slim'
-    - regex: 'Armor[_ ](C1w|I2w|P1s|P1w|V1s|H[12]s)'
+    - regex: 'Armor[_ ](C1w|I2w|P1s|P1w|V1s|H[12]s|C1 Max|P1 Pro)'
       device: 'smartphone'
       model: 'Armor $1'
     - regex: 'Kenshi[_ ](K10)(?:[);/ ]|$)'


### PR DESCRIPTION
### Description:

I cound not find any data about the devices "Armor C1 Max" and "Armor P1 Pro" with brand "Ulefone", but with brand "Kenshi".

Sources:
- [Armor C1 Max](https://www.imei.info/phonedatabase/kenshi-armor-c1-max)
- [Armor P1 Pro](https://market.yandex.ru/card/658-smartfon-kenshi-armor-p1-pro-12256-gb-5g-chernyy/4298500422)

This PR wants to change the brand name for these 2 devices.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
