### PR TITLE
Adds detection for various tv brands

### DIFF
--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -992,6 +992,7 @@ abstract class AbstractDeviceParser extends AbstractParser
         'VJ'  => 'Jivi',
         'JK'  => 'JKL',
         'JR1' => 'JREN',
+        'JOH' => 'johnson',
         'JO'  => 'Jolla',
         'JP'  => 'Joy',
         'JOY' => 'JoySurf',

--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -1378,6 +1378,7 @@ abstract class AbstractDeviceParser extends AbstractParser
         'OLA' => 'Olax',
         'OLK' => 'Olkya',
         'OLY' => 'Olympia',
+        'OCN' => 'OCEAN',
         'OCE' => 'OCEANIC',
         'OLT' => 'OLTO',
         'OJ'  => 'Ookee',

--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -816,6 +816,7 @@ abstract class AbstractDeviceParser extends AbstractParser
         'ZH'  => 'Hezire',
         'HEX' => 'HexaByte',
         'HEW' => 'HeadWolf',
+        'HDR' => 'Heider',
         'HEI' => 'Heimat',
         'HL'  => 'Hi-Level',
         '3H'  => 'Hi',

--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -520,6 +520,7 @@ abstract class AbstractDeviceParser extends AbstractParser
         'DY'  => 'Dreamgate',
         'DR1' => 'DreamStar',
         'DTA' => 'Dtac',
+        'DUA' => 'Dual',
         'DU'  => 'Dune HD',
         'DUO' => 'DuoTV',
         'UD'  => 'DUNNS Mobile',

--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -1756,6 +1756,7 @@ abstract class AbstractDeviceParser extends AbstractParser
         'SUA' => 'SUAAT',
         'SUR' => 'Surge',
         'SUF' => 'Surfans',
+        'SRF' => 'SURFTV',
         '06'  => 'Subor',
         'SUT' => 'SULPICE TV',
         'SZ'  => 'Sumvision',

--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -1297,7 +1297,7 @@ abstract class AbstractDeviceParser extends AbstractParser
         'NDP' => 'Nedaphone',
         '8N'  => 'Necnot',
         'NF'  => 'Neffos',
-        '9X'  => 'Neo',
+        '9X'  => 'NEO',
         'NEK' => 'NEKO',
         '1N'  => 'Neomi',
         '7Q'  => 'Neon IQ',

--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -1509,6 +1509,7 @@ abstract class AbstractDeviceParser extends AbstractParser
         '2P'  => 'Prixton',
         'PRI' => 'Pritom',
         'PRP' => 'PRISM+',
+        'PRC' => 'ProCaster',
         'PF'  => 'PROFiLO',
         'P6'  => 'Proline',
         '5O'  => 'Prology',

--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -1541,6 +1541,7 @@ abstract class AbstractDeviceParser extends AbstractParser
         'Q9'  => 'QTECH',
         '84'  => 'Quanta Computer',
         'QA'  => 'Quantum',
+        'QRT' => 'Quart',
         'QUA' => 'Quatro',
         'QU'  => 'Quechua',
         'QUE' => 'Quest',

--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -616,6 +616,7 @@ abstract class AbstractDeviceParser extends AbstractParser
         'EV1' => 'Everex',
         'EVR' => 'Everis',
         'EVF' => 'Everfine',
+        'EST' => 'Eversteel',
         'E3'  => 'Evolio',
         'EO'  => 'Evolveo',
         '0Q'  => 'Evoo',

--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -207,6 +207,7 @@ abstract class AbstractDeviceParser extends AbstractParser
         'AU'  => 'Asus',
         '6A'  => 'AT&T',
         'ATH' => 'Athesi',
+        'ATL' => 'ATLANTIC',
         'ATE' => 'Atlantic Electrics',
         '5Q'  => 'Atmaca Elektronik',
         'YH'  => 'ATMAN',

--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -523,6 +523,7 @@ abstract class AbstractDeviceParser extends AbstractParser
         'DUO' => 'DuoTV',
         'UD'  => 'DUNNS Mobile',
         'DUU' => 'Duubee',
