### PR TITLE
Fix phpcs deprecation

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -56,7 +56,9 @@
     <!-- Disallow is_null function -->
     <rule ref="Generic.PHP.ForbiddenFunctions">
         <properties>
-            <property name="forbiddenFunctions" type="array" value="is_null=>null"/>
+            <property name="forbiddenFunctions" type="array">
+                <element key="is_null" value="null"/>
+            </property>
         </properties>
     </rule>
 


### PR DESCRIPTION
```
DEPRECATED: Passing an array of values to a property using a comma-separated string
was deprecated in PHP_CodeSniffer 3.3.0. Support will be removed in PHPCS 4.0.0.
The deprecated syntax was used for property "forbiddenFunctions"
for sniff "Generic.PHP.ForbiddenFunctions".
Pass array values via <element [key="..." ]value="..."> nodes instead.
```