### PR TITLE
Improves version detection for iOS and macOS

### DIFF
--- a/Tests/Parser/fixtures/oss.yml
+++ b/Tests/Parser/fixtures/oss.yml
@@ -7202,3 +7202,11 @@
     version: "26.5"
     platform: ""
     family: Mac
+-
+  user_agent: ArcMobile2/53382.2 CFNetwork/3892.100.1 Darwin/27.0.0
+  os:
+    name: iOS
+    short_name: IOS
+    version: "27.0"
+    platform: ""
+    family: iOS

--- a/Tests/Parser/fixtures/oss.yml
+++ b/Tests/Parser/fixtures/oss.yml
@@ -7194,3 +7194,11 @@
     family: GNU/Linux
   headers:
     Sec-CH-UA-Platform: Ubuntu
+-
+  user_agent: Self Service+/7570 CFNetwork/macOS/3860.600.21 Darwin/25.5.0
+  os:
+    name: Mac
+    short_name: MAC
+    version: "26.5"
+    platform: ""
+    family: Mac

--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -1600,7 +1600,7 @@
 - regex: '^(?!com\.apple\.Safari\.SearchHelper|Safari|com\.apple\.WebKit\.Networking|NetworkingExtension).*(?:CFNetwork(?!/macOS/)|Mana)/.+ Darwin/(\d+[.\d]+)(?!.*(?:x86_64|i386|PowerMac|Power%20Macintosh))'
   name: 'iOS'
   versions:
-    - regex: 'Darwin/26\.(0)\.0'
+    - regex: 'Darwin/2[67]\.(0)\.0'
       version: '27.$1'
     - regex: 'Darwin/25\.([0-6])\.0'
       version: '26.$1'
@@ -1802,7 +1802,7 @@
 - regex: '(?:CFNetwork|Mana|StudioDisplay)/.+Darwin(?:/|; )(?:[\d.]+).+(?:x86_64|i386|Power%20Macintosh)|CFNetwork/macOS/.+Darwin/|(?:x86_64-apple-)?darwin(?:[\d.]+)|C?Python.*Darwin|PowerMac|com\.apple\.Safari\.SearchHelper|^(?:com\.apple\.WebKit\.Networking|NetworkingExtension|Safari)'
   name: 'Mac'
   versions:
-    - regex: '(?:x86_64-apple-)?Darwin(?:/|; )?26\.(0)\.0'
+    - regex: '(?:x86_64-apple-)?Darwin(?:/|; )?2[67]\.(0)\.0'
       version: '27.$1'
     - regex: '(?:x86_64-apple-)?Darwin(?:/|; )?25\.([0-6])\.0'
       version: '26.$1'

--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -1597,7 +1597,7 @@
   name: 'iOS'
   version: '$1'
 
-- regex: '^(?!com\.apple\.Safari\.SearchHelper|Safari|com\.apple\.WebKit\.Networking|NetworkingExtension).*(?:CFNetwork|Mana)/.+ Darwin/(\d+[.\d]+)(?!.*(?:x86_64|i386|PowerMac|Power%20Macintosh))'
+- regex: '^(?!com\.apple\.Safari\.SearchHelper|Safari|com\.apple\.WebKit\.Networking|NetworkingExtension).*(?:CFNetwork(?!/macOS/)|Mana)/.+ Darwin/(\d+[.\d]+)(?!.*(?:x86_64|i386|PowerMac|Power%20Macintosh))'
   name: 'iOS'
   versions:
     - regex: 'Darwin/26\.(0)\.0'
@@ -1790,7 +1790,7 @@
 ##########
 # Mac
 ##########
-- regex: '(?:macOS(?:\(Catalyst\))?[ /,]|Mac(?:os)?-)(\d+[.\d]+)'
+- regex: '(?:(?<!CFNetwork/)macOS(?:\(Catalyst\))?[ /,]|Mac(?:os)?-)(\d+[.\d]+)'
   name: 'Mac'
   version: '$1'
 
@@ -1799,7 +1799,7 @@
   name: 'Mac'
   version: '$1'
 
-- regex: '(?:CFNetwork|Mana|StudioDisplay)/.+Darwin(?:/|; )(?:[\d.]+).+(?:x86_64|i386|Power%20Macintosh)|(?:x86_64-apple-)?darwin(?:[\d.]+)|C?Python.*Darwin|PowerMac|com\.apple\.Safari\.SearchHelper|^(?:com\.apple\.WebKit\.Networking|NetworkingExtension|Safari)'
+- regex: '(?:CFNetwork|Mana|StudioDisplay)/.+Darwin(?:/|; )(?:[\d.]+).+(?:x86_64|i386|Power%20Macintosh)|CFNetwork/macOS/.+Darwin/|(?:x86_64-apple-)?darwin(?:[\d.]+)|C?Python.*Darwin|PowerMac|com\.apple\.Safari\.SearchHelper|^(?:com\.apple\.WebKit\.Networking|NetworkingExtension|Safari)'
   name: 'Mac'
   versions:
     - regex: '(?:x86_64-apple-)?Darwin(?:/|; )?26\.(0)\.0'


### PR DESCRIPTION
macOS 27 - Darwin 26:

```
https://en.wikipedia.org/wiki/MacOS_version_history
```

macOS 27 - Darwin 27 (26 is missing):

```
https://en.wikipedia.org/wiki/Darwin_(operating_system)
https://theapplewiki.com/wiki/Kernel#macOS/OS_X
https://github.com/blacktop/ipsw-diffs/tree/main/27_0_26A5378n_vs_27_0_26A5388g
```

I do see mixed user-agents, so probably they are going to stick with 27.