+        'DRB' => 'Durabase',
         'DUR' => 'Durabook',
         'DUD' => 'DUDU AUTO',
         'DYO' => 'Dyon',

--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -974,6 +974,7 @@ abstract class AbstractDeviceParser extends AbstractParser
         'UI'  => 'ivvi',
         'QW'  => 'iWaylink',
         'I9'  => 'iZotron',
+        'IXI' => 'IXI',
         'IXT' => 'iXTech',
         'IOT' => 'IOTWE',
         'JA'  => 'JAY-Tech',

--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -773,6 +773,7 @@ abstract class AbstractDeviceParser extends AbstractParser
         '8G'  => 'Gplus',
         'GR'  => 'Gradiente',
         'GRE' => 'Graetz',
+        'GRN' => 'Grandin',
         'GP'  => 'Grape',
         'G6'  => 'Gree',
         'GRA' => 'Great Asia',

--- a/Parser/Device/AbstractDeviceParser.php
+++ b/Parser/Device/AbstractDeviceParser.php
@@ -1804,6 +1804,7 @@ abstract class AbstractDeviceParser extends AbstractParser
         'TC'  => 'TCL',
         'T0'  => 'TD Systems',
         'YY'  => 'TD Tech',
+        'TNC' => 'Technical',
         'H4'  => 'Technicolor',
         'TEA' => 'TeachTouch',
         'Z5'  => 'Technika',

--- a/Tests/fixtures/tv-1.yml
+++ b/Tests/fixtures/tv-1.yml
@@ -4908,7 +4908,7 @@
     engine_version: 2.12.407
   device:
     type: tv
-    brand: Neo
+    brand: NEO
     model: ""
   os_family: GNU/Linux
   browser_family: Opera

--- a/Tests/fixtures/tv-5.yml
+++ b/Tests/fixtures/tv-5.yml
@@ -4866,3 +4866,21 @@
     model: Smart TV (2017)
   os_family: GNU/Linux
   browser_family: Opera
