### PR TITLE
Update wiki link

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "support": {
         "forum": "https://forum.matomo.org/",
         "issues": "https://github.com/matomo-org/device-detector/issues",
-        "wiki": "https://dev.matomo.org/",
+        "wiki": "https://developer.matomo.org/",
         "source": "https://github.com/matomo-org/matomo"
     },
     "autoload": {


### PR DESCRIPTION
`dev.matomo.org` seems to be down and replaced by `developer.matomo.org`