### PR TITLE
Fixed false-positive Mobile Safari detection for AppleCoreMedia/1.0.0…

### DIFF
--- a/Tests/Parser/Client/fixtures/library.yml
+++ b/Tests/Parser/Client/fixtures/library.yml
@@ -833,3 +833,20 @@
     type: library
     name: nscurl
     version: ""
+-
+  user_agent: AppleCoreMedia/1.0.0.18G82 (iPhone; U; CPU OS 14_7_1 like Mac OS X; es_xl)
+  os:
+    name: iOS
+    version: 14.7.1
+    platform: ""
+  client:
+    type: library
+    name: iOS Application
+    version: ""
+  device:
+    type: smartphone
+    brand: Apple
+    model: iPhone
+  os_family: iOS
+  browser_family: Unknown
+

--- a/Tests/Parser/Client/fixtures/library.yml
+++ b/Tests/Parser/Client/fixtures/library.yml
@@ -834,19 +834,44 @@
     name: nscurl
     version: ""
 -
-  user_agent: AppleCoreMedia/1.0.0.18G82 (iPhone; U; CPU OS 14_7_1 like Mac OS X; es_xl)
-  os:
-    name: iOS
-    version: 14.7.1
-    platform: ""
+  user_agent: AppleCoreMedia/1.0.0.22F76 (iPad; U; CPU OS 18_5 like Mac OS X; en_us)
   client:
     type: library
-    name: iOS Application
+    name: Apple Core Media
     version: ""
-  device:
-    type: smartphone
-    brand: Apple
-    model: iPhone
-  os_family: iOS
-  browser_family: Unknown
-
+-
+  user_agent: AppleCoreMedia/1.0.0.9A405 (iPod; U; CPU OS 5_0_1 like Mac OS X; en_us)
+  client:
+    type: library
+    name: Apple Core Media
+    version: ""
+-
+  user_agent: AppleCoreMedia/1.0.0.19H218 (iPod touch; U; CPU OS 15_7_2 like Mac OS X; en_us)
+  client:
+    type: library
+    name: Apple Core Media
+    version: ""
+-
+  user_agent: AppleCoreMedia/1.0.0.18A347e (Macintosh; U; Intel Mac OS X 10_14; en_us)
+  client:
+    type: library
+    name: Apple Core Media
+    version: ""
+-
+  user_agent: AppleCoreMedia/1.0.0.18G82 (iPhone; U; CPU OS 14_7_1 like Mac OS X; es_xl)
+  client:
+    type: library
+    name: Apple Core Media
+    version: ""
+-
+  user_agent: AppleCoreMedia/1.0.0.15F80 (HomePod; U; CPU OS 11_4 like Mac OS X; fr_fr)
+  client:
+    type: library
+    name: Apple Core Media
+    version: ""
+-
+  user_agent: AppleCoreMedia/1.0.0.17K449 (Apple TV; U; CPU OS 13_3 like Mac OS X; en_us)
+  client:
+    type: library
+    name: Apple Core Media
+    version: ""

--- a/Tests/fixtures/smart_speaker.yml
+++ b/Tests/fixtures/smart_speaker.yml
@@ -7,7 +7,7 @@
     platform: ""
   client:
     type: library
-    name: iOS Application
+    name: Apple Core Media
     version: ""
   device:
     type: smart speaker

--- a/Tests/fixtures/tv.yml
+++ b/Tests/fixtures/tv.yml
@@ -1136,7 +1136,7 @@
     platform: ARM
   client:
     type: library
-    name: iOS Application
+    name: Apple Core Media
     version: ""
   device:
     type: tv
@@ -6601,7 +6601,7 @@
     platform: ARM
   client:
     type: library
-    name: iOS Application
+    name: Apple Core Media
     version: ""
   device:
     type: tv
@@ -6617,7 +6617,7 @@
     platform: ARM
   client:
     type: library
-    name: iOS Application
+    name: Apple Core Media
     version: ""
   device:
     type: tv

--- a/Tests/fixtures/wearable.yml
+++ b/Tests/fixtures/wearable.yml
@@ -1274,7 +1274,7 @@
     platform: ""
   client:
     type: library
