### PR TITLE
Allow later Symfony versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "phpstan/phpstan": "^1.10.44",
         "mayflower/mo4-coding-standard": "^v9.0.0",
         "slevomat/coding-standard": "<8.16.0",
-        "symfony/yaml": "^5.4||^6.3||7.0"
+        "symfony/yaml": "^5.4 || ^6.4 || ^7.4 || ^8.0"
     },
     "suggest": {
         "ext-yaml": "Necessary for using the Pecl YAML parser"

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "phpstan/phpstan": "^1.10.44",
         "mayflower/mo4-coding-standard": "^v9.0.0",
         "slevomat/coding-standard": "<8.16.0",
-        "symfony/yaml": "^5.1.7"
+        "symfony/yaml": "^5.4||^6.3||7.0"
     },
     "suggest": {
         "ext-yaml": "Necessary for using the Pecl YAML parser"


### PR DESCRIPTION
Replaces #7570

```
^5.4 - PHP >= 7.2.5
^6.4 - PHP >= 8.1
^7.4 - PHP >= 8.2
^8.0 - PHP >= 8.4
```