### PR TITLE
Add detection for Vivaldi Mobile iOS

### DIFF
--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -701,6 +701,7 @@ class Browser extends AbstractClientParser
         'N0' => 'Nova Video Downloader Pro',
         'VS' => 'Viasat Browser',
         'VI' => 'Vivaldi',
+        'V7' => 'Vivaldi Mobile iOS',
         'VV' => 'vivo Browser',
         'V2' => 'Vivid Browser Mini',
         'VB' => 'Vision Mobile Browser',
@@ -810,7 +811,7 @@ class Browser extends AbstractClientParser
             'W2', 'ZB', 'HN', 'Q6', 'Q7', 'G0', '00', 'R6', 'D8',
             'PQ', 'LM', 'T5', '2N', 'SJ', 'X6', 'SM', 'AY', 'BQ',
             'BC', 'NQ', 'VQ', '9C', 'KA', 'YS', 'D4', 'PZ', '0I',
-            '3F', 'Z1', 'XC', 'ZC',
+            '3F', 'Z1', 'XC', 'ZC', 'V7',
         ],
         'Firefox'            => [
             'FF', 'BI', 'BF', 'BH', 'BN', 'C0', 'CU', 'EI', 'F1',
@@ -864,6 +865,7 @@ class Browser extends AbstractClientParser
         '2M', 'K7', '1N', '8A', 'H7', 'X3', 'X4', '5O', '6I',
         '7I', 'X5', '3P', '2E', 'T5', '2N', 'SJ', 'X6', 'SM',
         'AY', 'BQ', 'BC', 'NQ', 'VQ', 'KA', 'YS', 'D4', 'PZ',
+        'V7',
     ];
 
     /**

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -7549,6 +7549,15 @@
   headers:
     Sec-CH-UA: '"Not.A/Brand";v="8.0.0.0", "Chromium";v="114.0.5735.245", "Vivaldi";v="6.1.3035.204"'
 -
+  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 26_2_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/146.0.7680.55 Mobile/15E148 Safari/604.1 VivaiOS/7.9.3974.10000
+  client:
+    type: browser
+    name: Vivaldi Mobile iOS
+    version: 7.9.3974.10000
+    engine: WebKit
+    engine_version: 605.1.15
+    family: Chrome
+-
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36 Norton/115.0.21984.175
   client:
     type: browser

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -2473,6 +2473,11 @@
   version: '$1'
   engine:
     default: 'Blink'
+- regex: 'VivaiOS/(\d+[.\d]+)'
+  name: 'Vivaldi Mobile iOS'
+  version: '$1'
+  engine:
+    default: 'WebKit'
 
 #TweakStyle
 - regex: 'TweakStyle(?:/(\d+[.\d]+))?'


### PR DESCRIPTION
### Description

Adds detection for the Vivaldi Mobile browser on iOS. (Note that Vivaldi hides its full UA string/disguises as Chrome on most sites, but there are some sites which receive the full string).

Being an iOS browser it is naturally forced to use the WebKit engine, differing it from the Blink-based Vivaldi browser on desktop and Android, thus I have given it a new prefix (but I'm not sure of the exact procedure for doing this). Since it has a different prefix to the existing Vivaldi entry, it will presumably also need a new icon to be added in the `matomo-org/matomo-icons` repository. I can submit a pull request there if needed.

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