-    name: iOS Application
+    name: Apple Core Media
     version: ""
   device:
     type: wearable

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -3576,7 +3576,7 @@
   version: '$1'
   engine:
     default: 'WebKit'
-- regex: '^(?!AppleCoreMedia).*?\b(?:Apple-)?(?:iPod|(?<!Apple TV; U; CPU )iPhone|iPad)'
+- regex: '^(?!AppleCoreMedia).*?\b(?<!Apple-)(?:iPod|(?<!Apple TV; U; CPU )iPhone|iPad)'
   name: 'Mobile Safari'
   version: ''
   engine:
@@ -3591,7 +3591,7 @@
   version: '$1'
   engine:
     default: 'WebKit'
-- regex: 'Macintosh'
+- regex: '^(?!AppleCoreMedia).*?\bMacintosh'
   name: 'Safari'
   version: ''
   engine:

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -3576,7 +3576,7 @@
   version: '$1'
   engine:
     default: 'WebKit'
-- regex: '(?!^AppleCoreMedia/1\.0\.0)(?:iPod|(?<!Apple TV; U; CPU )iPhone|iPad)'
+- regex: '^(?!.*AppleCoreMedia/1\.0\.0).*?(?<![A-Z0-9_-])(?:iPod|(?<!Apple TV; U; CPU )iPhone|iPad)'
   name: 'Mobile Safari'
   version: ''
   engine:

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -3576,7 +3576,7 @@
   version: '$1'
   engine:
     default: 'WebKit'
-- regex: '^(?!.*AppleCoreMedia/1\.0\.0).*?(?<![A-Z0-9_-])(?:iPod|(?<!Apple TV; U; CPU )iPhone|iPad)'
+- regex: '^(?!AppleCoreMedia).*?\b(?:Apple-)?(?:iPod|(?<!Apple TV; U; CPU )iPhone|iPad)'
   name: 'Mobile Safari'
   version: ''
   engine:

--- a/regexes/client/libraries.yml
+++ b/regexes/client/libraries.yml
@@ -551,8 +551,8 @@
 # agent will default to this, always with 1.0.0 version.
 # there was a time when (not even that long ago) apple didn't let you set
 # a user agent so a ton of random applications still identify themselves this way.
-- regex: 'AppleCoreMedia/1\.0\.0'
-  name: 'iOS Application'
+- regex: 'AppleCoreMedia'
+  name: 'Apple Core Media'  
   version: ''
 
 - regex: 'cpp-httplib(?:/(\d+[.\d]+))?'

--- a/regexes/client/libraries.yml
+++ b/regexes/client/libraries.yml
@@ -552,7 +552,7 @@
 # there was a time when (not even that long ago) apple didn't let you set
 # a user agent so a ton of random applications still identify themselves this way.
 - regex: 'AppleCoreMedia'
-  name: 'Apple Core Media'  
+  name: 'Apple Core Media'
   version: ''
 
 - regex: 'cpp-httplib(?:/(\d+[.\d]+))?'


### PR DESCRIPTION
AppleCoreMedia/1.0.0.18G82 (iPhone; U; CPU OS 14_7_1 like Mac OS X; es_xl)

### Description

Fix detection of AppleCoreMedia user agents that are incorrectly identified as Mobile Safari.

User agents such as:

- AppleCoreMedia/1.0.0.18G82 (iPhone; U; CPU OS 14_7_1 like Mac OS X; es_xl)

contain iPhone, causing them to match the Mobile Safari browser regex even though the user agent represents an iOS application using AppleCoreMedia/1.0.0 framewiork.

The 

- AppleCoreMedia/1.0.0.18G82 (iPhone; U; CPU OS 14_7_1 like Mac OS X; es_xl)

user agent should match the following regex from regexes/client/libraries.yml:

- regex: 'AppleCoreMedia/1\.0\.0'
  name: 'iOS Application'
  version: ''

Instead, it currently matches the Mobile Safari regex from regexes/client/browsers.yml:

- regex: '(?!^AppleCoreMedia/1\.0\.0)(?:iPod|(?<!Apple TV; U; CPU )iPhone|iPad)'
  name: 'Mobile Safari'
  version: ''
  engine:

Expected behavior
AppleCoreMedia/1.0.0 (iPhone; ...) → iOS Application

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
