### PR TITLE
Fixes fixture corruption in rewriteTestFixtureFiles.php

### DIFF
--- a/misc/rewriteTestFixtureFiles.php
+++ b/misc/rewriteTestFixtureFiles.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use DeviceDetector\DeviceDetector;
 use DeviceDetector\Parser\AbstractParser;
+use Symfony\Component\Yaml\Yaml;
 
 include __DIR__ . '/../vendor/autoload.php';
 
@@ -19,7 +20,7 @@ $fixtureFiles = array_merge(
 $overwrite = !empty($argv[1]) && '--f' === $argv[1];
 
 foreach ($fixtureFiles as $file) {
-    $fileFixtures = Spyc::YAMLLoad(file_get_contents($file));
+    $fileFixtures = Yaml::parse(file_get_contents($file));
     $data         = [];
 
     foreach ($fileFixtures as $i => $fixture) {
@@ -32,14 +33,8 @@ foreach ($fixtureFiles as $file) {
         $data[$i] = array_intersect_key($fixture, $keys);
     }
 
-    $content = Spyc::YAMLDump($data, 2, 0);
-
-    $content = str_replace(": ON\n", ": 'ON'\n", $content);
-    $content = str_replace(": NO\n", ": 'NO'\n", $content);
-
-    file_put_contents($file, $content);
-
-    shell_exec("sed -i -e 's/version: \\([^\"].*\\)/version: \"\\1\"/g' " . $file);
+    // fixtures nest at most 5 levels, so nothing is ever dumped inline
+    file_put_contents($file, Yaml::dump($data, 10, 2));
 }
 
 echo "done.\n";


### PR DESCRIPTION
Fixes #7637

Spyc breaks fixtures on both sides of the round trip, which is why the two symptoms in the issue look unrelated:

- its **dumper** writes `Sec-CH-UA` as a plain scalar even though the value starts with `"`, so reloading drops the outer quotes. `Sec-CH-UA-Mobile: "?1"` also comes back as `?1`, which YAML reads as the start of a complex key.
- its **loader** treats `#` as a comment start without requiring a space before it, against the spec, so `Android 10#V12.0.17.0.QCDMIXM#29` is already truncated before anything is dumped.

Running the script on `Tests/fixtures/clienthints.yml` as it stands reproduces the first one on the very first entry.

Switching to `symfony/yaml`, already a dev dependency and already wrapped in `Yaml/`, fixes both. It also makes the `ON`/`NO` replacements and the `sed` call for `version:` unnecessary, since its dumper quotes those on its own.

Checked over the 95 fixture files: `Yaml::parse()` returns the same data before and after a rewrite for all of them, a second run is byte identical, and the test suite passes on the rewritten files.

The fixtures are left untouched here. Rewriting them is 183k lines of pure formatting and belongs in its own commit, whenever you want it.
