### PR TITLE
Adds detection for Vega OS

### DIFF
--- a/Parser/OperatingSystem.php
+++ b/Parser/OperatingSystem.php
@@ -221,6 +221,7 @@ class OperatingSystem extends AbstractParser
         'UBT' => 'Ubuntu',
         'ULT' => 'ULTRIX',
         'UOS' => 'UOS',
+        'VEG' => 'Vega OS',
         'VID' => 'VIDAA',
         'VIZ' => 'ViziOS',
         'WAS' => 'watchOS',
@@ -293,7 +294,7 @@ class OperatingSystem extends AbstractParser
         'WebTV'                 => ['WTV'],
         'Windows'               => ['WIN'],
         'Windows Mobile'        => ['WPH', 'WMO', 'WCE', 'WRT', 'WIO', 'KIN'],
-        'Other Smart TV'        => ['WHS', 'TIT', 'ORS'],
+        'Other Smart TV'        => ['WHS', 'TIT', 'ORS', 'VEG'],
     ];
 
     /**

--- a/Tests/Parser/Client/fixtures/mobile_app.yml
+++ b/Tests/Parser/Client/fixtures/mobile_app.yml
@@ -2507,3 +2507,9 @@
     type: mobile app
     name: Google
     version: ""
+-
+  user_agent: Amazon AFTCA002 Kepler/1.1 espn/2026.3.1 NativeClientPlatform/2025.09.10
+  client:
+    type: mobile app
+    name: ESPN
+    version: 2026.3.1

--- a/Tests/Parser/fixtures/oss.yml
+++ b/Tests/Parser/fixtures/oss.yml
@@ -6719,3 +6719,19 @@
     version: 26.3.1
     platform: ""
     family: iOS
+-
+  user_agent: Amazon AFTCA002 Kepler/1.1 Hulu/1.43.0 NativeClientPlatform/2025.09.8
+  os:
+    name: Vega OS
+    short_name: VEG
+    version: "1.1"
+    platform: ""
+    family: Other Smart TV
+-
+  user_agent: Mozilla/5.0 (Linux; Kepler 1.1; AFTCA002 user/1234; wv) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Chrome/132.0.6834.209 Safari/537.36
+  os:
+    name: Vega OS
+    short_name: VEG
+    version: "1.1"
+    platform: ""
+    family: Other Smart TV

--- a/Tests/fixtures/tv-5.yml
+++ b/Tests/fixtures/tv-5.yml
@@ -4209,3 +4209,32 @@
     model: 43UN68006LA
   os_family: Other Mobile
   browser_family: Chrome
+-
+  user_agent: Kepler/1.1 (Linux; AFTCL001)
+  os:
+    name: Vega OS
+    version: "1.1"
+    platform: ""
+  client: null
+  device:
+    type: tv
+    brand: Amazon
+    model: Fire TV Stick HD (2026)
+  os_family: Other Smart TV
+  browser_family: Unknown
+-
+  user_agent: Amazon AFTCA002 Kepler/1.1 Hulu/1.43.0 NativeClientPlatform/2025.09.8
+  os:
+    name: Vega OS
+    version: "1.1"
+    platform: ""
+  client:
+    type: mobile app
+    name: Hulu
+    version: 1.43.0
+  device:
+    type: tv
+    brand: Amazon
+    model: Fire TV Stick 4K Select (2025)
+  os_family: Other Smart TV
+  browser_family: Unknown

--- a/regexes/client/mobile_apps.yml
+++ b/regexes/client/mobile_apps.yml
@@ -2772,6 +2772,11 @@
   name: 'Redline'
   version: '$1'
 
+# ESPN
+- regex: 'espn/([\d.]+)'
+  name: 'ESPN'
+  version: '$1'
+
 # Electron generic apps
 - regex: ' (?!(?:AppleWebKit|brave|Cypress|Franz|Mailspring|Notion|Basecamp|Evernote|catalyst|ramboxpro|BlueMail|BeakerBrowser|Dezor|TweakStyle|Colibri|Polypane|Singlebox|Skye|VibeMate|(?:d|LT|Glass|Sushi|Flash|OhHai)Browser|Sizzy))([a-z0-9]*)(?:-desktop|-electron-app)?/(\d+\.[\d.]+).*Electron/'
   name: '$1'

--- a/regexes/device/mobiles.yml
+++ b/regexes/device/mobiles.yml
@@ -26630,7 +26630,7 @@ Amazon Basics:
 
 # Kindle
 Amazon:
-  regex: '(?:smarttv_)?(?:AFT[ABMNRST]|AFTSSS?|AFTANNA0|AFTGAZL|AFTMM|AFTK(?:A|M|RT)|AFTTI43|AFTTIFF43|AFTHA001|AFTKA(?:DE|UK)?00[12]|SD4930UR|AEO(?:AT|B[CP]|C[HNW]|H[PY]|KN|RH|TA)|KF(?:OT|ONWI|TT|JWI|JWA|[DFS]OWI|A[PRSU]WI|T[BH]WI|TRP?WI|SAW[IA]|GIWI|[KMR]AWI|MEWI|[MSTQ]UWI|SNWI|RAPWI))(?:[);/ _]|$)|Kindle|AlexaMediaPlayer|Amazon (?:Tate|Jem)|Silk/\d+\.\d+|Echo/1|.+FIRETVSTICK|Amazon;Echo'
+  regex: '(?:smarttv_)?(?:AFT[ABMNRST]|AFTSSS?|AFTANNA0|AFTCA002|AFTCL001|AFTGAZL|AFTMM|AFTK(?:A|M|RT)|AFTTI43|AFTTIFF43|AFTHA001|AFTKA(?:DE|UK)?00[12]|SD4930UR|AEO(?:AT|B[CP]|C[HNW]|H[PY]|KN|RH|TA)|KF(?:OT|ONWI|TT|JWI|JWA|[DFS]OWI|A[PRSU]WI|T[BH]WI|TRP?WI|SAW[IA]|GIWI|[KMR]AWI|MEWI|[MSTQ]UWI|SNWI|RAPWI))(?:[);/ _]|$)|Kindle|AlexaMediaPlayer|Amazon (?:Tate|Jem)|Silk/\d+\.\d+|Echo/1|.+FIRETVSTICK|Amazon;Echo'
   device: 'tablet'
   models:
     - regex: '(?:smarttv_)?AFTA(?:[);/ _]|$)'
@@ -26695,6 +26695,12 @@ Amazon:
       device: 'tv'
     - regex: '(?:smarttv_)?AFTKRT(?:[);/ _]|$)'
       model: 'Fire TV Stick 4K Max (2023)'
+      device: 'tv'
+    - regex: '(?:smarttv_)?AFTCA002(?:[);/ _]|$)'
+      model: 'Fire TV Stick 4K Select (2025)'
+      device: 'tv'
+    - regex: '(?:smarttv_)?AFTCL001(?:[);/ _]|$)'
+      model: 'Fire TV Stick HD (2026)'
       device: 'tv'
     - regex: 'KFFOWI(?:[);/ ]|$)'
       model: 'Fire 7"'

--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -763,6 +763,13 @@
   version: ''
 
 ##########
+# Vega OS (https://developer.amazon.com/apps-and-games/vega)
+##########
+- regex: 'Kepler[ /](\d+[.\d]+)'
+  name: 'Vega OS'
+  version: '$1'
+
+##########
 # Revenge OS
 ##########
 - regex: 'revengeos_x2'


### PR DESCRIPTION
`Kepler` is the internal OS name for `Vega OS`.

```
https://developer.amazon.com/apps-and-games/vega
https://community.amazondeveloper.com/t/vega-ids-uuid-ad-id-vendor-tracking-and-device-info/11447
https://developer.amazon.com/docs/fire-tv/fire-os-overview.html
```