+-
+  user_agent: Mozilla/5.0 (Linux ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36 OPR/46.0.2207.0 OMI/4.13.5.431.SIERRA.158 Model/Vestel-MB230 VSTVB MB200 HbbTV/1.5.1 (+DRM; NEO; MB230; 0.51.39.0; ; _TV_NT72671_2019;) SmartTvA/3.0.0
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: ""
+  client:
+    type: browser
+    name: Opera Devices
+    version: 4.13.5.431
+    engine: Blink
+    engine_version: 67.0.3396.99
+  device:
+    type: tv
+    brand: Neo
+    model: Smart TV (2019)
+  os_family: GNU/Linux
+  browser_family: Opera

--- a/Tests/fixtures/tv-5.yml
+++ b/Tests/fixtures/tv-5.yml
@@ -4776,3 +4776,21 @@
     model: Smart TV (2023)
   os_family: GNU/Linux
   browser_family: Opera
+-
+  user_agent: Mozilla/5.0 (Linux ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Safari/537.36 OPR/46.0.2207.0 OMI/4.20.5.61.LIMA.223 Model/Vestel-MB180 VSTVB MB100 HbbTV/1.5.1 (+DRM; IXI; MB180; 2.51.0.0; ; _TV_G32_2020;) SmartTvA/3.0.0
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: ""
+  client:
+    type: browser
+    name: Opera Devices
+    version: 4.20.5.61
+    engine: Blink
+    engine_version: 77.0.3865.120
+  device:
+    type: tv
+    brand: IXI
+    model: Smart TV (2020)
+  os_family: GNU/Linux
+  browser_family: Opera

--- a/Tests/fixtures/tv-5.yml
+++ b/Tests/fixtures/tv-5.yml
@@ -4880,7 +4880,7 @@
     engine_version: 67.0.3396.99
   device:
     type: tv
-    brand: Neo
+    brand: NEO
     model: Smart TV (2019)
   os_family: GNU/Linux
   browser_family: Opera

--- a/Tests/fixtures/tv-5.yml
+++ b/Tests/fixtures/tv-5.yml
@@ -4704,3 +4704,21 @@
     model: Smart TV (2017)
   os_family: GNU/Linux
   browser_family: Unknown
+-
+  user_agent: Mozilla/5.0 (Linux ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.5359.128 Safari/537.36 OPR/46.0.2207.0 OMI/4.23.2.96.LIMA2.127 Model/Vestel-MB180 VSTVB MB100 HbbTV/1.6.1 (+DRM; EVERSTEEL; MB180; 1.63.0.0; ; _TV_G32_2023;) TiVoOS/1.0.0 (Vestel MB180 EVERSTEEL) SmartTvA/3.0.0
+  os:
+    name: TiVo OS
+    version: 1.0.0
+    platform: ""
+  client:
+    type: browser
+    name: Opera Devices
+    version: 4.23.2.96
+    engine: Blink
+    engine_version: 108.0.5359.128
+  device:
+    type: tv
+    brand: Eversteel
+    model: Smart TV (2023)
+  os_family: GNU/Linux
+  browser_family: Opera

--- a/Tests/fixtures/tv-5.yml
+++ b/Tests/fixtures/tv-5.yml
@@ -4794,3 +4794,21 @@
     model: Smart TV (2020)
   os_family: GNU/Linux
   browser_family: Opera
+-
+  user_agent: Mozilla/5.0 (Linux ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Safari/537.36 OPR/46.0.2207.0 OMI/4.20.5.61.LIMA.215 Model/Vestel-MB181 VSTVB MB100 HbbTV/1.5.1 (+DRM; JOHNSON; MB181; 2.49.0.0; ; _TV_G36_2020;) SmartTvA/3.0.0 LovesTV2020
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: ""
+  client:
+    type: browser
+    name: Opera Devices
+    version: 4.20.5.61
+    engine: Blink
+    engine_version: 77.0.3865.120
+  device:
+    type: tv
+    brand: johnson
+    model: Smart TV (2020)
+  os_family: GNU/Linux
+  browser_family: Opera

--- a/Tests/fixtures/tv-5.yml
+++ b/Tests/fixtures/tv-5.yml
@@ -4688,3 +4688,19 @@
     model: Smart TV (2020)
   os_family: GNU/Linux
   browser_family: Opera
+-
+  user_agent: Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36 OPR/40.0.2207.0 OMI/4.9.0.237.DOM3.217 Model/Vestel-MB130 VSTVB MB100 HbbTV/1.2.1 (; PROCASTER; MB130; 4.35.11.0; _TV_G10_2017;) SmartTvA/3.0.0
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: ARM
+  client:
+    type: mobile app
+    name: Procast
+    version: ""
+  device:
+    type: tv
+    brand: ProCaster
+    model: Smart TV (2017)
+  os_family: GNU/Linux
+  browser_family: Unknown

--- a/Tests/fixtures/tv-5.yml
+++ b/Tests/fixtures/tv-5.yml
@@ -4722,3 +4722,21 @@
     model: Smart TV (2023)
   os_family: GNU/Linux
   browser_family: Opera
+-
+  user_agent: Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.130 Safari/537.36 OPR/31.0.1890.0 OMI/4.6.1.40.Dominik2.0 VSTVB MB100 HbbTV/1.2.1 (; DURABASE; MB110; 2.9.8.0; ;) SmartTvA/3.0.0
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: ARM
+  client:
+    type: browser
+    name: Opera Devices
+    version: 4.6.1.40
+    engine: Blink
+    engine_version: 44.0.2403.130
+  device:
+    type: tv
+    brand: Durabase
+    model: ""
+  os_family: GNU/Linux
+  browser_family: Opera

--- a/Tests/fixtures/tv-5.yml
+++ b/Tests/fixtures/tv-5.yml
@@ -4830,3 +4830,21 @@
     model: Smart TV (2021)
   os_family: Android
   browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36 OPR/46.0.2207.0 OMI/4.13.5.431.SIERRA.158 Model/Vestel-MB230 VSTVB MB200 HbbTV/1.5.1 (+DRM; DUAL; MB230; 0.51.41.0; ; _TV_NT72671_2019;) SmartTvA/3.0.0
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: ""
+  client:
+    type: browser
+    name: Opera Devices
+    version: 4.13.5.431
+    engine: Blink
+    engine_version: 67.0.3396.99
+  device:
+    type: tv
+    brand: Dual
+    model: Smart TV (2019)
+  os_family: GNU/Linux
+  browser_family: Opera

--- a/Tests/fixtures/tv-5.yml
+++ b/Tests/fixtures/tv-5.yml
@@ -4848,3 +4848,21 @@
     model: Smart TV (2019)
   os_family: GNU/Linux
   browser_family: Opera
+-
+  user_agent: Mozilla/5.0 (Linux ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36 OPR/40.0.2207.0 OMI/4.9.0.237.DOM3-OPT.253 Model/Vestel-MB211 VSTVB MB200 HbbTV/1.2.1 (; QUART; MB211; 3.33.17.0; _TV_NT72563_2017;) SmartTvA/3.0.0
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: ""
+  client:
+    type: browser
+    name: Opera Devices
+    version: 4.9.0.237
+    engine: Blink
+    engine_version: 53.0.2785.143
+  device:
+    type: tv
+    brand: Quart
+    model: Smart TV (2017)
+  os_family: GNU/Linux
+  browser_family: Opera

--- a/Tests/fixtures/tv-5.yml
+++ b/Tests/fixtures/tv-5.yml
@@ -4812,3 +4812,21 @@
     model: Smart TV (2020)
   os_family: GNU/Linux
   browser_family: Opera
+-
+  user_agent: Mozilla/5.0 (Android armv8l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36 Model/Vestel-MB186 VSTVB MB186 FVC/6.0 (ATLANTIC ; MB186; ) HbbTV/1.5.1 (+DRM; ATLANTIC ; MB186; R2.0.1.0.0.V0.17.4; ; _TV_MSTARG56_2021;) SmartTvA/3.0.0 LaTiVu_1.0.1_2022
+  os:
+    name: Android
+    version: ""
+    platform: ARM
+  client:
+    type: browser
+    name: Chrome
+    version: 55.0.2883.91
+    engine: Blink
+    engine_version: 55.0.2883.91
+  device:
+    type: tv
+    brand: ATLANTIC
+    model: Smart TV (2021)
+  os_family: Android
+  browser_family: Chrome

--- a/Tests/fixtures/tv-5.yml
+++ b/Tests/fixtures/tv-5.yml
@@ -4652,3 +4652,21 @@
     model: Smart TV (2023)
   os_family: GNU/Linux
   browser_family: Opera
+-
+  user_agent: Mozilla/5.0 (Linux ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.5359.128 Safari/537.36 OPR/46.0.2207.0 OMI/4.23.2.96.LIMA2.105 Model/Vestel-MB180 VSTVB MB100 HbbTV/1.6.1 (+DRM; SURFTV; MB180; 2.48.0.0; ; _TV_G31_2023;) TiVoOS/1.0.0 (Vestel MB180 SURFTV) SmartTvA/3.0.0
+  os:
+    name: TiVo OS
+    version: 1.0.0
+    platform: ""
+  client:
+    type: browser
+    name: Opera Devices
+    version: 4.23.2.96
+    engine: Blink
+    engine_version: 108.0.5359.128
+  device:
+    type: tv
+    brand: SURFTV
+    model: Smart TV (2023)
+  os_family: GNU/Linux
+  browser_family: Opera

--- a/Tests/fixtures/tv-5.yml
+++ b/Tests/fixtures/tv-5.yml
@@ -4634,3 +4634,21 @@
     model: Z Mini
   os_family: Android
   browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.5359.128 Safari/537.36 OPR/46.0.2207.0 OMI/4.23.2.96.LIMA2.116 Model/Vestel-MB181 VSTVB MB100 HbbTV/1.6.1 (+DRM; TECHNICAL; MB181; 2.56.0.0; ; _TV_G36_2023;) TiVoOS/1.0.0 (Vestel MB181 TECHNICAL) SmartTvA/3.0.0
+  os:
+    name: TiVo OS
+    version: 1.0.0
+    platform: ""
+  client:
+    type: browser
+    name: Opera Devices
+    version: 4.23.2.96
+    engine: Blink
+    engine_version: 108.0.5359.128
+  device:
+    type: tv
+    brand: Technical
+    model: Smart TV (2023)
+  os_family: GNU/Linux
+  browser_family: Opera

--- a/Tests/fixtures/tv-5.yml
+++ b/Tests/fixtures/tv-5.yml
@@ -4740,3 +4740,21 @@
     model: ""
   os_family: GNU/Linux
   browser_family: Opera
+-
+  user_agent: Mozilla/5.0 (Linux ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.5359.128 Safari/537.36 OPR/46.0.2207.0 OMI/4.23.2.96.LIMA2.127 Model/Vestel-MB180 VSTVB MB100 HbbTV/1.6.1 (+DRM; GRANDIN; MB180; 1.63.0.0; ; _TV_G32_2023;) TiVoOS/1.0.0 (Vestel MB180 GRANDIN) SmartTvA/3.0.0
+  os:
+    name: TiVo OS
+    version: 1.0.0
+    platform: ""
+  client:
+    type: browser
+    name: Opera Devices
+    version: 4.23.2.96
+    engine: Blink
+    engine_version: 108.0.5359.128
+  device:
+    type: tv
+    brand: Grandin
+    model: Smart TV (2023)
+  os_family: GNU/Linux
+  browser_family: Opera

--- a/Tests/fixtures/tv-5.yml
+++ b/Tests/fixtures/tv-5.yml
@@ -4670,3 +4670,21 @@
     model: Smart TV (2023)
   os_family: GNU/Linux
   browser_family: Opera
+-
+  user_agent: Mozilla/5.0 (Linux ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Safari/537.36 OPR/46.0.2207.0 OMI/4.20.5.61.LIMA.223 Model/Vestel-MB180 VSTVB MB100 HbbTV/1.5.1 (+DRM; OCEAN; MB180; 2.51.0.0; ; _TV_G32_2020;) SmartTvA/3.0.0
+  os:
+    name: GNU/Linux
+    version: ""
+    platform: ""
+  client:
+    type: browser
+    name: Opera Devices
+    version: 4.20.5.61
+    engine: Blink
+    engine_version: 77.0.3865.120
+  device:
+    type: tv
+    brand: OCEAN
+    model: Smart TV (2020)
+  os_family: GNU/Linux
+  browser_family: Opera

--- a/Tests/fixtures/tv-5.yml
+++ b/Tests/fixtures/tv-5.yml
@@ -4758,3 +4758,21 @@
     model: Smart TV (2023)
   os_family: GNU/Linux
   browser_family: Opera
+-
+  user_agent: Mozilla/5.0 (Linux ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.5359.128 Safari/537.36 OPR/46.0.2207.0 OMI/4.23.2.96.LIMA2.127 Model/Vestel-MB180 VSTVB MB100 HbbTV/1.6.1 (+DRM; HEIDER; MB180; 1.63.0.0; ; _TV_G32_2023;) TiVoOS/1.0.0 (Vestel MB180 HEIDER) SmartTvA/3.0.0
+  os:
+    name: TiVo OS
+    version: 1.0.0
+    platform: ""
+  client:
+    type: browser
+    name: Opera Devices
+    version: 4.23.2.96
+    engine: Blink
+    engine_version: 108.0.5359.128
+  device:
+    type: tv
+    brand: Heider
+    model: Smart TV (2023)
+  os_family: GNU/Linux
+  browser_family: Opera

--- a/regexes/device/mobiles.yml
+++ b/regexes/device/mobiles.yml
@@ -45615,7 +45615,7 @@ Yutmart:
     - regex: 'YUTMART-MXQPRO'
       model: 'MXQ Pro'
 
-# Bulsatcom or b-box
+# Bulsatcom or b-box (https://www.bulsatcom.bg/)
 Bulsatcom:
   regex: '(IMTM741)(?:[);/ ]|$)'
   device: 'tv'

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -1404,6 +1404,14 @@ TALBERG:
     - regex: 'SmartTV(2019|2020)'
       model: 'Smart TV ($1)'
 
+# Technical (https://vestel-france.fr/en/tv)
+Technical:
+  regex: 'Technical'
+  device: 'tv'
+  models:
+    - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
+      model: 'Smart TV ($1)'
+
 # Technicolor
 Technicolor:
   regex: 'Technicolor'

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -462,6 +462,14 @@ Hanseatic:
     - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
       model: 'Smart TV ($1)'
 
+# Heider
+Heider:
+  regex: 'Heider[;,)]'
+  device: 'tv'
+  models:
+    - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
+      model: 'Smart TV ($1)'
+
 # Hi-Level
 Hi-Level:
   regex: 'HI-LEVEL[;,)]'

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -632,6 +632,14 @@ Inverto:
     - regex: 'LaTivu_(?:\d+[.\d]+)_([0-9]{4})'
       model: 'Smart TV ($1)'
 
+# IXI (https://web.archive.org/web/20240614122417/https://ixielectronics.com/)
+IXI:
+  regex: 'IXI[;,)]'
+  device: 'tv'
+  models:
+    - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
+      model: 'Smart TV ($1)'
+
 # JVC
 JVC:
   regex: 'AFTSO001|JVC[;,)]'

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -1090,9 +1090,11 @@ NABO:
 
 # Neo
 Neo:
-  regex: 'NEO, ([a-z0-9_ -]+), (?:wired|wireless)'
+  regex: 'NEO[;,)]'
   device: 'tv'
-  model: ''
+  models:
+    - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
+      model: 'Smart TV ($1)'
 
 # NEXON
 NEXON:

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -1080,6 +1080,14 @@ NORMANDE:
     - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
       model: 'Smart TV ($1)'
 
+# OCEAN (https://www.ocean.it/)
+OCEAN:
+  regex: 'OCEAN[;,)]'
+  device: 'tv'
+  models:
+    - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
+      model: 'Smart TV ($1)'
+
 # OCEANIC (https://www.oceanic.eu/)
 OCEANIC:
   regex: 'OCEANIC[;,)]'

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -328,6 +328,14 @@ Essentielb:
     - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
       model: 'Smart TV ($1)'
 
+# Eversteel
+Eversteel:
+  regex: 'Eversteel[;,)]'
+  device: 'tv'
+  models:
+    - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
+      model: 'Smart TV ($1)'
+
 # Express LUCK (https://www.expressluck.com/)
 Express LUCK:
   regex: 'Expressluck[;,)]'

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -280,6 +280,14 @@ Dream Multimedia:
   device: 'tv'
   model: 'Dreambox'
 
+# Durabase
+Durabase:
+  regex: 'Durabase[;,)]'
+  device: 'tv'
+  models:
+    - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
+      model: 'Smart TV ($1)'
+
 # EGL
 EGL:
   regex: 'EGL[;,)]'

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -1282,6 +1282,14 @@ Qilive:
     - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
       model: 'Smart TV ($1)'
 
+# Quart
+Quart:
+  regex: 'Quart[;,)]'
+  device: 'tv'
+  models:
+    - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
+      model: 'Smart TV ($1)'
+
 # RCA Tablets (RCA) (https://www.rca.com/ https://rca-televisions.com/)
 RCA Tablets:
   regex: 'RCA;'

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -428,6 +428,14 @@ Graetz:
     - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
       model: 'Smart TV ($1)'
 
+# Grandin
+Grandin:
+  regex: 'Grandin[;,)]'
+  device: 'tv'
+  models:
+    - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
+      model: 'Smart TV ($1)'
+
 # Grundig
 Grundig:
   regex: '(OWB|(?:Amazon.+)?Grundig)'

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -1380,6 +1380,14 @@ Star-Light:
   device: 'tv'
   model: ''
 
+# SURFTV
+SURFTV:
+  regex: 'SURFTV'
+  device: 'tv'
+  models:
+    - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
+      model: 'Smart TV ($1)'
+
 # SULPICE TV (https://sulpicetv.com/)
 SULPICE TV:
   regex: 'SULPICE_TV[;,)]'

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -96,6 +96,14 @@ ARRIS:
     - regex: 'FS-ARS-01B'
       model: 'FS-ARS-01B'
 
+# ATLANTIC
+ATLANTIC:
+  regex: 'ATLANTIC [;,)]'
+  device: 'tv'
+  models:
+    - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
+      model: 'Smart TV ($1)'
+
 # Atlantic Electrics (https://www.atlanticelectrics.co.uk/)
 Atlantic Electrics:
   regex: 'ATLANTIC[;,)]'

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -1184,6 +1184,14 @@ PREMIER:
     - regex: 'LGE/[^/]+/PREMIER; ([a-z0-9]+);'
       model: '$1'
 
+# ProCaster
+ProCaster:
+  regex: 'ProCaster[;,)]'
+  device: 'tv'
+  models:
+    - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
+      model: 'Smart TV ($1)'
+
 # PROFiLO
 PROFiLO:
   regex: 'PROFILO[;,)]'

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -288,6 +288,14 @@ Dream Multimedia:
   device: 'tv'
   model: 'Dreambox'
 
+# Dual (https://www.dualav.com/)
+Dual:
+  regex: 'Dual[;,)]'
+  device: 'tv'
+  models:
+    - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
+      model: 'Smart TV ($1)'
+
 # Durabase
 Durabase:
   regex: 'Durabase[;,)]'

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -1088,8 +1088,8 @@ NABO:
     - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
       model: 'Smart TV ($1)'
 
-# Neo
-Neo:
+# NEO
+NEO:
   regex: 'NEO[;,)]'
   device: 'tv'
   models:

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -640,6 +640,14 @@ IXI:
     - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
       model: 'Smart TV ($1)'
 
+# johnson (https://ponjohnsonentuvida.es/)
+johnson:
+  regex: 'johnson[;,)]'
+  device: 'tv'
+  models:
+    - regex: '_TV_[A-Z0-9]+_([0-9]{4});'
+      model: 'Smart TV ($1)'
+
 # JVC
 JVC:
   regex: 'AFTSO001|JVC[;,)]'


### PR DESCRIPTION
ref #7994

I renamed `Neo` to `NEO` as seen on the tv screen - `https://www.facebook.com/groups/908152702639026/posts/9496080500512827/`

Logos:

```
ATLANTIC - https://bi-siparis.com/wp-content/uploads/2024/07/MBTV32HD-Atlantic-32-Smart-LED-TV.png
Dual - https://www.dualav.com/wp-content/uploads/2022/02/dual_logo_motto.png.webp
Eversteel - https://kalo.yt/img/m/18.jpg
Heider - https://www.ame.cz/RC39105-Dalkovy-ovladac-VESTEL-Heider-originalni-23606182-RC39170-a169753639.webp
IXI - https://www.facebook.com/photo/?fbid=185982973943963&set=a.185982987277295
johnson - https://ponjohnsonentuvida.es/img/logo-16823339102.jpg
NEO - https://www.facebook.com/groups/908152702639026/posts/9496080500512827/
OCEAN - https://www.ocean.it/themes/ocean/assets/base/img/layout/logos/logo.png
ProCaster - https://images.ctfassets.net/nggsuamsum0l/7AeuxTwXR9X9DMi6mPbwXV/e232afee6b698e14f516cf0a0c68af85/Procaster_logo_brand_page.jpg
Technical - https://vestel-france.fr/file/IB-TECHNICAL-LCD8204HDBMKII.pdf
```