### PR TITLE
Fix case when $regexes can be an emtpy array

### DIFF
--- a/Parser/AbstractParser.php
+++ b/Parser/AbstractParser.php
@@ -467,6 +467,10 @@ abstract class AbstractParser
     {
         $regexes = $this->getRegexes();
 
+        if ([] === $regexes) {
+            return null;
+        }
+
         $cacheKey = $this->parserName . DeviceDetector::VERSION . '-all';
         $cacheKey = (string) \preg_replace('/([^a-z0-9_-]+)/i', '', $cacheKey);
 


### PR DESCRIPTION
Fixes https://github.com/matomo-org/device-detector/issues/7916#issuecomment-4504520263

If `regexes` files cannot be read/missing/maformed, will return an empty array (case that wasn't handled).

https://github.com/matomo-org/device-detector/blob/06b9adaedbcf4e77c812dd5897214f67ce3d0129/Parser/AbstractParser.php#L297-L301