### PR TITLE
Add The Podcast App (Magnolia) mobile app detection

### DIFF
--- a/regexes/client/mobile_apps.yml
+++ b/regexes/client/mobile_apps.yml
@@ -2287,6 +2287,14 @@
   name: 'Podcast App'
   version: '$1'
 
+- regex: '^TPA/(\d+\.[.\d]+)'
+  name: 'The Podcast App (Magnolia)'
+  version: '$1'
+
+- regex: '^TPA-Wear/(\d+\.[.\d]+)'
+  name: 'The Podcast App (Magnolia)'
+  version: '$1'
+
 - regex: '^TREBLE/([\d.]+)'
   name: 'Treble.fm'
   version: '$1'


### PR DESCRIPTION
Adds detection for a podcast player whose user agents are currently unmatched.

```
TPA/3.0.507 (+https://thepodcastapp.dev)
TPA-Wear/1.0
```

**Not a duplicate of the existing entry.** `^ThePodcastApp/` → `Podcast App` is the unrelated podcast.app (`com.evolve.podcast`). This is a different app from a different vendor that happens to share the brand name, which is exactly why it uses the `TPA/` token instead. I named it `The Podcast App (Magnolia)` so the two don't merge in reports — happy to rename if you'd prefer a different convention.

Both builds report the same name so the product aggregates; `TPA-Wear/` is the Wear OS build.

Verified before opening, against the current `mobile_apps.yml`:
- neither UA matches **any** of the 642 existing patterns today (they're unclassified)
- `^TPA/` matches the phone UA and does **not** match `TPA-Wear/`
- the existing `ThePodcastApp/` UA still resolves to `Podcast App`, unchanged
- YAML parses; entries 642 → 644

I couldn't run `./vendor/bin/phpunit` (no PHP on this machine), so the checks above are regex-level rather than a suite run. I also didn't add fixtures — these UAs carry no OS/device tokens, and the existing `ThePodcastApp/` entry has none either, so I matched the file's precedent. Glad to add fixtures if you want them, just tell me the expected `os`/`device` shape for a UA with no platform hints.

Disclosure: I work on the app. The user agent is set in the app's own source (Dart/Kotlin/Swift) and is already registered in OPAWG's list as `TPA/`, `TPA-Wear/`.