### PR TITLE
Fix PHPStan deprecation

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,5 +12,5 @@ parameters:
     ignoreErrors:
         - '#.+Doctrine\\Common\\Cache\\CacheProvider.+#'
         - '#.+unknown class Illuminate\\Support\\Facades\\Cache.+#'
+        - identifier: missingType.iterableValue
     reportUnmatchedIgnoredErrors: false
-    checkMissingIterableValueType: false


### PR DESCRIPTION
```
⚠️  You're using a deprecated config option checkMissingIterableValueType ⚠️️

It's strongly recommended to remove it from your configuration file
and add the missing array typehints.

If you want to continue ignoring missing typehints from arrays,
add missingType.iterableValue error identifier to your ignoreErrors:

parameters:
        ignoreErrors:
                -
                        identifier: missingType.iterableValue
```

PHPStan 2 won't run:

```
Invalid configuration:
Unexpected item 'parameters › checkMissingIterableValueType'.
```