### PR TITLE
Adds bot detection from the From header

### DIFF
--- a/ClientHints.php
+++ b/ClientHints.php
@@ -84,6 +84,13 @@ class ClientHints
     protected $formFactors = [];
 
     /**
+     * Represents `From` header field: the email address of the person controlling the client
+     *
+     * @var string
+     */
+    protected $from = '';
+
+    /**
      * Constructor
      *
      * @param string $model           `Sec-CH-UA-Model` header field
@@ -96,8 +103,9 @@ class ClientHints
      * @param string $bitness         `Sec-CH-UA-Bitness`
      * @param string $app             `HTTP_X-REQUESTED-WITH`
      * @param array  $formFactors     `Sec-CH-UA-Form-Factors` header field
+     * @param string $from            `From` header field
      */
-    public function __construct(string $model = '', string $platform = '', string $platformVersion = '', string $uaFullVersion = '', array $fullVersionList = [], bool $mobile = false, string $architecture = '', string $bitness = '', string $app = '', array $formFactors = []) // phpcs:ignore Generic.Files.LineLength
+    public function __construct(string $model = '', string $platform = '', string $platformVersion = '', string $uaFullVersion = '', array $fullVersionList = [], bool $mobile = false, string $architecture = '', string $bitness = '', string $app = '', array $formFactors = [], string $from = '') // phpcs:ignore Generic.Files.LineLength
     {
         $this->model           = $model;
         $this->platform        = $platform;
@@ -109,6 +117,7 @@ class ClientHints
         $this->bitness         = $bitness;
         $this->app             = $app;
         $this->formFactors     = $formFactors;
+        $this->from            = $from;
     }
 
     /**
@@ -234,6 +243,16 @@ class ClientHints
     }
 
     /**
+     * Returns the email address of the person controlling the client
+     *
+     * @return string
+     */
+    public function getFrom(): string
+    {
+        return $this->from;
+    }
+
+    /**
      * Returns the formFactor device type name
      *
      * @return array
@@ -253,7 +272,7 @@ class ClientHints
     public static function factory(array $headers): ClientHints
     {
         $model           = $platform = $platformVersion = $uaFullVersion = $architecture = $bitness = '';
-        $app             = '';
+        $app             = $from = '';
         $mobile          = false;
         $fullVersionList = [];
         $formFactors     = [];
@@ -358,6 +377,13 @@ class ClientHints
                     }
 
                     break;
+                case 'http-from':
+                case 'from':
+                    if (\is_string($value)) {
+                        $from = $value;
+                    }
+
+                    break;
                 case 'http-x-requested-with':
                 case 'x-requested-with':
                     if (\is_string($value) && 'xmlhttprequest' !== \strtolower($value)) {
@@ -392,7 +418,8 @@ class ClientHints
             $architecture,
             $bitness,
             $app,
-            $formFactors
+            $formFactors,
+            $from
         );
     }
 }

--- a/Parser/Bot.php
+++ b/Parser/Bot.php
@@ -67,6 +67,47 @@ class Bot extends AbstractBotParser
      */
     public function parse(): ?array
     {
+        $result = $this->parseValue($this->userAgent);
+
+        if (null !== $result) {
+            return $result;
+        }
+
+        $from = null !== $this->clientHints ? $this->clientHints->getFrom() : '';
+
+        if ('' === $from) {
+            return null;
+        }
+
+        // Browsers do not send a From header while bots are expected to, so a request carrying
+        // one comes from a bot even when its user agent claims otherwise. The address usually
+        // names the bot, so it goes through the same detection before falling back.
+        return $this->parseValue($from)
+            ?? ($this->discardDetails ? [true] : ['name' => 'Generic Bot']);
+    }
+
+    /**
+     * Matches the given value against the bot definitions
+     *
+     * @return array<string, mixed>|null
+     */
+    private function parseValue(string $value): ?array
+    {
+        $userAgent       = $this->userAgent;
+        $this->userAgent = $value;
+
+        try {
+            return $this->matchValue();
+        } finally {
+            $this->userAgent = $userAgent;
+        }
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function matchValue(): ?array
+    {
         $result = null;
 
         if ($this->preMatchOverall()) {

--- a/Parser/Bot.php
+++ b/Parser/Bot.php
@@ -89,7 +89,9 @@ class Bot extends AbstractBotParser
     /**
      * Matches the given value against the bot definitions
      *
-     * @return array<string, mixed>|null
+     * @param string $value user agent or contact address to match
+     *
+     * @return array<array-key, mixed>|null
      */
     private function parseValue(string $value): ?array
     {
@@ -104,7 +106,7 @@ class Bot extends AbstractBotParser
     }
 
     /**
-     * @return array<string, mixed>|null
+     * @return array<array-key, mixed>|null
      */
     private function matchValue(): ?array
     {

--- a/Tests/ClientHintsTest.php
+++ b/Tests/ClientHintsTest.php
@@ -91,6 +91,13 @@ class ClientHintsTest extends TestCase
         self::assertEquals(['desktop'], $ch->formFactors);
     }
 
+    public function testFromHeader(): void
+    {
+        self::assertSame('bingbot(at)microsoft.com', ClientHints::factory(['from' => 'bingbot(at)microsoft.com'])->getFrom());
+        self::assertSame('bingbot(at)microsoft.com', ClientHints::factory(['HTTP_FROM' => 'bingbot(at)microsoft.com'])->getFrom());
+        self::assertSame('', ClientHints::factory(['sec-ch-ua-mobile' => '?0'])->getFrom());
+    }
+
     public function testIncorrectVersionListIsDiscarded(): void
     {
         $headers = [

--- a/Tests/DeviceDetectorTest.php
+++ b/Tests/DeviceDetectorTest.php
@@ -614,6 +614,64 @@ class DeviceDetectorTest extends TestCase
         }, $fixtures);
     }
 
+    /**
+     * @param array<string, string> $headers
+     */
+    #[DataProvider('getFromHeaderFixtures')]
+    public function testParseBotsFromTheFromHeader(array $headers, string $userAgent, string $expectedName): void
+    {
+        $dd = new DeviceDetector($userAgent, ClientHints::factory($headers));
+        $dd->parse();
+
+        $this->assertTrue($dd->isBot());
+        $this->assertEquals($expectedName, $dd->getBot()['name']);
+    }
+
+    public static function getFromHeaderFixtures(): iterable
+    {
+        // a bot the user agent does not give away at all
+        yield [
+            ['HTTP_FROM' => 'bingbot(at)microsoft.com'],
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36 Edg/130.0.0.0',
+            'BingBot',
+        ];
+
+        yield [
+            ['From' => 'crawler@alexa.com'],
+            'ia_archiver (+http://www.alexa.com/site/help/webmasters; crawler@alexa.com)',
+            'Alexa Crawler',
+        ];
+
+        // an address naming no known bot still means a bot
+        yield [
+            ['HTTP_FROM' => 'TGVnaXRpbWF0ZSBsaW5rIHRyYWNrZXI='],
+            'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:61.0) Gecko/20100101 Firefox/61.0',
+            'Generic Bot',
+        ];
+    }
+
+    public function testAUserAgentWithoutTheFromHeaderIsNotABot(): void
+    {
+        $dd = new DeviceDetector(
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36',
+            ClientHints::factory(['Sec-CH-UA-Mobile' => '?0'])
+        );
+        $dd->parse();
+
+        $this->assertFalse($dd->isBot());
+    }
+
+    public function testTheUserAgentWinsOverTheFromHeader(): void
+    {
+        $dd = new DeviceDetector(
+            'Googlebot/2.1 (http://www.googlebot.com/bot.html)',
+            ClientHints::factory(['HTTP_FROM' => 'someone@example.org'])
+        );
+        $dd->parse();
+
+        $this->assertEquals('Googlebot', $dd->getBot()['name']);
+    }
+
     public function testGetInfoFromUABot(): void
     {
         $expected = [

--- a/Tests/DeviceDetectorTest.php
+++ b/Tests/DeviceDetectorTest.php
@@ -556,7 +556,10 @@ class DeviceDetectorTest extends TestCase
     public function testParseBots(array $fixtureData): void
     {
         $ua = $fixtureData['user_agent'];
-        $dd = new DeviceDetector($ua);
+        $dd = new DeviceDetector(
+            $ua,
+            isset($fixtureData['headers']) ? ClientHints::factory($fixtureData['headers']) : null
+        );
         $dd->parse();
         $this->assertTrue($dd->isBot());
         $botData = $dd->getBot();
@@ -616,6 +619,8 @@ class DeviceDetectorTest extends TestCase
 
     /**
      * @param array<string, string> $headers
+     *
+     * @dataProvider getFromHeaderFixtures
      */
     #[DataProvider('getFromHeaderFixtures')]
     public function testParseBotsFromTheFromHeader(array $headers, string $userAgent, string $expectedName): void

--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -1,5 +1,33 @@
 ---
 -
+  user_agent: Test
+  headers:
+    http-from: crawler@rois.ac.jp
+  bot:
+    name: Cotoyogi
+    category: Crawler
+    url: https://ds.rois.ac.jp/center8/crawler/
+    producer:
+      name: Joint Support-Center for Data Science Research (ROIS-DS)
+      url: https://ds.rois.ac.jp/
+-
+  user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36 Edg/130.0.0.0
+  headers:
+    http-from: bingbot(at)microsoft.com
+  bot:
+    name: BingBot
+    category: Search bot
+    url: http://search.msn.com/msnbot.htmn
+    producer:
+      name: Microsoft Corporation
+      url: http://www.microsoft.com
+-
+  user_agent: Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:61.0) Gecko/20100101 Firefox/61.0
+  headers:
+    http-from: TGVnaXRpbWF0ZSBsaW5rIHRyYWNrZXI=
+  bot:
+    name: Generic Bot
+-
   user_agent: monitoring360bot/1.1
   bot:
     name: 360 Monitoring

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -74,7 +74,7 @@
     name: 'Ahrefs Pte Ltd'
     url: 'https://ahrefs.com/'
 
-- regex: 'ia_archiver|alexabot|verifybot'
+- regex: 'ia_archiver|alexabot|verifybot|crawler@alexa\.com'
   name: 'Alexa Crawler'
   category: 'Search bot'
   url: 'https://support.alexa.com/hc/en-us/sections/200100794-Crawlers'
@@ -5185,7 +5185,7 @@
     name: 'aStonish Studio Srl'
     url: 'http://www.astonishstudio.com/'
 
-- regex: 'Cotoyogi'
+- regex: 'Cotoyogi|crawler@rois\.ac\.jp'
   name: 'Cotoyogi'
   category: 'Crawler'
   url: 'https://ds.rois.ac.jp/center8/crawler/'


### PR DESCRIPTION
Fixes #7929

Browsers do not send a `From` header while bots are expected to, so a request carrying one comes from a bot even when its user agent claims otherwise. Bing is the case from the issue: it crawls with a plain Edge user agent, and only `From` gives it away.

`ClientHints` picks the header up, next to the `X-Requested-With` it already handles, as a trailing optional constructor argument. `Parser\Bot` tries the user agent first and falls back to the address, which goes through the same definitions before ending on `Generic Bot`.

That fallback is almost free, because the existing regexes already recognise these addresses. All seven entries of the checklist in the issue now detect:

| `From` | user agent | detected as |
| --- | --- | --- |
| `bingbot(at)microsoft.com` | plain Edge 130 | BingBot |
| `googlebot(at)googlebot.com` | Googlebot | Googlebot |
| `gptbot(at)openai.com` | GPTBot | GPTBot |
| `crawler@alexa.com` | ia_archiver | Alexa Crawler |
| `crawler@rois.ac.jp` | Cotoyogi | Cotoyogi |
| `TGVnaXRpbWF0ZSBsaW5rIHRyYWNrZXI=` | plain Firefox 61 | Generic Bot |
| `"<?=print(9347655345-4954366);?>"` | Mozilliqa | Generic Bot |

Six tests cover it, including a user agent with no `From` staying a browser, and a user agent that names a bot winning over a `From` that says otherwise.
